### PR TITLE
added healthcheck page for the application load balancer

### DIFF
--- a/app/healthcheck/page.tsx
+++ b/app/healthcheck/page.tsx
@@ -1,0 +1,4 @@
+// This is just a healthcheck page that indicates whether or not the server is running
+export default function HealthCheck() {
+  return <div>OK</div>;
+}


### PR DESCRIPTION
The AWS load balancer requires a health check. The current homepage returns a 500 at the moment, so the ALB will not direct traffic to nextJS.

I have added a simple health check page here. I tried to override the default layout, so that it just returns something very simple like `<html><body>Ok</body></html>` but couldn't figure out how to do that.

Once this is merged to development, it should auto-deploy to ECS and the site should become available