### PR TITLE
Feature/add logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [1.0.0]
 
 ### Added
+- Added logout api and link [#65]
 - Added loading state and velocity controls to the login and signup forms [#66]
 - Added placeholders for /signup and /login pages and added a new api endpoint for setting the access token in a cookie [#19]
 - Added .editorconfig file to help maintain consistent coding styles [#37]

--- a/app/api/check-auth/__tests__/route.spec.ts
+++ b/app/api/check-auth/__tests__/route.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment node
+ */
+import { NextResponse } from 'next/server';
+import { GET } from '../route';
+import { getAuthTokenServer } from '@/utils/getAuthTokenServer';
+import { verifyJwtToken } from '@/lib/server/auth';
+import logger from '@/utils/logger';
+
+jest.mock('@/utils/logger');
+
+jest.mock('@/utils/getAuthTokenServer', () => ({
+    getAuthTokenServer: jest.fn(),
+}));
+
+jest.mock('@/lib/server/auth', () => ({
+    verifyJwtToken: jest.fn(),
+}));
+
+
+describe('GET Function', () => {
+    let redirectSpy: jest.SpyInstance;
+    beforeEach(() => {
+        redirectSpy = jest.spyOn(NextResponse, 'redirect');
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        redirectSpy.mockRestore();
+
+    })
+
+    it('should return true for "authenticated" and a status of 200 if auth cookie is present and passes verification', async () => {
+        (getAuthTokenServer as jest.Mock).mockResolvedValue('valid-token');
+        (verifyJwtToken as jest.Mock).mockImplementation(() => true);
+        const response = await GET();
+        expect(response.status).toEqual(200);
+        const data = await response.json();
+
+        expect(data).toEqual({ authenticated: true })
+    })
+
+    it('should return false for "authenticated" if it auth token does not pass verification', async () => {
+        (getAuthTokenServer as jest.Mock).mockResolvedValue('valid-token');
+        (verifyJwtToken as jest.Mock).mockImplementation(() => false);
+        const response = await GET();
+        const data = await response.json();
+
+        expect(data).toEqual({ authenticated: false })
+        expect(logger.error).toHaveBeenCalledWith('User verification failed');
+    })
+
+    it('should return false for "authenticated" if there is no "dmspt" auth cookie/token', async () => {
+        (getAuthTokenServer as jest.Mock).mockResolvedValue(null);
+        const response = await GET();
+        const data = await response.json();
+
+        expect(data).toEqual({ authenticated: false })
+    })
+
+    it('should return error with "authenticated" set to false when an error is thrown getting the token', async () => {
+        (getAuthTokenServer as jest.Mock).mockRejectedValue(new Error('Test error'));
+        (verifyJwtToken as jest.Mock).mockImplementation(() => false);
+        const response = await GET();
+        const data = await response.json();
+
+        expect(data).toEqual({ authenticated: false, error: 'Internal Server Error' })
+        expect(logger.error).toHaveBeenCalledWith('Error getting auth token', expect.objectContaining({ error: expect.any(Error), })
+        );
+    })
+
+    it('should redirect to login page if verification of token fails', async () => {
+        (getAuthTokenServer as jest.Mock).mockResolvedValue('invalid-token');
+        (verifyJwtToken as jest.Mock).mockRejectedValue(new Error('Verification failed'));
+        await GET();
+
+        expect(logger.error).toHaveBeenCalledWith('Token verification error', expect.objectContaining({ error: expect.any(Error), })
+        );
+        expect(redirectSpy).toHaveBeenCalledWith('http://localhost:3000/login');
+    })
+
+});

--- a/app/api/check-auth/route.ts
+++ b/app/api/check-auth/route.ts
@@ -12,7 +12,6 @@ export async function GET() {
         if (token) {
             try {
                 const user = await verifyJwtToken(token);
-                console.log("***USER", user);
                 if (user) {
                     return NextResponse.json({ authenticated: true });
                 } else {
@@ -20,7 +19,6 @@ export async function GET() {
                     return NextResponse.json({ authenticated: false });
                 }
             } catch (err) {
-                console.log("TOKEN ERROR")
                 logger.error('Token verification error', { error: err })
                 return NextResponse.redirect(LOGIN);
             }

--- a/app/api/check-auth/route.ts
+++ b/app/api/check-auth/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { getAuthTokenServer } from '@/utils/getAuthTokenServer';
+import { verifyJwtToken } from '../../../lib/server/auth'
+import logger from '@/utils/logger';
+
+const LOGIN = `${process.env.NEXT_PUBLIC_BASE_URL}/login`;
+
+export async function GET() {
+    try {
+        const token = await getAuthTokenServer();
+
+        if (token) {
+            try {
+                const user = await verifyJwtToken(token);
+                console.log("***USER", user);
+                if (user) {
+                    return NextResponse.json({ authenticated: true });
+                } else {
+                    logger.error('User verification failed');
+                    return NextResponse.json({ authenticated: false });
+                }
+            } catch (err) {
+                console.log("TOKEN ERROR")
+                logger.error('Token verification error', { error: err })
+                return NextResponse.redirect(LOGIN);
+            }
+
+        } else {
+            return NextResponse.json({ authenticated: false })
+        }
+    } catch (err) {
+        logger.error('Error getting auth token', { error: err });
+        return NextResponse.json({ authenticated: false, error: 'Internal Server Error' })
+    }
+}

--- a/app/api/logout/__tests__/route.spec.ts
+++ b/app/api/logout/__tests__/route.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import httpMocks from 'node-mocks-http';
+import { POST } from '../route';
+import { deleteCookie } from '@/utils/cookiesUtil';
+
+jest.mock('@/utils/cookiesUtil', () => ({
+    deleteCookie: jest.fn(),
+}));
+
+describe('POST /logout', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+
+    it('should return 200 and delete the cookie on successful logout', async () => {
+        const req = httpMocks.createRequest({
+            method: 'POST',
+            url: '/api/logout',
+        })
+
+        const jsonResponse = await POST(req as unknown as NextRequest);
+        const responseData = await jsonResponse.json();
+        expect(jsonResponse.status).toBe(200);
+        expect(responseData).toEqual({ message: 'Logout successful' });
+        expect(deleteCookie).toHaveBeenCalledWith(expect.any(NextResponse), 'dmspt');
+    });
+
+    it('should return 500 if an error occurs', async () => {
+
+        // Simulate an error in the POST function
+        jest.spyOn(NextResponse, 'json').mockImplementationOnce(() => {
+            throw new Error('Failed to delete cookie');
+        });
+
+        const req = httpMocks.createRequest({
+            method: 'POST',
+            url: '/api/logout',
+        })
+
+        const jsonResponse = await POST(req as unknown as NextRequest);
+        const responseData = await jsonResponse.json();
+
+        expect(jsonResponse.status).toBe(500);
+        expect(responseData).toEqual({ message: 'Logout failed' });
+    });
+});

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,0 +1,15 @@
+
+import { NextResponse } from 'next/server';
+import { deleteCookie } from '@/utils/cookiesUtil';
+
+export async function POST() {
+    try {
+        //TODO: Will eventually want to send a request to the backend server so that it can invalidate the JWT token
+        const response = NextResponse.json({ message: 'Logout successful' });
+        deleteCookie(response, 'dmspt');
+        return response;
+    } catch (error) {
+        console.error('Logout failed:', error);
+        return NextResponse.json({ message: 'Logout failed' }, { status: 500 });
+    }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "@/styles/globals.scss";
 import Header from "@/components/Header";
 import Footer from "@/components/footer";
 import { ApolloWrapper } from "@/lib/graphql/apollo-wrapper";
+import { AuthProvider } from "@/context/AuthContext";
 
 
 const poppins_init = Poppins({
@@ -28,11 +29,13 @@ export default function RootLayout({
     <html lang="en">
       <body className={poppins_init.className}>
         <a href="#mainContent" className="skip-nav">Skip to main content</a>
-        <Header />
-        <div id="App">
-          <main id="mainContent"><ApolloWrapper>{children}</ApolloWrapper></main>
-        </div>
-        <Footer />
+        <AuthProvider>
+          <Header />
+          <div id="App">
+            <main id="mainContent"><ApolloWrapper>{children}</ApolloWrapper></main>
+          </div>
+          <Footer />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/app/login/__tests__/page.spec.tsx
+++ b/app/login/__tests__/page.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/utils/test-utils'; //wrapping test with AuthProvider
 import userEvent from '@testing-library/user-event';
 import LoginPage from '../page';
 import logECS from '@/utils/clientLogger';
@@ -180,11 +180,6 @@ describe('LoginPage', () => {
         await waitFor(() => expect(submitButton).not.toBeDisabled());
         userEvent.click(submitButton);
         await waitFor(() => expect(submitButton).toBeDisabled());
-
-        await waitFor(() => {
-            expect(screen.queryByText(/Too many attempts. Please try again later in 15 minutes./i)).not.toBeInTheDocument();
-            expect(submitButton).not.toBeDisabled();
-        });
 
         // Ensure the button is not disabled before clicking after lockout period
         await waitFor(() => expect(submitButton).not.toBeDisabled());

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useRef } from "react";
 import { useRouter } from 'next/navigation';
 import styles from './login.module.scss'
 import logECS from '@/utils/clientLogger';
+import { useAuthContext } from "@/context/AuthContext";
 
 type User = {
     email: string;
@@ -22,6 +23,7 @@ const LoginPage: React.FC = () => {
     const [lockoutTime, setLockoutTime] = useState<number | null>(null);
     const router = useRouter();
     const errorRef = useRef<HTMLDivElement>(null);
+    const { setIsAuthenticated } = useAuthContext();
 
 
     const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -56,6 +58,7 @@ const LoginPage: React.FC = () => {
 
         if (response.status === 200) {
             await saveTokenInCookie(token)
+            setIsAuthenticated(true);
             router.push('/') //redirect to home page
         } else if (response.status === 401) {
             if (message) {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,11 +1,46 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useState, MouseEvent } from 'react';
 
 function Header() {
+    const router = useRouter();
+    const [loggingOut, setLoggingOut] = useState(false);
 
+    const handleLogout = async (e: MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault();
+        setLoggingOut(true);
+
+        try {
+            const response = await fetch('/api/logout', {
+                method: 'POST'
+            })
+
+            if (response.ok) {
+                setLoggingOut(false);
+                router.push('/login')
+            } else {
+                console.error('Failed to logout');
+                setLoggingOut(false);
+            }
+        } catch (err) {
+            console.error('An error occurred during logout:', err);
+            setLoggingOut(false);
+        }
+
+    }
     return (
         <header>
             <h1>Header Placeholder</h1>
+            <div>
+                {loggingOut ? (
+                    <span style={{ color: 'white' }}>Logging out ...</span>
+                ) : (
+                    <Link href="/login" onClick={handleLogout} style={{ color: 'white' }}>Log out</Link>
+                )
+                }
+            </div>
         </header>
     )
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,15 +2,15 @@
 
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { useState, MouseEvent } from 'react';
+import { useState, MouseEvent, useEffect } from 'react';
+import { useAuthContext } from '@/context/AuthContext';
 
 function Header() {
+    const { isAuthenticated, setIsAuthenticated } = useAuthContext();
     const router = useRouter();
-    const [loggingOut, setLoggingOut] = useState(false);
 
     const handleLogout = async (e: MouseEvent<HTMLAnchorElement>) => {
         e.preventDefault();
-        setLoggingOut(true);
 
         try {
             const response = await fetch('/api/logout', {
@@ -18,30 +18,33 @@ function Header() {
             })
 
             if (response.ok) {
-                setLoggingOut(false);
+                setIsAuthenticated(false);
                 router.push('/login')
             } else {
                 console.error('Failed to logout');
-                setLoggingOut(false);
             }
         } catch (err) {
             console.error('An error occurred during logout:', err);
-            setLoggingOut(false);
         }
 
     }
+
+    if (isAuthenticated === null) {
+        return <div></div>;
+    }
+
     return (
         <header>
             <h1>Header Placeholder</h1>
             <div>
-                {loggingOut ? (
-                    <span style={{ color: 'white' }}>Logging out ...</span>
-                ) : (
-                    <Link href="/login" onClick={handleLogout} style={{ color: 'white' }}>Log out</Link>
-                )
+                {
+                    isAuthenticated ? (
+                        <Link href="/logout" onClick={handleLogout} style={{ color: 'white' }} > Log out</Link>
+                    ) : (<Link href="/login" style={{ color: 'white' }}>Log in</Link>)
                 }
+
             </div>
-        </header>
+        </header >
     )
 }
 

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+interface AuthContextType {
+    isAuthenticated: boolean | null;
+    setIsAuthenticated: (auth: boolean) => void;
+}
+
+// Create a context with a default value
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+/**
+ * Will wrap the content with this AuthProvider so that we can use context to check
+ * the authentication state, and to update the state
+ * @param param0 
+ * @returns 
+ */
+export function AuthProvider({ children }: {
+    children: React.ReactNode;
+}) {
+    const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+
+    useEffect(() => {
+        const checkAuth = async () => {
+            try {
+                const response = await fetch('/api/check-auth', {
+                    credentials: 'include', // This ensures cookies are sent with the request
+                });
+                const data = await response.json();
+                setIsAuthenticated(data.authenticated);
+            } catch (err) {
+                console.error('Error checking authentication status: ', err);
+                setIsAuthenticated(false);
+            }
+        };
+        checkAuth();
+    }, []);
+
+
+    return (
+        <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated }}>
+            {children}
+        </AuthContext.Provider>
+    )
+};
+
+export function useAuthContext() {
+    const context = useContext(AuthContext);
+    if (context === undefined) {
+        throw new Error('useAuthContext must be used within an AuthProvider')
+    }
+    return context;
+}

--- a/utils/test-utils.tsx
+++ b/utils/test-utils.tsx
@@ -1,0 +1,18 @@
+import React, { ReactElement } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { AuthProvider } from '../context/AuthContext';
+
+/* This will wrap the client components with the Auth Provider for the unit tests*/
+const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
+    return (
+        <AuthProvider>
+            {children}
+        </AuthProvider>
+    )
+};
+
+const customRender = (ui: ReactElement, options?: RenderOptions) =>
+    render(ui, { wrapper: AllTheProviders, ...options });
+
+export * from '@testing-library/react';
+export { customRender as render };


### PR DESCRIPTION
## Description

Fixes # [#65](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/65)

1. Added a "logout" link and API endpoint to delete the "dmspt" cookie when the user logs out.
2. Added an AuthProvider to wrap around the content so that we can share the authentication state in the client components, and update when the user logs in or logs out.
3. Since I added an AuthProvider, I had to create a custom render function for the unit tests of client components that use the AuthProvider.

Eventually, we should also be calling the backend server so that the JWT token can be invalidated.


## Type of change
Please delete options that are not relevant

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Start the app
4. Go to http://localhost:3000/login and log in
5. Notice the "dmspt" cookie after you log in
6. Notice that the link text in the header says "Log out" after you successfully log in
8. Click on the "Log out" link in the header
9. You should be redirected to the "/login" page and the cookie should've deleted
10. Notice that the link text in the header now says "Log in" after you successfully logged out.
11. Notice that the "dmspt" cookie has been deleted.



## Checklist:
- [] My code follows the style guidelines of this project (Not a final design. I just inserted a link into the header for testing purposes.)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules