### PR TITLE
Fixed /login 404 issue related to new [locale] directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 
 ### Fixed
+- Fixed `login` 404 error issue and looping issue in middleware [#194]
 - Removed old `app/layout.tsx` page. It was causing errors, since we have one located at `app/[locale]/layout.tsx` now.
 - Fixed a failing unit test and build for `confirm-email` component when backend server was not running [#180]
 - Removed use of NEXT_PUBLIC_GRAPHQL_ENDPOINT env variable, since it was a duplicate of NEXT_PUBLIC_SERVER_ENDPOINT [#171]

--- a/__tests__/middleware.spec.ts
+++ b/__tests__/middleware.spec.ts
@@ -66,15 +66,6 @@ describe('middleware', () => {
         expect(NextResponse.redirect).toHaveBeenCalledWith(expectedUrl);
     });
 
-    it('should return next response when it is an excluded path', async () => {
-        request.nextUrl.pathname = '/_next';
-
-        const result = await middleware(request);
-
-        expect(NextResponse.next).toHaveBeenCalled();
-        expect(result).toBe(response);
-    });
-
     it('should redirect to /login if both tokens are missing and path is protected', async () => {
         request.nextUrl.pathname = '/dmps/';
         request.cookies.get = jest.fn().mockReturnValue(undefined); // No tokens

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,7 +20,7 @@ interface JWTAccessToken extends JwtPayload {
 }
 
 // TODO: These routes will need to be updated.
-const excludedPaths = ['/email', '/favicon.ico', '/_next', '/api'];
+const excludedPaths = ['/email', '/favicon.ico', '/_next', '/api', '/login', '/signup'];
 
 const handleI18nRouting = createMiddleware(routing);
 
@@ -72,20 +72,16 @@ async function getLocale(request: NextRequest) {
 export async function middleware(request: NextRequest) {
   const response = NextResponse.next();
   const { pathname } = request.nextUrl;
-  // Check if the path is in the excludedPaths array
-  if (excludedPaths.some(path => pathname.startsWith(path))) {
-    // If it is, return the response without checking for tokens
-    return response;
-  }
-
   const accessToken = request.cookies.get('dmspt');
   const refreshToken = request.cookies.get('dmspr');
 
   /* TODO: might want to add a 'redirect' query param to url to redirect user after
    login to the original page they were trying to get to.*/
 
-  // Check for tokens for paths that are not excluded from authentication
-  if (!excludedPaths.some(path => pathname.startsWith(path))) {
+  /* Check for tokens for paths that are not excluded from authentication
+  and are not signup or login */
+  const isExcludedPath = excludedPaths.some(path => pathname.includes(path));
+  if (!isExcludedPath) {
     if (!accessToken && !refreshToken) {
       return NextResponse.redirect(new URL('/login', request.url));
     }


### PR DESCRIPTION
## Description

After we added the `[locale]` directory, the `/login` page was giving a **404** error in the middleware.

We need to update the logic in the middleware to add `login` and `signup` page to the exclusion list, and remove the return response for all excluded pages.

Fixes # ([194](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/194))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Run unit tests and manually tested


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [NA] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules