### PR TITLE
Removed use of NEXT_PUBLIC_GRAPHQL_ENDPOINT env variable, since it wa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Cleaned up the styleguide and added additional text to explain the spacing guidelines
 - Created SCSS helpers/mixins to generate alot of our font sizes,colours and spacing
 
+### Fixed
+- Removed use of NEXT_PUBLIC_GRAPHQL_ENDPOINT env variable, since it was a duplicate of NEXT_PUBLIC_SERVER_ENDPOINT [#171]
 ### Added
 =======
 - Made some updates related to authentication [#142]

--- a/app/email/confirm-email/page.tsx
+++ b/app/email/confirm-email/page.tsx
@@ -1,8 +1,8 @@
-import {redirect} from 'next/navigation';
+import { redirect } from 'next/navigation';
 
 async function verifyEmail(userId: string, token: string) {
   // Verify the email address
-  const response = await fetch(`${process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT}/verify-email`, {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/verify-email`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ userId, token }),

--- a/lib/graphql/apollo-wrapper.tsx
+++ b/lib/graphql/apollo-wrapper.tsx
@@ -19,7 +19,7 @@ import {
 
 function makeClient() {
     const httpLink = createHttpLink({
-        uri: `${process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT}/graphql`
+        uri: `${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/graphql`
     });
 
 

--- a/lib/graphql/client/apollo-client.ts
+++ b/lib/graphql/client/apollo-client.ts
@@ -3,7 +3,7 @@ import { authLink, retryLink } from "../graphqlHelper";
 
 export const createApolloClient = () => {
     const httpLink = createHttpLink({
-        uri: `${process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT}/graphql`
+        uri: `${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/graphql`
     });
     return new ApolloClient({
         link: from([authLink, retryLink, httpLink]),


### PR DESCRIPTION

## Description

Currently, the app is using two different env variables with the same value:

NEXT_PUBLIC_SERVER_ENDPOINT="http://localhost:4000"
NEXT_PUBLIC_GRAPHQL_ENDPOINT="http://localhost:4000"

Switched to using NEXT_PUBLIC_SERVER_ENDPOINT for all instances.

Fixes # ([171](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/171))

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested that no existing unit tests fail


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [NA] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules