### PR TITLE
Added logging state and velocity controls to the login and signup forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [1.0.0]
 
 ### Added
+- Added loading state and velocity controls to the login and signup forms [#66]
 - Added placeholders for /signup and /login pages and added a new api endpoint for setting the access token in a cookie [#19]
 - Added .editorconfig file to help maintain consistent coding styles [#37]
 - Added buildspec.yaml file for CI/CD pipeline [#81]

--- a/app/login/__tests__/page.spec.tsx
+++ b/app/login/__tests__/page.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import LoginPage from '../page';
 import logECS from '@/utils/clientLogger';
 
@@ -89,6 +90,95 @@ describe('LoginPage', () => {
                 body: JSON.stringify({ token: 'valid-token' }),
             });
         })
+    });
+
+    it('should initially disable submit button after submitting form until response is returned ', async () => {
+        jest.spyOn(global, 'fetch').mockImplementation((url) => {
+            if (url === 'http://localhost:4000/signin') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve({ token: 'valid-token' }),
+                } as unknown as Response);
+            }
+            if (url === '/api/setCookie') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve({ message: 'Cookie set successfully' }),
+                } as unknown as Response);
+            }
+
+            return Promise.reject(new Error('Unknown URL'));
+        });
+
+        render(<LoginPage />);
+
+        //Find input fields and button in screen
+        const emailInput = screen.getByLabelText(/email/i);
+        const passwordInput = screen.getByLabelText(/password/i);
+        const submitButton = screen.getByRole('button', { name: /login/i });
+
+        //Simulate user input
+        fireEvent.change(emailInput, { target: { value: 'test@test.com' } });
+        fireEvent.change(passwordInput, { target: { value: 'password123' } });
+
+        //Simulate form submission
+        fireEvent.click(submitButton);
+
+        expect(submitButton).toBeDisabled();
+        expect(submitButton).toHaveTextContent('Logging in ...');
+
+        await waitFor(() => {
+            expect(submitButton).not.toBeDisabled();
+            expect(submitButton).toHaveTextContent('Login');
+        });
+    });
+
+    it('should show error message after too many attempts ', async () => {
+        jest.spyOn(global, 'fetch').mockImplementation((url) => {
+            if (url === 'http://localhost:4000/signin') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve({ token: 'valid-token' }),
+                } as unknown as Response);
+            }
+            if (url === '/api/setCookie') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve({ message: 'Cookie set successfully' }),
+                } as unknown as Response);
+            }
+
+            return Promise.reject(new Error('Unknown URL'));
+        });
+
+        render(<LoginPage />);
+
+        //Find input fields and button in screen
+        const emailInput = screen.getByLabelText(/email/i);
+        const passwordInput = screen.getByLabelText(/password/i);
+        const submitButton = screen.getByRole('button', { name: /login/i });
+
+        //Simulate user input
+        fireEvent.change(emailInput, { target: { value: 'test@test.com' } });
+        fireEvent.change(passwordInput, { target: { value: 'password123' } });
+
+        for (let i = 0; i < 15; i++) {
+            userEvent.click(submitButton);
+            await waitFor(() => {
+                expect(submitButton).toHaveTextContent('Logging in ...')
+            })
+        }
+
+        fireEvent.click(submitButton);
+        await waitFor(() => {
+            expect(submitButton).toBeDisabled();
+            expect(screen.getByText(/Too many attempts. Please wait before trying again./i)).toBeInTheDocument();
+        });
+
     });
 
     it('should handle 401 error', async () => {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -19,6 +19,7 @@ const LoginPage: React.FC = () => {
     const [errors, setErrors] = useState<string[]>([]);
     const [loading, setLoading] = useState(false);
     const [attempts, setAttempts] = useState(0);
+    const [lockoutTime, setLockoutTime] = useState<number | null>(null);
     const router = useRouter();
     const errorRef = useRef<HTMLDivElement>(null);
 
@@ -75,8 +76,12 @@ const LoginPage: React.FC = () => {
         setLoading(true);
         setErrors([]); // Clear previous errors
 
-        if (attempts >= 5) {
-            setErrors(['Too many attempts. Please wait 15 minutes before trying again.']);
+        if (attempts > 5) {
+            const remainingTime = lockoutTime ? Math.max(lockoutTime - Date.now(), 0) : 0;
+            const minutesLeft = Math.ceil(remainingTime / 60000);
+            const remainingMinutesText = minutesLeft < 2 ? 'minute' : 'minutes'
+            setErrors([`Too many attempts. Please try again later${remainingTime > 0 ? ` in ${Math.ceil(remainingTime / 60000)} ${remainingMinutesText}.` : '.'}`]);
+            setLoading(false);
             return;
         }
 
@@ -114,10 +119,14 @@ const LoginPage: React.FC = () => {
     }, [errors])
 
     useEffect(() => {
-        if (attempts > 5) {
+        if (attempts >= 5) {
+            const lockoutDuration = 15 * 60 * 1000; //15 minutes
+            const newLockoutTime = Date.now() + lockoutDuration;
+            setLockoutTime(newLockoutTime);
             const timer = setTimeout(() => {
                 setAttempts(0);
-            }, 15 * 60 * 1000); // 15 minutes
+                setLockoutTime(null);
+            }, lockoutDuration); // 15 minutes
 
             return () => clearTimeout(timer);
         }
@@ -153,7 +162,7 @@ const LoginPage: React.FC = () => {
                     onChange={handleInputChange}
                     required
                 />
-                <button type="submit" disabled={(loading || attempts > 5) ? true : false}>{loading ? 'Logging in ...' : 'Login'}</button>
+                <button type="submit" disabled={loading}>{loading ? 'Logging in ...' : 'Login'}</button>
             </form>
         </div>
     );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -76,7 +76,7 @@ const LoginPage: React.FC = () => {
         setErrors([]); // Clear previous errors
 
         if (attempts >= 5) {
-            setErrors(['Too many attempts. Please wait before trying again.']);
+            setErrors(['Too many attempts. Please wait 15 minutes before trying again.']);
             return;
         }
 
@@ -153,7 +153,7 @@ const LoginPage: React.FC = () => {
                     onChange={handleInputChange}
                     required
                 />
-                <button type="submit" disabled={(loading || attempts > 5) ? true : false}>{attempts}{loading ? 'Logging in ...' : 'Login'}</button>
+                <button type="submit" disabled={(loading || attempts > 5) ? true : false}>{loading ? 'Logging in ...' : 'Login'}</button>
             </form>
         </div>
     );

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -42,7 +42,7 @@ const SignUpPage: React.FC = () => {
         setErrors([]); // Clear previous errors
 
         if (attempts >= 5) {
-            setErrors(['Too many attempts. Please wait before trying again.']);
+            setErrors(['Too many attempts. Please wait 15 minutes before trying again.']);
             return;
         }
 

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -9,6 +9,8 @@ const SignUpPage: React.FC = () => {
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [errors, setErrors] = useState<string[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [attempts, setAttempts] = useState(0);
     const router = useRouter();
     const errorRef = useRef<HTMLDivElement>(null);
 
@@ -36,7 +38,13 @@ const SignUpPage: React.FC = () => {
 
     const handleSignUp = async (event: React.FormEvent) => {
         event.preventDefault();
+        setLoading(true);
         setErrors([]); // Clear previous errors
+
+        if (attempts >= 5) {
+            setErrors(['Too many attempts. Please wait before trying again.']);
+            return;
+        }
 
         /* eslint-disable @typescript-eslint/no-explicit-any */
         try {
@@ -55,6 +63,9 @@ const SignUpPage: React.FC = () => {
                 error: err,
                 url: { path: '/signup' }
             });
+        } finally {
+            setLoading(false);
+            setAttempts(prev => prev + 1);
         }
     };
 
@@ -66,6 +77,16 @@ const SignUpPage: React.FC = () => {
             }
         }
     }, [errors])
+
+    useEffect(() => {
+        if (attempts > 5) {
+            const timer = setTimeout(() => {
+                setAttempts(0);
+            }, 15 * 60 * 1000); // 15 minutes
+
+            return () => clearTimeout(timer);
+        }
+    }, [attempts])
 
     return (
         <div className={styles.signupWrapper} ref={errorRef}>
@@ -97,7 +118,7 @@ const SignUpPage: React.FC = () => {
                     onChange={e => setPassword(e.target.value)}
                     required />
 
-                <button type="submit">Sign Up</button>
+                <button type="submit" disabled={loading || attempts > 5}>{loading ? 'Signing up ...' : 'Sign Up'}</button>
             </form>
 
         </div>


### PR DESCRIPTION
## Description

We need to add some controls on the frontend to stop users from repeated submit attacks. I implemented a loading state to disable the "submit" button while the POST request is being made. That way a user is prevented from repeatedly pushing the button to start new requests while the request is in progress.

I also added an "attempts" state. After 5 attempts, the user gets an error message telling them that there were too many attempts, and that they need to wait before tying again.

The messaging, and possibly some of the functionality, will be updated when the designs for these pages come in. However, I just wanted to put some minimal defenses in place to remind us to address these with the finalized pages.

Fixes # ([#66](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/66)

## Type of change
Please delete options that are not relevant
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
The associated unit tests were updated to test some basics of the new functionality.

1) Start the app
2) Navigate to either the /login or /signup page
3) Make more than 5 attempts to submit bad data in the form
4) On the sixth try, you should get the "too many attempts" message which should display the amount of minutes the user has to wait to try again.


## Checklist:
- [ ] My code follows the style guidelines of this project (Since the signup and login form pages are just placeholders, and no final style guides are in place, this is not the case.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes (I did not carry out detailed accessibility tests, since these pages are just placeholders until we get a final design in place)
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules