### PR TITLE
[Bug] - Fixed the server-side component unit test, and removed graphql-codege…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 - Cleaned up the styleguide and added additional text to explain the spacing guidelines
 - Created SCSS helpers/mixins to generate alot of our font sizes,colours and spacing
 
+
+### Fixed
+- Fixed a failing unit test and build for `confirm-email` component when backend server was not running [#180]
+
 ### Added
 =======
 - Made some updates related to authentication [#142]

--- a/app/email/confirm-email/__tests__/page.spec.tsx
+++ b/app/email/confirm-email/__tests__/page.spec.tsx
@@ -1,31 +1,35 @@
-/**
- * @jest-environment node
- */
-
-import {redirect} from 'next/navigation';
-import ConfirmEmailPage from '../page';
+import { redirect } from 'next/navigation';
 
 // Mock the redirect function from next/navigation
 jest.mock('next/navigation', () => ({
   redirect: jest.fn(),
 }));
 
-// Mock the fetch global
-global.fetch = jest.fn();
 
 describe('ConfirmEmailPage', () => {
   const mockParams = {
     params: { userId: '123', token: 'abc' },
   };
 
-  afterEach(() => {
-    jest.clearAllMocks();
+  beforeEach(() => {
+    global.fetch = jest.fn();
+
+    // Explicitly mock process.env
+    process.env.NEXT_PUBLIC_SERVER_ENDPOINT = 'http://test-endpoint.com';
   });
 
+  afterEach(() => {
+    jest.resetAllMocks();
+  })
+
   it('should redirect to /email-confirmed when email verification is successful', async () => {
+    // Import the component dynamically to ensure fresh mocks
+    const { default: ConfirmEmailPage } = await import('../page');
+
     // Mock fetch to return a successful response
-    (fetch as jest.Mock).mockResolvedValueOnce({
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
+      json: async () => ({})
     });
 
     // Call the server-side function
@@ -36,8 +40,11 @@ describe('ConfirmEmailPage', () => {
   });
 
   it('should redirect to /verification-failed when email verification fails', async () => {
-    // Mock fetch to return a failed response
-    (fetch as jest.Mock).mockResolvedValueOnce({
+    // Import the component dynamically to ensure fresh mocks
+    const { default: ConfirmEmailPage } = await import('../page');
+
+    // Mock fetch to return a successful response
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: false,
     });
 

--- a/app/email/confirm-email/page.tsx
+++ b/app/email/confirm-email/page.tsx
@@ -1,8 +1,10 @@
-import {redirect} from 'next/navigation';
+import { redirect } from 'next/navigation';
+
+export const dynamic = 'force-dynamic'
 
 async function verifyEmail(userId: string, token: string) {
   // Verify the email address
-  const response = await fetch(`${process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT}/verify-email`, {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/verify-email`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ userId, token }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8992,9 +8992,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && graphql-codegen --config codegen.ts",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint && npx eslint .",
     "generate": "graphql-codegen --config codegen.ts",


### PR DESCRIPTION

## Description

When the backend server was not running the confirm-email component unit test was failing. We need to update it to properly mock the fetch calls so that it would not attempt to make actual calls to the backend.

Also, when running npm run build, there were errors because NextJS was attempting to generate a static page by actually fetching the data from the backend. However, when the backend server was not running, the build was failing. Need to update the code so that it does not attempt a static page generation.

Fixes # ([180](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/180))

## Type of change
- [x} Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Ran `npm test`, `npm run lint` and `npm run build` when the backend server was not running.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [NA] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules