### PR TITLE
[Chore] - Updated signin and signup endpoints to be 'apollo-signin' and 'apollo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   components. [#51]
 
 ### Updates
+- Updated endpoints for 'signin' and 'signup' to be 'apollo-signin' and 'apollo-signup' [#99]
 - Updates for auth pages to accomodate backend changes [#63]
 - Updated lib/graphql/client.ts with adding an errorLink to the client instance, and intercepting specific error types or codes to handle them differently if we want.[#29]
 - Updated lib/graphql/server/queries/dmpDataQueries.ts to 1) Map the error code to a user friendly message using a hash like utils/userFriendlyErrorMessage, log the error to the new utils/logger.ts, and throw an error that will be caught by the "try-catch" in the client- or server-side component. logger.ts can be used directly in client- and server-components as well.[#29]

--- a/app/login/__tests__/page.spec.tsx
+++ b/app/login/__tests__/page.spec.tsx
@@ -42,7 +42,7 @@ describe('LoginPage', () => {
 
     it('should render login form, save token in cookie, and redirect to home page', async () => {
         jest.spyOn(global, 'fetch').mockImplementation((url) => {
-            if (url === 'http://localhost:4000/signin') {
+            if (url === 'http://localhost:4000/apollo-signin') {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
@@ -76,7 +76,7 @@ describe('LoginPage', () => {
 
         await waitFor(() => {
             //Assert that the fetch calls were made with the correct arguments
-            expect(global.fetch).toHaveBeenCalledWith('http://localhost:4000/signin', {
+            expect(global.fetch).toHaveBeenCalledWith('http://localhost:4000/apollo-signin', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -96,7 +96,7 @@ describe('LoginPage', () => {
 
     it('should initially disable submit button after submitting form until response is returned ', async () => {
         jest.spyOn(global, 'fetch').mockImplementation((url) => {
-            if (url === 'http://localhost:4000/signin') {
+            if (url === 'http://localhost:4000/apollo-signin') {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
@@ -139,7 +139,7 @@ describe('LoginPage', () => {
 
     it('should show error message after too many attempts ', async () => {
         jest.spyOn(global, 'fetch').mockImplementation((url) => {
-            if (url === 'http://localhost:4000/signin') {
+            if (url === 'http://localhost:4000/apollo-signin') {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
@@ -250,7 +250,7 @@ describe('LoginPage', () => {
 
         // Check that user is redirected to 500 error page
         await waitFor(() => {
-            expect(mockUseRouter().push).toHaveBeenCalledWith('/500')
+            expect(mockUseRouter().push).toHaveBeenCalledWith('/500-error')
         })
     });
 
@@ -288,7 +288,7 @@ describe('LoginPage', () => {
                 'Signin error',
                 expect.objectContaining({
                     error: expect.anything(),
-                    url: { path: '/signin' },
+                    url: { path: '/apollo-signin' },
                 })
             )
         })

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -44,11 +44,11 @@ const LoginPage: React.FC = () => {
         const data = await result.json();
         if (data.status !== 200) {
             logECS('error', data.message, {
-                url: { path: '/signin' }
+                url: { path: '/apollo-signin' }
             });
         } else {
             logECS('info', data.message, {
-                url: { path: '/signin' }
+                url: { path: '/apollo-signin' }
             });
         }
     }
@@ -66,9 +66,9 @@ const LoginPage: React.FC = () => {
             }
         } else if (response.status === 500) {
             logECS('error', 'Internal server error', {
-                url: { path: '/signin' }
+                url: { path: '/apollo-signin' }
             });
-            router.push('/500');
+            router.push('/500-error');
         } else {
             setErrors(['An unexpected error occurred. Please try again.'])
         }
@@ -90,7 +90,7 @@ const LoginPage: React.FC = () => {
 
         /* eslint-disable @typescript-eslint/no-explicit-any */
         try {
-            const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/signin`, {
+            const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/apollo-signin`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -103,7 +103,7 @@ const LoginPage: React.FC = () => {
         } catch (err: any) {
             logECS('error', 'Signin error', {
                 error: err,
-                url: { path: '/signin' }
+                url: { path: '/apollo-signin' }
             });
         } finally {
             setLoading(false);

--- a/app/signup/__tests__/page.spec.tsx
+++ b/app/signup/__tests__/page.spec.tsx
@@ -44,7 +44,7 @@ describe('SignUpPage', () => {
 
     it('should render signup form and submit successfully', async () => {
         jest.spyOn(global, 'fetch').mockImplementation((url) => {
-            if (url === 'http://localhost:4000/signup') {
+            if (url === 'http://localhost:4000/apollo-signup') {
                 return Promise.resolve({
                     ok: true,
                     status: 200,
@@ -72,7 +72,7 @@ describe('SignUpPage', () => {
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
 
         //Assert that the fetch calls were made with the correct arguments
-        expect(global.fetch).toHaveBeenCalledWith('http://localhost:4000/signup', {
+        expect(global.fetch).toHaveBeenCalledWith('http://localhost:4000/apollo-signup', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -85,7 +85,7 @@ describe('SignUpPage', () => {
 
     it('should message user with lockout time period when user makes over 5 attempts to signup', async () => {
         jest.spyOn(global, 'fetch').mockImplementation((url) => {
-            if (url === `${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/signup`) {
+            if (url === `${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/apollo-signup`) {
                 return Promise.resolve({
                     ok: false,
                     status: 400,
@@ -253,7 +253,7 @@ describe('SignUpPage', () => {
                 'Signup error',
                 expect.objectContaining({
                     error: expect.anything(),
-                    url: { path: '/signup' },
+                    url: { path: '/apollo-signup' },
                 })
             )
         })

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -29,7 +29,7 @@ const SignUpPage: React.FC = () => {
             }
         } else if (response.status === 500) {
             logECS('error', 'Internal server error', {
-                url: { path: '/signup' }
+                url: { path: '/apollo-signup' }
             });
             router.push('/500');
         } else {
@@ -53,7 +53,7 @@ const SignUpPage: React.FC = () => {
 
         /* eslint-disable @typescript-eslint/no-explicit-any */
         try {
-            const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/signup`, {
+            const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/apollo-signup`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -66,7 +66,7 @@ const SignUpPage: React.FC = () => {
         } catch (err: any) {
             logECS('error', 'Signup error', {
                 error: err,
-                url: { path: '/signup' }
+                url: { path: '/apollo-signup' }
             });
         } finally {
             setLoading(false);


### PR DESCRIPTION
## Description

In response to the updates in this ticket, https://github.com/CDLUC3/dmsp_backend_prototype/pull/70, the frontend needed to update the endpoints for `signup` and `signin` to `apollo-signup` and `apollo-sigin`.

Additionally, I fixed the paths to the 500 error page.

Fixes # ([99](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/99))

## Type of change
Chore

## How Has This Been Tested?
I ran the backend branch for this ticket, [#70](https://github.com/CDLUC3/dmsp_backend_prototype/pull/70), and tested my changes by navigating to the "/login" and "/signup" pages of the app and made sure I could signup and sign in.

