### PR TITLE
Hook up the Edit and Add Question pages and add fields and functionality for current question types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## v0.0.1
 
 ### Updated
+- Updated the Edit Question `template/[templateId]/q/[q_slug]/page.tsx` with actual data from backend and added functionality for `options` question types [#188]
+- Updated the Add Question`template/[templateId]/q/new/page.tsx` page with actual data from backend and added functionality to accomodate `option` question types. [#188]
+- Updated shared FormInput component [#188]
 - Updated `/template/create/page.tsx`[#186]
 - Removed select-template page, since we are using `SelectExistingTemplate` in place of it [#186]
 - Updated existing Templates graphql query with more fields [#186]
@@ -15,7 +18,11 @@
 
 ### Added
 - Added new `QuestionEdit` and `QuestionTypeCard` components [#220]
-
+- Added new Question and QuestionOption types [#188]
+- Added a new FormTextArea component [#188]
+- Added new QuestionOptionsComponent for handling the `options` question types in the form [#188]
+- Added new QuestionAdd component for adding a new question [#188]
+- Added new `QuestionsDisplayOrder` and `Question` queries and `AddQuestion` and `UpdateQuestion` mutations [#188]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Added new QuestionOptionsComponent for handling the `options` question types in the form [#188]
 - Added new QuestionAdd component for adding a new question [#188]
 - Added new `QuestionsDisplayOrder` and `Question` queries and `AddQuestion` and `UpdateQuestion` mutations [#188]
+- Added useSampleTextAsDefault checkbox for text field question types [#188]
 
 ### Fixed
 

--- a/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/generated/graphql';
 
 import { axe, toHaveNoViolations } from 'jest-axe';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations as OriginalUseTranslations } from 'next-intl';
 import QuestionEdit from '../page';
 expect.extend(toHaveNoViolations);
@@ -21,7 +21,8 @@ jest.mock("@/generated/graphql", () => ({
 
 jest.mock('next/navigation', () => ({
   useParams: jest.fn(),
-  useRouter: jest.fn()
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn()
 }))
 
 jest.mock('@/context/ToastContext', () => ({
@@ -161,7 +162,7 @@ describe("QuestionEditPage", () => {
     const mockUseParams = useParams as jest.Mock;
 
     // Mock the return value of useParams
-    mockUseParams.mockReturnValue({ templateId: `${mockTemplateId}` });
+    mockUseParams.mockReturnValue({ templateId: `${mockTemplateId}`, q_slug: 67 });
 
     // Mock the router
     mockRouter = { push: jest.fn() };
@@ -184,6 +185,23 @@ describe("QuestionEditPage", () => {
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
       { loading: false, error: undefined },
     ]);
+
+    // Render with text question type
+    (useSearchParams as jest.MockedFunction<typeof useSearchParams>).mockImplementation(() => {
+      return {
+        get: (key: string) => {
+          const params: Record<string, string> = { questionTypeId: '1' };
+          return params[key] || null;
+        },
+        getAll: () => [],
+        has: (key: string) => key in { questionTypeId: '1' },
+        keys: function* () { },
+        values: function* () { },
+        entries: function* () { },
+        forEach: () => { },
+        toString: () => '',
+      } as unknown as ReturnType<typeof useSearchParams>;
+    });
 
     await act(async () => {
       render(
@@ -229,6 +247,23 @@ describe("QuestionEditPage", () => {
       { loading: false, error: undefined },
     ]);
 
+    // Render with text question type
+    (useSearchParams as jest.MockedFunction<typeof useSearchParams>).mockImplementation(() => {
+      return {
+        get: (key: string) => {
+          const params: Record<string, string> = { questionTypeId: '1' };
+          return params[key] || null;
+        },
+        getAll: () => [],
+        has: (key: string) => key in { questionTypeId: '1' },
+        keys: function* () { },
+        values: function* () { },
+        entries: function* () { },
+        forEach: () => { },
+        toString: () => '',
+      } as unknown as ReturnType<typeof useSearchParams>;
+    });
+
     await act(async () => {
       render(
         <QuestionEdit />
@@ -254,6 +289,23 @@ describe("QuestionEditPage", () => {
       { loading: false, error: undefined },
     ]);
 
+    // Render with text question type
+    (useSearchParams as jest.MockedFunction<typeof useSearchParams>).mockImplementation(() => {
+      return {
+        get: (key: string) => {
+          const params: Record<string, string> = { questionTypeId: '1' };
+          return params[key] || null;
+        },
+        getAll: () => [],
+        has: (key: string) => key in { questionTypeId: '1' },
+        keys: function* () { },
+        values: function* () { },
+        entries: function* () { },
+        forEach: () => { },
+        toString: () => '',
+      } as unknown as ReturnType<typeof useSearchParams>;
+    });
+
     await act(async () => {
       render(
         <QuestionEdit />
@@ -264,7 +316,7 @@ describe("QuestionEditPage", () => {
     fireEvent.click(changeTypeButton);
 
     // Verify that router redirects to question types page
-    expect(mockRouter.push).toHaveBeenCalledWith('/template/123/q/new?section_id=67&step=1');
+    expect(mockRouter.push).toHaveBeenCalledWith('/template/123/q/new?section_id=67&step=1&questionId=67');
   })
 
   // QuestionOptionsComponent has it's own separate unit test, so we are just testing that it loads here
@@ -273,6 +325,23 @@ describe("QuestionEditPage", () => {
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
       { loading: false, error: undefined },
     ]);
+
+    // Render with text question type
+    (useSearchParams as jest.MockedFunction<typeof useSearchParams>).mockImplementation(() => {
+      return {
+        get: (key: string) => {
+          const params: Record<string, string> = { questionTypeId: '3' };
+          return params[key] || null;
+        },
+        getAll: () => [],
+        has: (key: string) => key in { questionTypeId: '3' },
+        keys: function* () { },
+        values: function* () { },
+        entries: function* () { },
+        forEach: () => { },
+        toString: () => '',
+      } as unknown as ReturnType<typeof useSearchParams>;
+    });
 
     await act(async () => {
       render(
@@ -288,6 +357,23 @@ describe("QuestionEditPage", () => {
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
       { loading: false, error: undefined },
     ]);
+
+    // Render with text question type
+    (useSearchParams as jest.MockedFunction<typeof useSearchParams>).mockImplementation(() => {
+      return {
+        get: (key: string) => {
+          const params: Record<string, string> = { questionTypeId: '1' };
+          return params[key] || null;
+        },
+        getAll: () => [],
+        has: (key: string) => key in { questionTypeId: '1' },
+        keys: function* () { },
+        values: function* () { },
+        entries: function* () { },
+        forEach: () => { },
+        toString: () => '',
+      } as unknown as ReturnType<typeof useSearchParams>;
+    });
 
     await act(async () => {
       render(
@@ -311,6 +397,23 @@ describe("QuestionEditPage", () => {
       { loading: false, error: undefined },
     ]);
 
+    // Render with text question type
+    (useSearchParams as jest.MockedFunction<typeof useSearchParams>).mockImplementation(() => {
+      return {
+        get: (key: string) => {
+          const params: Record<string, string> = { questionTypeId: '' };
+          return params[key] || null;
+        },
+        getAll: () => [],
+        has: (key: string) => key in { questionTypeId: '' },
+        keys: function* () { },
+        values: function* () { },
+        entries: function* () { },
+        forEach: () => { },
+        toString: () => '',
+      } as unknown as ReturnType<typeof useSearchParams>;
+    });
+
     await act(async () => {
       render(
         <QuestionEdit />
@@ -326,6 +429,23 @@ describe("QuestionEditPage", () => {
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
       { loading: false, error: undefined },
     ]);
+
+    // Render with text question type
+    (useSearchParams as jest.MockedFunction<typeof useSearchParams>).mockImplementation(() => {
+      return {
+        get: (key: string) => {
+          const params: Record<string, string> = { questionTypeId: '' };
+          return params[key] || null;
+        },
+        getAll: () => [],
+        has: (key: string) => key in { questionTypeId: '' },
+        keys: function* () { },
+        values: function* () { },
+        entries: function* () { },
+        forEach: () => { },
+        toString: () => '',
+      } as unknown as ReturnType<typeof useSearchParams>;
+    });
 
     (useQuestionQuery as jest.Mock).mockReturnValue({
       data: mockQuestionDataForTextField,

--- a/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import { render, screen, act, fireEvent } from '@/utils/test-utils';
+import {
+  useQuestionQuery,
+  useUpdateQuestionMutation,
+  useQuestionTypesQuery
+} from '@/generated/graphql';
+
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { useParams } from 'next/navigation';
+import { useTranslations as OriginalUseTranslations } from 'next-intl';
+import QuestionEdit from '../page';
+expect.extend(toHaveNoViolations);
+
+// Mock the useTemplateQuery hook
+jest.mock("@/generated/graphql", () => ({
+  useQuestionQuery: jest.fn(),
+  useUpdateQuestionMutation: jest.fn(),
+  useQuestionTypesQuery: jest.fn()
+}));
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  useRouter: jest.fn()
+}))
+
+jest.mock('@/context/ToastContext', () => ({
+  useToast: jest.fn(() => ({
+    add: jest.fn(),
+  })),
+}));
+
+// Create a mock for scrollIntoView and focus
+const mockScrollIntoView = jest.fn();
+
+type UseTranslationsType = ReturnType<typeof OriginalUseTranslations>;
+
+// Mock useTranslations from next-intl
+jest.mock('next-intl', () => ({
+  useTranslations: jest.fn(() => {
+    const mockUseTranslations: UseTranslationsType = ((key: string) => key) as UseTranslationsType;
+
+    /*eslint-disable @typescript-eslint/no-explicit-any */
+    mockUseTranslations.rich = (
+      key: string,
+      values?: Record<string, any>
+    ) => {
+      // Handle rich text formatting
+      if (values?.p) {
+        return values.p(key); // Simulate rendering the `p` tag function
+      }
+      return key;
+    };
+
+    return mockUseTranslations;
+  }),
+}));
+
+const mockQuestionData = {
+  question: {
+    displayOrder: 17,
+    errors: null,
+    guidanceText: "This is the guidance text",
+    id: 2271,
+    isDirty: true,
+    questionOptions:
+      [
+        {
+          id: 63,
+          orderNumber: 1,
+          questionId: 2271,
+          Text: "Alpha"
+        },
+        {
+          id: 66,
+          orderNumber: 2,
+          questionId: 2271,
+          Text: "Bravo"
+        }
+      ],
+    questionText: "Testing",
+    questionTypeId: 3,
+    requirementText: "This is requirement text",
+    sampleText: "This is sample text",
+    sectionId: 67,
+    templateId: 15
+  }
+}
+
+const mockQuestionTypesData = {
+  questionTypes: [
+    {
+      id: 1,
+      name: "Text Area",
+      usageDescription: "For questions that require longer answers, you can select formatting options too."
+    },
+    {
+      id: 2,
+      name: "Text Field",
+      usageDescription: "For questions that require short, simple answers."
+    },
+    {
+      id: 3,
+      name: "Radio Buttons",
+      usageDescription: "For multiple choice questions where users select just one option."
+    },
+    {
+      id: 4,
+      name: "Check Boxes",
+      usageDescription: "For multiple choice questions where users can select multiple options."
+    }
+  ]
+}
+
+
+describe("QuestionEditPage", () => {
+  beforeEach(() => {
+    HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
+    window.scrollTo = jest.fn(); // Called by the wrapping PageHeader
+    const mockTemplateId = 123;
+    const mockUseParams = useParams as jest.Mock;
+
+    // Mock the return value of useParams
+    mockUseParams.mockReturnValue({ templateId: `${mockTemplateId}` });
+
+    (useQuestionQuery as jest.Mock).mockReturnValue({
+      data: mockQuestionData,
+      loading: false,
+      error: undefined,
+    });
+
+    (useQuestionTypesQuery as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: mockQuestionTypesData }),
+      { loading: false, error: undefined },
+    ]);
+  });
+
+  it("should render correct fields", async () => {
+    (useUpdateQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+    await act(async () => {
+      render(
+        <QuestionEdit />
+      );
+    });
+
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent('Edit: Testing');
+    const editQuestionTab = screen.getByRole('tab', { name: 'tabs.editQuestion' });
+    expect(editQuestionTab).toBeInTheDocument();
+    const editOptionsTab = screen.getByRole('tab', { name: 'tabs.options' });
+    expect(editOptionsTab).toBeInTheDocument();
+    const editLogicTab = screen.getByRole('tab', { name: 'tabs.logic' });
+    expect(editLogicTab).toBeInTheDocument();
+    const questionTypeLabel = screen.getByRole('textbox', { name: 'labels.type' });
+    expect(questionTypeLabel).toBeInTheDocument();
+    const questionTextLabel = screen.getByRole('textbox', { name: 'labels.questionText' });
+    expect(questionTextLabel).toBeInTheDocument();
+    const questionRequirementTextLabel = screen.getByRole('textbox', { name: 'labels.requirementText' });
+    expect(questionRequirementTextLabel).toBeInTheDocument();
+    const questionGuidanceTextLabel = screen.getByRole('textbox', { name: 'labels.guidanceText' });
+    expect(questionGuidanceTextLabel).toBeInTheDocument();
+    const questionSampleTextLabel = screen.getByRole('textbox', { name: 'labels.sampleText' });
+    expect(questionSampleTextLabel).toBeInTheDocument();
+
+  });
+
+  it('should pass axe accessibility test', async () => {
+    (useUpdateQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+    const { container } = render(
+      <QuestionEdit />
+    );
+    await act(async () => {
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
@@ -95,6 +95,37 @@ const mockQuestionData = {
   }
 }
 
+const mockQuestionDataForTextField = {
+  question: {
+    displayOrder: 17,
+    errors: null,
+    guidanceText: "This is the guidance text",
+    id: 2271,
+    isDirty: true,
+    questionOptions:
+      [
+        {
+          id: 63,
+          orderNumber: 1,
+          questionId: 2271,
+          Text: "Alpha"
+        },
+        {
+          id: 66,
+          orderNumber: 2,
+          questionId: 2271,
+          Text: "Bravo"
+        }
+      ],
+    questionText: "Testing",
+    questionTypeId: 1,
+    requirementText: "This is requirement text",
+    sampleText: "This is sample text",
+    sectionId: 67,
+    templateId: 15
+  }
+}
+
 const mockQuestionTypesData = {
   questionTypes: [
     {
@@ -272,6 +303,44 @@ describe("QuestionEditPage", () => {
     await waitFor(() => {
       expect(useUpdateQuestionMutation).toHaveBeenCalled();
     });
+  })
+
+  it('should not display the useSampleTextAsDefault checkbox if the questionTypeId is Radio Button field', async () => {
+    (useUpdateQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+    await act(async () => {
+      render(
+        <QuestionEdit />
+      );
+    });
+
+    const checkboxText = screen.queryByText('descriptions.sampleTextAsDefault');
+    expect(checkboxText).not.toBeInTheDocument();
+  })
+
+  it('should display the useSampleTextAsDefault checkbox if the questionTypeId is for a text field', async () => {
+    (useUpdateQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+    (useQuestionQuery as jest.Mock).mockReturnValue({
+      data: mockQuestionDataForTextField,
+      loading: false,
+      error: undefined,
+    });
+
+    await act(async () => {
+      render(
+        <QuestionEdit />
+      );
+    });
+
+    const checkboxText = screen.queryByText('descriptions.sampleTextAsDefault');
+    expect(checkboxText).toBeInTheDocument();
   })
 
   it('should pass axe accessibility test', async () => {

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -8,7 +8,6 @@ import {
   Breadcrumb,
   Breadcrumbs,
   Button,
-  FieldError,
   Form,
   Input,
   Label,
@@ -18,7 +17,6 @@ import {
   TabPanel,
   Tabs,
   Text,
-  TextArea,
   TextField
 } from "react-aria-components";
 
@@ -33,6 +31,7 @@ import {
 import PageHeader from "@/components/PageHeader";
 import QuestionOptionsComponent from '@/components/Form/QuestionOptionsComponent';
 import FormInput from '@/components/Form/FormInput';
+import FormTextArea from '@/components/Form/FormTextArea';
 
 //Other
 import { useToast } from '@/context/ToastContext';
@@ -247,59 +246,44 @@ const QuestionEdit = () => {
                   errorMessage={QuestionEdit('messages.errors.questionTextRequired')}
                 />
 
-                <TextField
+                <FormTextArea
                   name="question_requirements"
-                  isRequired
-                >
-                  <Label>{QuestionEdit('labels.requirementText')}</Label>
-                  <Text slot="description" className="help-text">
-                    {QuestionEdit('helpText.requirementText')}
-                  </Text>
-                  <TextArea
-                    value={question?.requirementText ? question.requirementText : ''}
-                    onChange={(e) => setQuestion({
-                      ...question,
-                      requirementText: e.currentTarget.value
-                    })}
-                    style={{ height: '100px' }}
-                  />
-                  <FieldError />
-                </TextField>
+                  isRequired={false}
+                  description={QuestionEdit('helpText.requirementText')}
+                  textAreaClasses={styles.questionFormField}
+                  label={QuestionEdit('labels.requirementText')}
+                  value={question?.requirementText ? question.requirementText : ''}
+                  onChange={(e) => setQuestion({
+                    ...question,
+                    requirementText: e.currentTarget.value
+                  })}
+                  helpMessage={QuestionEdit('helpText.requirementText')}
+                />
 
-                <TextField
-                  name="question_guidance">
-                  <Label>{QuestionEdit('labels.guidanceText')}</Label>
-                  <TextArea
-                    value={question?.guidanceText ? question.guidanceText : ''}
-                    onChange={(e) => setQuestion({
-                      ...question,
-                      guidanceText: e.currentTarget.value
-                    })}
-                    style={{ height: '150px' }}
-                  />
-                  <FieldError />
-                </TextField>
+                <FormTextArea
+                  name="question_guidance"
+                  isRequired={false}
+                  textAreaClasses={styles.questionFormField}
+                  label={QuestionEdit('labels.guidanceText')}
+                  value={question?.guidanceText ? question.guidanceText : ''}
+                  onChange={(e) => setQuestion({
+                    ...question,
+                    guidanceText: e.currentTarget.value
+                  })}
+                />
 
-                <TextField
+                <FormTextArea
                   name="sample_text"
-                >
-                  <Label>{QuestionEdit('labels.sampleText')}</Label>
-                  <Text slot="description" className="help-text">
-                    {QuestionEdit('descriptions.sampleText')}
-                  </Text>
-                  <TextArea
-                    value={question?.sampleText ? question?.sampleText : ''}
-                    onChange={(e) => setQuestion({
-                      ...question,
-                      sampleText: e.currentTarget.value
-                    })}
-                    style={{ height: '80px' }}
-                  />
-                  <FieldError />
-                  <Text slot="description" className="help-text">
-                    {QuestionEdit('helpText.sampleText')}
-                  </Text>
-                </TextField>
+                  isRequired={false}
+                  description={QuestionEdit('descriptions.sampleText')}
+                  textAreaClasses={styles.questionFormField}
+                  label={QuestionEdit('labels.sampleText')}
+                  value={question?.sampleText ? question?.sampleText : ''}
+                  onChange={(e) => setQuestion({
+                    ...question,
+                    sampleText: e.currentTarget.value
+                  })}
+                />
 
                 <Button type="submit">{Global('buttons.save')}</Button>
 

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -124,7 +124,7 @@ const QuestionEdit = () => {
     if (rows && rows.length > 0) {
       // If duplicate order numbers or text, do we want to give the user an error message?
       transformedRows = rows.map(option => {
-        return { questionOptionId: option.id, text: option.text, orderNumber: option.orderNumber, isDefault: option.isDefault, questionId: Number(q_slug) }
+        return { id: option.id, text: option.text, orderNumber: option.orderNumber, isDefault: option.isDefault, questionId: Number(q_slug) }
       })
     }
 

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -54,6 +54,7 @@ const QuestionEdit = () => {
   const [question, setQuestion] = useState<Question>();
   const [rows, setRows] = useState<QuestionOptions[]>([]);//Question options, initially set as an empty array
   const [questionType, setQuestionType] = useState<string>('');
+  const [formSubmitted, setFormSubmitted] = useState<boolean>(false);
   const [errors, setErrors] = useState<string[]>([]);
 
   // Initialize update question mutation
@@ -94,6 +95,8 @@ const QuestionEdit = () => {
   const handleUpdate = async (e: React.FormEvent) => {
     e.preventDefault();
     if (question) {
+      setFormSubmitted(true);
+
       try {
         // Add mutation for question
         const response = await updateQuestionMutation({
@@ -229,7 +232,7 @@ const QuestionEdit = () => {
                 {selectedQuestion?.question?.questionTypeId && [3, 4, 5].includes(selectedQuestion?.question?.questionTypeId) && (
                   <div className={styles.optionsWrapper}>
                     <p className={styles.optionsDescription}>{QuestionEdit('helpText.questionOptions', { questionType })}</p>
-                    <QuestionOptionsComponent rows={rows} setRows={setRows} questionId={Number(questionId)} />
+                    <QuestionOptionsComponent rows={rows} setRows={setRows} questionId={Number(questionId)} formSubmitted={formSubmitted} setFormSubmitted={setFormSubmitted} />
                   </div>
                 )}
 
@@ -305,7 +308,7 @@ const QuestionEdit = () => {
                   </Checkbox>
                 )}
 
-                <Button type="submit">{Global('buttons.save')}</Button>
+                <Button type="submit" onPress={() => setFormSubmitted(true)}>{Global('buttons.save')}</Button>
 
               </Form>
 

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -256,13 +256,10 @@ const QuestionEdit = () => {
 
                 {/**Question type fields here */}
                 {hasOptions && (
-                  <>
-                    <h2>Has options!!</h2>
-                    <div className={styles.optionsWrapper}>
-                      <p className={styles.optionsDescription}>{QuestionEdit('helpText.questionOptions', { questionType })}</p>
-                      <QuestionOptionsComponent rows={rows} setRows={setRows} questionId={Number(questionId)} formSubmitted={formSubmitted} setFormSubmitted={setFormSubmitted} />
-                    </div>
-                  </>
+                  <div className={styles.optionsWrapper}>
+                    <p className={styles.optionsDescription}>{QuestionEdit('helpText.questionOptions', { questionType })}</p>
+                    <QuestionOptionsComponent rows={rows} setRows={setRows} questionId={Number(questionId)} formSubmitted={formSubmitted} setFormSubmitted={setFormSubmitted} />
+                  </div>
                 )}
 
                 <FormInput

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { ApolloError } from '@apollo/client';
 import { useParams, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import {
   Breadcrumb,
   Breadcrumbs,
@@ -56,6 +57,10 @@ const QuestionEdit = () => {
 
   // Initialize update question mutation
   const [updateQuestionMutation] = useUpdateQuestionMutation();
+
+  // localization keys
+  const Global = useTranslations('Global');
+  const QuestionEdit = useTranslations('QuestionEdit');
 
   // Run selected question query
   const { data: selectedQuestion, loading, error: selectedQuestionQueryError } = useQuestionQuery(
@@ -166,9 +171,9 @@ const QuestionEdit = () => {
         showBackButton={true}
         breadcrumbs={
           <Breadcrumbs>
-            <Breadcrumb><Link href="/">Home</Link></Breadcrumb>
-            <Breadcrumb><Link href={`/template/${templateId}`}>Edit Template</Link></Breadcrumb>
-            <Breadcrumb>Question</Breadcrumb>
+            <Breadcrumb><Link href="/">{Global('breadcrumbs.home')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={`/template/${templateId}`}>{Global('breadcrumbs.editTemplate')}</Link></Breadcrumb>
+            <Breadcrumb>{Global('breadcrumbs.question')}</Breadcrumb>
           </Breadcrumbs>
         }
         actions={null}
@@ -194,9 +199,9 @@ const QuestionEdit = () => {
           }
           <Tabs>
             <TabList aria-label="Question editing">
-              <Tab id="edit">Edit Question</Tab>
-              <Tab id="options">Options</Tab>
-              <Tab id="logic">Logic</Tab>
+              <Tab id="edit">{Global('tabs.editQuestion')}</Tab>
+              <Tab id="options">{Global('tabs.options')}</Tab>
+              <Tab id="logic">{Global('tabs.logic')}</Tab>
             </TabList>
 
             <TabPanel id="edit">
@@ -207,21 +212,21 @@ const QuestionEdit = () => {
                   className={`${styles.searchField} react-aria-TextField`}
                   isRequired
                 >
-                  <Label className={`${styles.searchLabel} react-aria-Label`}>Type (required)</Label>
+                  <Label className={`${styles.searchLabel} react-aria-Label`}>{QuestionEdit('labels.type')}</Label>
                   <Input
                     value={questionType}
                     className={`${styles.searchInput} react-aria-Input`}
                     disabled />
-                  <Button className={`${styles.searchButton} react-aria-Button`} type="button" onPress={redirectToQuestionTypes}>Change type</Button>
+                  <Button className={`${styles.searchButton} react-aria-Button`} type="button" onPress={redirectToQuestionTypes}>{QuestionEdit('buttons.changeType')}</Button>
                   <Text slot="description" className={`${styles.searchHelpText} help-text`}>
-                    Changing the question type, for example from Short question to Radio button, may result in some data being lost.
+                    {QuestionEdit('helpText.textField')}
                   </Text>
                 </TextField>
 
                 {/**Question type fields here */}
                 {selectedQuestion?.question?.questionTypeId && [3, 4, 5].includes(selectedQuestion?.question?.questionTypeId) && (
                   <div className={styles.optionsWrapper}>
-                    <p className={styles.optionsDescription}>Please enter answer choices for the {questionType}</p>
+                    <p className={styles.optionsDescription}>{QuestionEdit('Please enter answer choices for the', { questionType })}</p>
                     <QuestionOptionsComponent rows={rows} setRows={setRows} questionId={Number(questionId)} />
                   </div>
                 )}
@@ -231,7 +236,7 @@ const QuestionEdit = () => {
                   type="text"
                   isRequired
                 >
-                  <Label>Question text (required)</Label>
+                  <Label>{QuestionEdit('labels.questionText')}</Label>
                   <Input
                     value={question?.questionText ? question.questionText : ''}
                     onChange={(e) => setQuestion({
@@ -240,7 +245,7 @@ const QuestionEdit = () => {
                     })}
                   />
                   <Text slot="description" className="help-text">
-                    Keep the question text concise and clear. Use the requirements or guidance to provide additional explanation.
+                    {QuestionEdit('helpText.questionText')}
                   </Text>
                   <FieldError />
                 </TextField>
@@ -249,9 +254,9 @@ const QuestionEdit = () => {
                   name="question_requirements"
                   isRequired
                 >
-                  <Label>Requirements plan writer must meet (optional but recommended)</Label>
+                  <Label>{QuestionEdit('labels.requirementText')}</Label>
                   <Text slot="description" className="help-text">
-                    Try to be precise and concise, so the plan writers won't miss any requirements. Question guidance is better for more general advice.
+                    {QuestionEdit('helpText.requirementText')}
                   </Text>
                   <TextArea
                     value={question?.requirementText ? question.requirementText : ''}
@@ -265,8 +270,8 @@ const QuestionEdit = () => {
                 </TextField>
 
                 <TextField
-                  name="question_guidance"                >
-                  <Label>Question guidance (optional but recommended)</Label>
+                  name="question_guidance">
+                  <Label>{QuestionEdit('labels.guidanceText')}</Label>
                   <TextArea
                     value={question?.guidanceText ? question.guidanceText : ''}
                     onChange={(e) => setQuestion({
@@ -281,11 +286,9 @@ const QuestionEdit = () => {
                 <TextField
                   name="sample_text"
                 >
-                  <Label>Sample text</Label>
+                  <Label>{QuestionEdit('labels.sampleText')}</Label>
                   <Text slot="description" className="help-text">
-                    Provide an example or template of expected answer (optional
-                    but
-                    recommended)
+                    {QuestionEdit('descriptions.sampleText')}
                   </Text>
                   <TextArea
                     value={question?.sampleText ? question?.sampleText : ''}
@@ -297,21 +300,21 @@ const QuestionEdit = () => {
                   />
                   <FieldError />
                   <Text slot="description" className="help-text">
-                    Plan creators will be able to copy the sample text into the field as a starting point, to speed up content entry.
+                    {QuestionEdit('helpText.sampleText')}
                   </Text>
                 </TextField>
 
-                <Button type="submit">Save</Button>
+                <Button type="submit">{Global('buttons.save')}</Button>
 
               </Form>
 
 
             </TabPanel>
             <TabPanel id="options">
-              <h2>Options</h2>
+              <h2>{Global('tabs.options')}</h2>
             </TabPanel>
             <TabPanel id="logic">
-              <h2>logic</h2>
+              <h2>{Global('tabs.logic')}</h2>
             </TabPanel>
           </Tabs>
 

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -32,6 +32,7 @@ import {
 // Components
 import PageHeader from "@/components/PageHeader";
 import QuestionOptionsComponent from '@/components/Form/QuestionOptionsComponent';
+import FormInput from '@/components/Form/FormInput';
 
 //Other
 import { useToast } from '@/context/ToastContext';
@@ -110,14 +111,14 @@ const QuestionEdit = () => {
         });
 
         if (response?.data) {
-          toastState.add('Question was successfully updated', { type: 'success' });
+          toastState.add(QuestionEdit('messages.success.questionUpdated'), { type: 'success' });
         }
       } catch (error) {
         if (error instanceof ApolloError) {
           //
         } else {
           // Handle other types of errors
-          setErrors(prevErrors => [...prevErrors, 'Error when updating profile']);
+          setErrors(prevErrors => [...prevErrors, QuestionEdit('messages.errors.questionUpdateError')]);
         }
       }
     }
@@ -166,7 +167,7 @@ const QuestionEdit = () => {
   return (
     <>
       <PageHeader
-        title={`Edit: ${selectedQuestion?.question?.questionText}`}
+        title={QuestionEdit('title', { title: selectedQuestion?.question?.questionText })}
         description=""
         showBackButton={true}
         breadcrumbs={
@@ -231,24 +232,20 @@ const QuestionEdit = () => {
                   </div>
                 )}
 
-                <TextField
+                <FormInput
                   name="question_text"
                   type="text"
-                  isRequired
-                >
-                  <Label>{QuestionEdit('labels.questionText')}</Label>
-                  <Input
-                    value={question?.questionText ? question.questionText : ''}
-                    onChange={(e) => setQuestion({
-                      ...question,
-                      questionText: e.currentTarget.value
-                    })}
-                  />
-                  <Text slot="description" className="help-text">
-                    {QuestionEdit('helpText.questionText')}
-                  </Text>
-                  <FieldError />
-                </TextField>
+                  isRequired={true}
+                  label={QuestionEdit('labels.questionText')}
+                  value={question?.questionText ? question.questionText : ''}
+                  onChange={(e) => setQuestion({
+                    ...question,
+                    questionText: e.currentTarget.value
+                  })}
+                  helpMessage={QuestionEdit('helpText.questionText')}
+                  isInvalid={!question?.questionText}
+                  errorMessage={QuestionEdit('messages.errors.questionTextRequired')}
+                />
 
                 <TextField
                   name="question_requirements"
@@ -321,19 +318,14 @@ const QuestionEdit = () => {
         </div >
 
         <div className="sidebar">
-          <h2>Preview</h2>
-          <p>See how this question will look to users.</p>
-          <Button>Preview question</Button>
+          <h2>{Global('headings.preview')}</h2>
+          <p>{QuestionEdit('descriptions.previewText')}</p>
+          <Button>{QuestionEdit('buttons.previewQuestion')}</Button>
 
-          <h3>Best practice by DMP Tool</h3>
-          <p>Keep the question concise and clear. Use the requirements or
-            guidance
-            to provide additional explanation.</p>
-          <p>Outline the requirements that a user must consider for this
-            question.</p>
-          <p>Researchers will be able to copy the sample text into the field as
-            a
-            starting point, as a way to speed up content entry.</p>
+          <h3>{QuestionEdit('headings.bestPractice')}</h3>
+          <p>{QuestionEdit('descriptions.bestPracticePara1')}</p>
+          <p>{QuestionEdit('descriptions.bestPracticePara2')}</p>
+          <p>{QuestionEdit('descriptions.bestPracticePara3')}</p>
         </div>
       </div >
     </>

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -226,7 +226,7 @@ const QuestionEdit = () => {
                 {/**Question type fields here */}
                 {selectedQuestion?.question?.questionTypeId && [3, 4, 5].includes(selectedQuestion?.question?.questionTypeId) && (
                   <div className={styles.optionsWrapper}>
-                    <p className={styles.optionsDescription}>{QuestionEdit('Please enter answer choices for the', { questionType })}</p>
+                    <p className={styles.optionsDescription}>{QuestionEdit('helpText.questionOptions', { questionType })}</p>
                     <QuestionOptionsComponent rows={rows} setRows={setRows} questionId={Number(questionId)} />
                   </div>
                 )}

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -1,12 +1,348 @@
-'use client';
+'use client'
 
-import QuestionEdit from '@/components/QuestionEdit';
+import { useEffect, useRef, useState } from 'react';
+import { ApolloError } from '@apollo/client';
+import { useParams, useRouter } from 'next/navigation';
+import {
+  Breadcrumb,
+  Breadcrumbs,
+  Button,
+  FieldError,
+  Form,
+  Input,
+  Label,
+  Link,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  Text,
+  TextArea,
+  TextField
+} from "react-aria-components";
 
-const QuestionEditPage: React.FC = () => {
+// GraphQL queries and mutations
+import {
+  useQuestionQuery,
+  useUpdateQuestionMutation,
+  useQuestionTypesQuery
+} from '@/generated/graphql';
+
+// Components
+import PageHeader from "@/components/PageHeader";
+import QuestionOptionsComponent from '@/components/Form/QuestionOptionsComponent';
+
+//Other
+import { useToast } from '@/context/ToastContext';
+import styles from './questionEdit.module.scss';
+
+
+
+// Sample data stub representing data fetched from a GraphQL server
+const sampleQuestion = {
+  id: 'q_mnopqr',
+  templateId: 't_abcdef', // Added template ID
+  type: 'Rich Text',
+  text: 'What types of data, samples, collections, software, materials, etc., will be produced during your project?',
+  requirements: 'Keep the question concise and clear. Use the requirements or guidance to provide additional explanation.',
+  guidance: 'Be concise\nExplain the data file format\nExplain the expected size\nExplain the blah blah blah blah blah blah blah',
+  sampleText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+};
+
+interface QuestionOptions {
+  id?: number | null;
+  text: string;
+  orderNumber: number;
+  isDefault?: boolean | null;
+  questionId: number;
+}
+interface Question {
+  id?: number | null;
+  displayOrder?: number | null;
+  questionText?: string | null;
+  requirementText?: string | null;
+  guidanceText?: string | null;
+  sampleText?: string | null;
+  required?: boolean;
+  questionOptions?: QuestionOptions[] | null;
+}
+
+const QuestionEdit = () => {
+  const params = useParams();
+  const router = useRouter();
+  const toastState = useToast(); // Access the toast state from context
+  const { templateId } = params; // From route /template/:templateId
+  const { q_slug } = params; //question id
+
+  //For scrolling to error in page
+  const errorRef = useRef<HTMLDivElement | null>(null);
+
+  // State for managing form inputs
+  const [question, setQuestion] = useState<Question | null>();
+  const [rows, setRows] = useState([{ id: 1, order: 1, text: "", isDefault: false }]);
+  const [questionType, setQuestionType] = useState<string>('');
+
+  const [errors, setErrors] = useState<string[]>([]);
+
+  // Initialize add and update question mutations
+  const [updateQuestionMutation] = useUpdateQuestionMutation();
+
+  // Run selected question query
+  const { data: selectedQuestion, loading, error: selectedQuestionQueryError } = useQuestionQuery(
+    {
+      variables: {
+        questionId: Number(q_slug)
+      },
+      skip: !q_slug // Skip query if q_slug/questionId is not provided
+    },
+  );
+
+  console.log("***quesgtion", selectedQuestion);
+
+  // Query for question types
+  const { data: questionTypes } = useQuestionTypesQuery({
+    skip: !q_slug
+  });
+
+  const getQuestionTypeName = (id: number) => {
+    if (questionTypes && questionTypes?.questionTypes) {
+      const questionType = questionTypes?.questionTypes?.find(qt => qt && qt.id === id);
+      return questionType ? questionType.name : null; // Return question type name if found, else null
+    }
+    return '';
+  };
+
+  const handleGuidanceChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setQuestion({ ...question, guidanceText: e.currentTarget.value });
+  };
+
+  const redirectToQuestionTypes = () => {
+    const sectionId = selectedQuestion?.question?.sectionId;
+    router.push(`/template/${templateId}/q/new?section_id=${sectionId}&step=1`)
+  }
+
+  const transformOptions = () => {
+    // If duplicate order numbers or text, do we want to give the user an error message?
+    const transformedRows = rows.map(option => {
+      return { text: option.text, orderNumber: option.order, isDefault: option.isDefault }
+    })
+
+    return transformedRows;
+  }
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const transformedQuestionOptions = transformOptions();
+    if (question) {
+      try {
+        // Add mutation for question
+        const response = await updateQuestionMutation({
+          variables: {
+            input: {
+              questionId: Number(q_slug),
+              displayOrder: question.displayOrder,
+              questionText: question.questionText,
+              requirementText: question.requirementText,
+              guidanceText: question.guidanceText,
+              sampleText: question.sampleText,
+              questionOptions: transformedQuestionOptions || selectedQuestion?.question?.questionOptions
+            }
+          },
+        });
+
+        if (response?.data) {
+          toastState.add('Question was successfully updated', { type: 'success' });
+        }
+      } catch (error) {
+        if (error instanceof ApolloError) {
+          //
+        } else {
+          // Handle other types of errors
+          setErrors(prevErrors => [...prevErrors, 'Error when updating profile']);
+        }
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (selectedQuestion) {
+      setQuestion(selectedQuestion?.question);
+      const qt = getQuestionTypeName(Number(selectedQuestion?.question?.questionTypeId))
+      if (qt) {
+        setQuestionType(qt);
+      }
+
+    }
+  }, [selectedQuestion])
+
+
   return (
-    /* We share this QuestionEdit form between adding a new question, or modifying an existing one*/
-    <QuestionEdit />
+    <>
+      <PageHeader
+        title={`Edit: ${selectedQuestion?.question?.questionText}`}
+        description=""
+        showBackButton={true}
+        breadcrumbs={
+          <Breadcrumbs>
+            <Breadcrumb><Link href="/">Home</Link></Breadcrumb>
+            <Breadcrumb><Link href={`/template/${templateId}`}>Edit Template</Link></Breadcrumb>
+            <Breadcrumb>Question</Breadcrumb>
+          </Breadcrumbs>
+        }
+        actions={null}
+        className=""
+      />
+
+      <div className="template-editor-container">
+        <div className="main-content">
+          {errors && errors.length > 0 &&
+            <div className="messages error" role="alert" aria-live="assertive" ref={errorRef}>
+              {errors.map((error, index) => (
+                <p key={index}>{error}</p>
+              ))}
+            </div>
+          }
+          <Tabs>
+            <TabList aria-label="Question editing">
+              <Tab id="edit">Edit Question</Tab>
+              <Tab id="options">Options</Tab>
+              <Tab id="logic">Logic</Tab>
+            </TabList>
+
+            <TabPanel id="edit">
+              <Form onSubmit={handleUpdate}>
+                <TextField
+                  name="type"
+                  type="text"
+                  className={`${styles.searchField} react-aria-TextField`}
+                  isRequired
+                >
+                  <Label className={`${styles.searchLabel} react-aria-Label`}>Type (required)</Label>
+                  <Input
+                    value={questionType}
+                    className={`${styles.searchInput} react-aria-Input`}
+                    disabled />
+                  <Button className={`${styles.searchButton} react-aria-Button`} type="button" onPress={redirectToQuestionTypes}>Change type</Button>
+                  <Text slot="description" className={`${styles.searchHelpText} help-text`}>
+                    Changing the question type, for example from Short question to Radio button, may result in some data being lost.
+                  </Text>
+                </TextField>
+
+                {/**Question type fields here */}
+                {selectedQuestion?.question?.questionTypeId && [3, 4, 5].includes(selectedQuestion?.question?.questionTypeId) && (
+                  <>
+                    <p className={styles.optionsDescription}>Please enter answer choices for the {questionType}</p>
+                    <QuestionOptionsComponent rows={rows} setRows={setRows} />
+                  </>
+                )}
+
+                <TextField
+                  name="question_text"
+                  type="text"
+                  isRequired
+                >
+                  <Label>Question text (required)</Label>
+                  <Input
+                    value={question?.questionText ? question.questionText : ''}
+                    onChange={(e) => setQuestion({
+                      ...question,
+                      questionText: e.currentTarget.value
+                    })}
+                  />
+                  <Text slot="description" className="help-text">
+                    Keep the question text concise and clear. Use the requirements or guidance to provide additional explanation.
+                  </Text>
+                  <FieldError />
+                </TextField>
+
+                <TextField
+                  name="question_requirements"
+                  isRequired
+                >
+                  <Label>Requirements plan writer must meet (optional but recommended)</Label>
+                  <Text slot="description" className="help-text">
+                    Try to be precise and concise, so the plan writers won't miss any requirements. Question guidance is better for more general advice.
+                  </Text>
+                  <TextArea
+                    value={question?.requirementText ? question.requirementText : ''}
+                    onChange={(e) => setQuestion({
+                      ...question,
+                      requirementText: e.currentTarget.value
+                    })}
+                    style={{ height: '100px' }}
+                  />
+                  <FieldError />
+                </TextField>
+
+                <TextField
+                  name="question_guidance"                >
+                  <Label>Question guidance (optional but recommended)</Label>
+                  <TextArea
+                    value={question?.guidanceText ? question.guidanceText : ''}
+                    onChange={handleGuidanceChange}
+                    style={{ height: '150px' }}
+                  />
+                  <FieldError />
+                </TextField>
+
+                <TextField
+                  name="sample_text"
+                >
+                  <Label>Sample text</Label>
+                  <Text slot="description" className="help-text">
+                    Provide an example or template of expected answer (optional
+                    but
+                    recommended)
+                  </Text>
+                  <TextArea
+                    value={question?.sampleText ? question?.sampleText : ''}
+                    onChange={(e) => setQuestion({
+                      ...question,
+                      sampleText: e.currentTarget.value
+                    })}
+                    style={{ height: '80px' }}
+                  />
+                  <FieldError />
+                  <Text slot="description" className="help-text">
+                    Plan creators will be able to copy the sample text into the field as a starting point, to speed up content entry.
+                  </Text>
+                </TextField>
+
+                <Button type="submit">Save</Button>
+
+              </Form>
+
+
+            </TabPanel>
+            <TabPanel id="options">
+              <h2>Options</h2>
+            </TabPanel>
+            <TabPanel id="logic">
+              <h2>logic</h2>
+            </TabPanel>
+          </Tabs>
+
+        </div >
+
+        <div className="sidebar">
+          <h2>Preview</h2>
+          <p>See how this question will look to users.</p>
+          <Button>Preview question</Button>
+
+          <h3>Best practice by DMP Tool</h3>
+          <p>Keep the question concise and clear. Use the requirements or
+            guidance
+            to provide additional explanation.</p>
+          <p>Outline the requirements that a user must consider for this
+            question.</p>
+          <p>Researchers will be able to copy the sample text into the field as
+            a
+            starting point, as a way to speed up content entry.</p>
+        </div>
+      </div >
+    </>
+
   );
 }
 
-export default QuestionEditPage;
+export default QuestionEdit;

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   Breadcrumb,
   Breadcrumbs,
   Button,
+  Checkbox,
   Form,
   Input,
   Label,
@@ -104,6 +105,7 @@ const QuestionEdit = () => {
               requirementText: question.requirementText,
               guidanceText: question.guidanceText,
               sampleText: question.sampleText,
+              useSampleTextAsDefault: question?.useSampleTextAsDefault || false,
               questionOptions: rows || selectedQuestion?.question?.questionOptions
             }
           },
@@ -284,6 +286,24 @@ const QuestionEdit = () => {
                     sampleText: e.currentTarget.value
                   })}
                 />
+
+                {selectedQuestion?.question?.questionTypeId && [1, 2].includes(selectedQuestion?.question?.questionTypeId) && (
+                  <Checkbox
+                    onChange={() => setQuestion({
+                      ...question,
+                      useSampleTextAsDefault: !question?.useSampleTextAsDefault
+                    })}
+                    isSelected={question?.useSampleTextAsDefault || false}
+                  >
+                    <div className="checkbox">
+                      <svg viewBox="0 0 18 18" aria-hidden="true">
+                        <polyline points="1 9 7 14 15 4" />
+                      </svg>
+                    </div>
+                    {QuestionEdit('descriptions.sampleTextAsDefault')}
+
+                  </Checkbox>
+                )}
 
                 <Button type="submit">{Global('buttons.save')}</Button>
 

--- a/app/[locale]/template/[templateId]/q/[q_slug]/questionEdit.module.scss
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/questionEdit.module.scss
@@ -32,3 +32,9 @@
   grid-area: help;
   width: fit-content;
 }
+
+.optionsWrapper {
+  border: 1px solid var(--border-color);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}

--- a/app/[locale]/template/[templateId]/q/[q_slug]/questionEdit.module.scss
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/questionEdit.module.scss
@@ -38,3 +38,7 @@
   padding: var(--space-4);
   margin-bottom: var(--space-4);
 }
+
+.questionFormField {
+  height: 100px
+}

--- a/app/[locale]/template/[templateId]/q/[q_slug]/questionEdit.module.scss
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/questionEdit.module.scss
@@ -1,0 +1,34 @@
+.optionsDescription {
+  font-size: var(--fs-sm);
+  font-weight:600;
+}
+
+.searchField {
+  display: grid;
+  grid-template-areas:
+  "label label"
+  "input button"
+  "help help";
+  grid-template-columns: 1fr auto;
+  max-width: 500px;
+}
+
+.searchLabel {
+  grid-area: label;
+}
+
+.searchInput {
+  grid-area: input;
+  
+}
+
+.searchButton {
+  grid-area: button;
+  margin-left: 10px;
+  width: fit-content;
+}
+
+.searchHelpText {
+  grid-area: help;
+  width: fit-content;
+}

--- a/app/[locale]/template/[templateId]/q/new/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/q/new/__tests__/page.spec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { act, fireEvent, render, screen } from '@/utils/test-utils';
 import { useQuestionTypesQuery } from '@/generated/graphql';
 import { axe, toHaveNoViolations } from 'jest-axe';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useQueryStep } from '@/app/[locale]/template/[templateId]/q/new/utils';
 import { useTranslations as OriginalUseTranslations } from 'next-intl';
 import QuestionTypeSelectPage from "../page";
@@ -16,12 +16,14 @@ jest.mock("@/generated/graphql", () => ({
 
 jest.mock('next/navigation', () => ({
   useParams: jest.fn(),
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn()
 }))
 
-jest.mock('@/components/QuestionEdit', () => {
+jest.mock('@/components/QuestionAdd', () => {
   return {
     __esModule: true,
-    default: () => <div>Mocked QuestionEdit</div>,
+    default: () => <div>Mocked QuestionAdd</div>,
   };
 });
 
@@ -63,6 +65,14 @@ jest.mock('next-intl', () => ({
   }),
 }));
 
+// Mock QuestionAdd component since it has it's own separate unit test
+jest.mock('@/components/QuestionAdd', () => {
+  return {
+    __esModule: true,
+    default: () => <div>Mocked Question Add Component</div>,
+  };
+});
+
 const mockQuestionTypes = {
   questionTypes: [
     {
@@ -87,6 +97,7 @@ const mockQuestionTypes = {
 }
 
 describe("QuestionTypeSelectPage", () => {
+  let pushMock: jest.Mock;
   beforeEach(() => {
     HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
     window.scrollTo = jest.fn(); // Called by the wrapping PageHeader
@@ -97,6 +108,27 @@ describe("QuestionTypeSelectPage", () => {
     // Mock the return value of useParams
     mockUseParams.mockReturnValue({ templateId: `${mockTemplateId}` });
     mockUseQueryStep.mockReturnValue(1);
+
+    pushMock = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push: pushMock });
+
+    (useSearchParams as jest.MockedFunction<typeof useSearchParams>).mockImplementation(() => {
+      return {
+        get: (key: string) => {
+          const params: Record<string, string> = { section_id: '123' };
+          return params[key] || null;
+        },
+        getAll: () => [],
+        has: (key: string) => key in { section_id: '123' },
+        keys: function* () { },
+        values: function* () { },
+        entries: function* () { },
+        forEach: () => { },
+        toString: () => '',
+      } as unknown as ReturnType<typeof useSearchParams>;
+    });
+
+
   });
 
   it("should render loading state", async () => {
@@ -169,7 +201,6 @@ describe("QuestionTypeSelectPage", () => {
       );
     });
 
-    screen.debug();
     // Searching for translation key since cannot run next-intl for unit tests
     const searchInput = screen.getByLabelText(/labels.searchByKeyword/i);
 
@@ -204,6 +235,33 @@ describe("QuestionTypeSelectPage", () => {
 
     expect(screen.getByText('There was an error.')).toBeInTheDocument();
 
+  })
+
+  it('should load QuestionAdd component when a user selects a question type', async () => {
+    (useQuestionTypesQuery as jest.Mock).mockReturnValue({
+      data: mockQuestionTypes,
+      loading: false,
+      error: null,
+    });
+
+    await act(async () => {
+      render(
+        <QuestionTypeSelectPage />
+      );
+    });
+
+    // Find a question type that has options, like a radio button
+    const buttons = screen.getAllByText('buttons.select');
+    const selectButton = buttons.find(button => button.getAttribute('data-type') === '3');
+    expect(selectButton).toBeInTheDocument();
+    if (selectButton) {
+      fireEvent.click(selectButton);
+    } else {
+      throw new Error('Select button not found');
+    }
+
+    // Should load the QuestionAdd component once a user selects a question type with options
+    expect(screen.getByText('Mocked Question Add Component')).toBeInTheDocument();
   })
 
   it('should pass axe accessibility test', async () => {

--- a/app/[locale]/template/[templateId]/q/new/page.tsx
+++ b/app/[locale]/template/[templateId]/q/new/page.tsx
@@ -1,8 +1,8 @@
-'use client';
+'use client'
 
 import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import {
     Breadcrumb,
     Breadcrumbs,
@@ -38,8 +38,11 @@ import styles from './newQuestion.module.scss';
 const QuestionTypeSelectPage: React.FC = () => {
     // Get templateId param
     const params = useParams();
+    const router = useRouter();
+    const searchParams = useSearchParams();
     const topRef = useRef<HTMLDivElement>(null);
     const { templateId } = params; // From route /template/:templateId
+    const sectionId = searchParams.get('section_id');
 
     // State management
     const [step, setStep] = useState<number | null>(null);
@@ -47,6 +50,7 @@ const QuestionTypeSelectPage: React.FC = () => {
     const [filteredQuestionTypes, setFilteredQuestionTypes] = useState<QuestionTypesInterface[] | null>([]);
     const [questionTypes, setQuestionTypes] = useState<QuestionTypesInterface[]>([]);
     const [searchButtonClicked, setSearchButtonClicked] = useState(false);
+    const [selectedQuestionType, setSelectedQuestionType] = useState<{ questionTypeId: number, questionTypeName: string }>();
     const [questionTypeId, setQuestionTypeId] = useState<number | null>(null);
     const [errors, setErrors] = useState<string[]>([]);
 
@@ -59,11 +63,12 @@ const QuestionTypeSelectPage: React.FC = () => {
     // Make graphql request for question types
     const { data, loading, error: queryError } = useQuestionTypesQuery();
 
-    const handleSelect = (questionTypeId: number) => {
+    const handleSelect = (questionTypeId: number, questionTypeName: string) => {
         // redirect to the Question Edit page
         if (questionTypeId) {
-            setQuestionTypeId(questionTypeId);
+            setSelectedQuestionType({ questionTypeId: questionTypeId, questionTypeName: questionTypeName })
             setStep(2);
+            router.push(`/template/${templateId}/q/new?section_id=${sectionId}&step=2`)
         }
     }
 
@@ -244,7 +249,11 @@ const QuestionTypeSelectPage: React.FC = () => {
             {step === 2 && (
                 <>
                     {/*Show Edit Question form*/}
-                    <QuestionEdit questionTypeId={questionTypeId ? questionTypeId : null} />
+                    <QuestionEdit
+                        questionTypeId={selectedQuestionType?.questionTypeId ?? null}
+                        questionTypeName={selectedQuestionType?.questionTypeName ?? null}
+                        sectionId={sectionId ? sectionId : ''}
+                    />
                 </>
             )}
         </>

--- a/app/[locale]/template/[templateId]/q/new/page.tsx
+++ b/app/[locale]/template/[templateId]/q/new/page.tsx
@@ -21,7 +21,7 @@ import {
     ContentContainer,
     LayoutContainer,
 } from '@/components/Container';
-import QuestionEdit from '@/components/QuestionEdit';
+import QuestionAdd from '@/components/QuestionAdd';
 import QuestionTypeCard from '@/components/QuestionTypeCard';
 
 //GraphQL
@@ -248,7 +248,7 @@ const QuestionTypeSelectPage: React.FC = () => {
             {step === 2 && (
                 <>
                     {/*Show Edit Question form*/}
-                    <QuestionEdit
+                    <QuestionAdd
                         questionTypeId={selectedQuestionType?.questionTypeId ?? null}
                         questionTypeName={selectedQuestionType?.questionTypeName ?? null}
                         sectionId={sectionId ? sectionId : ''}

--- a/app/[locale]/template/[templateId]/q/new/page.tsx
+++ b/app/[locale]/template/[templateId]/q/new/page.tsx
@@ -51,7 +51,6 @@ const QuestionTypeSelectPage: React.FC = () => {
     const [questionTypes, setQuestionTypes] = useState<QuestionTypesInterface[]>([]);
     const [searchButtonClicked, setSearchButtonClicked] = useState(false);
     const [selectedQuestionType, setSelectedQuestionType] = useState<{ questionTypeId: number, questionTypeName: string }>();
-    const [questionTypeId, setQuestionTypeId] = useState<number | null>(null);
     const [errors, setErrors] = useState<string[]>([]);
 
     const stepQueryValue = useQueryStep();

--- a/app/[locale]/template/[templateId]/q/new/page.tsx
+++ b/app/[locale]/template/[templateId]/q/new/page.tsx
@@ -43,6 +43,7 @@ const QuestionTypeSelectPage: React.FC = () => {
     const topRef = useRef<HTMLDivElement>(null);
     const { templateId } = params; // From route /template/:templateId
     const sectionId = searchParams.get('section_id');
+    const questionId = searchParams.get('questionId');// if user is switching their question type while editing an existing question
 
     // State management
     const [step, setStep] = useState<number | null>(null);
@@ -63,11 +64,16 @@ const QuestionTypeSelectPage: React.FC = () => {
     const { data, loading, error: queryError } = useQuestionTypesQuery();
 
     const handleSelect = (questionTypeId: number, questionTypeName: string) => {
-        // redirect to the Question Edit page
-        if (questionTypeId) {
-            setSelectedQuestionType({ questionTypeId: questionTypeId, questionTypeName: questionTypeName })
-            setStep(2);
-            router.push(`/template/${templateId}/q/new?section_id=${sectionId}&step=2`)
+        if (questionId) {
+            //If the user came from editing an existing question, we want to return them to that page with the new questionTypeId
+            router.push(`/template/${templateId}/q/${questionId}?questionTypeId=${questionTypeId}`)
+        } else {
+            // redirect to the Question Edit page if a user is adding a new question
+            if (questionTypeId) {
+                setSelectedQuestionType({ questionTypeId: questionTypeId, questionTypeName: questionTypeName })
+                setStep(2);
+                router.push(`/template/${templateId}/q/new?section_id=${sectionId}&step=2`)
+            }
         }
     }
 

--- a/app/[locale]/template/[templateId]/q/new/page.tsx
+++ b/app/[locale]/template/[templateId]/q/new/page.tsx
@@ -237,7 +237,7 @@ const QuestionTypeSelectPage: React.FC = () => {
                                 {/*Show # of results with clear filter link*/}
                                 {(searchTerm.length > 0 && searchButtonClicked) && (
                                     <div className={styles.clearFilter}>
-                                        <div className={styles.searchMatchText}> {Global('messaging.resultsText', { name: filteredQuestionTypes?.length })} - <Link onPress={resetSearch} href="/" className={styles.searchMatchText}>clear filter</Link></div>
+                                        <div className={styles.searchMatchText}> {Global('messaging.resultsText', { name: filteredQuestionTypes?.length })} - <Link onPress={resetSearch} href="/" className={styles.searchMatchText}>{QuestionTypeSelect('links.clearFilter')}</Link></div>
                                     </div>
                                 )}
                             </div>

--- a/app/[locale]/template/[templateId]/q/new/utils.tsx
+++ b/app/[locale]/template/[templateId]/q/new/utils.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useSearchParams } from 'next/navigation';
 
 export const useQueryStep = () => {

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -135,3 +135,22 @@ export interface QuestionTypesInterface {
   name: string;
   usageDescription: string;
 }
+
+export interface QuestionOptions {
+  id?: number | null;
+  text: string;
+  orderNumber: number;
+  isDefault?: boolean | null;
+  questionId: number;
+}
+
+export interface Question {
+  id?: number | null | undefined;
+  displayOrder?: number | null;
+  questionText?: string | null;
+  requirementText?: string | null;
+  guidanceText?: string | null;
+  sampleText?: string | null;
+  required?: boolean;
+  questionOptions?: QuestionOptions[] | null;
+}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -151,6 +151,7 @@ export interface Question {
   requirementText?: string | null;
   guidanceText?: string | null;
   sampleText?: string | null;
+  useSampleTextAsDefault?: boolean | null;
   required?: boolean;
   questionOptions?: QuestionOptions[] | null;
 }

--- a/components/Form/FormInput/index.tsx
+++ b/components/Form/FormInput/index.tsx
@@ -17,6 +17,10 @@ interface InputProps {
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   className?: string;
+  labelClasses?: string;
+  inputClasses?: string;
+  disabled?: boolean;
+  isRequired?: boolean;
   isInvalid?: boolean;
   errorMessage?: string;
   helpMessage?: string;
@@ -31,6 +35,10 @@ const FormInput: React.FC<InputProps> = ({
   value,
   onChange,
   className = '',
+  labelClasses = '',
+  inputClasses = '',
+  disabled = false,
+  isRequired = false,
   isInvalid = false,
   errorMessage = '',
   helpMessage = ''
@@ -42,16 +50,19 @@ const FormInput: React.FC<InputProps> = ({
         name={name}
         type={type}
         className={`${className} react-aria-TextField ${isInvalid ? 'field-error' : ''}`}
+        isRequired={isRequired}
         isInvalid={isInvalid}
         data-testid="field-wrapper"
       >
-        <Label>{label}</Label>
+        <Label className={labelClasses}>{label}</Label>
         <Input
           name={name}
           type={type}
+          className={inputClasses}
           placeholder={placeholder}
           onChange={onChange}
           value={value}
+          disabled={disabled}
           aria-describedby={ariaDescribedBy}
         />
 
@@ -62,7 +73,7 @@ const FormInput: React.FC<InputProps> = ({
             {helpMessage}
           </Text>
         )}
-
+        <FieldError />
       </TextField>
     </>
   );

--- a/components/Form/FormTextArea/__tests__/index.spec.tsx
+++ b/components/Form/FormTextArea/__tests__/index.spec.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FormTextArea from '@/components/Form/FormTextArea';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+describe('FormTextArea', () => {
+  it('should render the component correctly', () => {
+    render(
+      <FormTextArea
+        name="name"
+        label="Name"
+        placeholder="Enter your name"
+        value="John Doe"
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter your name')).toHaveValue('John Doe');
+  });
+
+  it('should handle invalid state correctly', () => {
+    render(
+      <FormTextArea
+        name="email"
+        label="Email"
+        isInvalid={true}
+        errorMessage="Please enter a valid email address"
+      />
+    );
+
+    const fieldWrapper = screen.getByTestId('field-wrapper');
+    expect(fieldWrapper).toHaveClass('field-error');
+    expect(screen.getByText('Please enter a valid email address')).toBeInTheDocument();
+  });
+
+
+  it('should call the onChange handler when the input value changes', () => {
+    const onChange = jest.fn();
+    render(
+      <FormTextArea
+        name="password"
+        label="Password"
+        onChange={onChange}
+      />
+    );
+
+    const input = screen.getByLabelText('Password');
+    fireEvent.change(input, { target: { value: 'password123' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render the help message if provided', () => {
+    render(
+      <FormTextArea
+        name="phone"
+        label="Phone"
+        helpMessage="Please enter your phone number in the format xxx-xxx-xxxx"
+      />
+    );
+
+    expect(screen.getByText('Please enter your phone number in the format xxx-xxx-xxxx')).toBeInTheDocument();
+  });
+
+  it('should pass axe accessibility test', async () => {
+    const { container } = render(
+      <FormTextArea
+        name="phone"
+        label="Phone"
+        helpMessage="Please enter your phone number in the format xxx-xxx-xxxx"
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  })
+});

--- a/components/Form/FormTextArea/index.tsx
+++ b/components/Form/FormTextArea/index.tsx
@@ -1,25 +1,24 @@
 import React from 'react';
 import {
   FieldError,
-  Input,
   Label,
   Text,
+  TextArea,
   TextField,
 } from "react-aria-components";
+import styles from './formInput.module.scss';
 
 interface InputProps {
   name: string;
-  id?: string;
-  type?: string;
   label: string;
+  description?: string;
   placeholder?: string;
   ariaDescribedBy?: string;
-  ariaLabel?: string;
-  value?: string | number;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   className?: string;
   labelClasses?: string;
-  inputClasses?: string;
+  textAreaClasses?: string;
   disabled?: boolean;
   isRequired?: boolean;
   isInvalid?: boolean;
@@ -27,19 +26,17 @@ interface InputProps {
   helpMessage?: string;
 }
 
-const FormInput: React.FC<InputProps> = ({
+const FormTextArea: React.FC<InputProps> = ({
   name,
-  id,
-  type,
   label,
+  description,
   placeholder,
   ariaDescribedBy,
-  ariaLabel,
   value,
   onChange,
   className = '',
   labelClasses = '',
-  inputClasses = '',
+  textAreaClasses = '',
   disabled = false,
   isRequired = false,
   isInvalid = false,
@@ -51,24 +48,23 @@ const FormInput: React.FC<InputProps> = ({
     <>
       <TextField
         name={name}
-        type={type}
         className={`${className} react-aria-TextField ${isInvalid ? 'field-error' : ''}`}
         isRequired={isRequired}
         isInvalid={isInvalid}
         data-testid="field-wrapper"
       >
-        <Label htmlFor={id} className={labelClasses}>{label}</Label>
-        <Input
-          id={id}
+        <Label className={labelClasses}>{label}</Label>
+        <Text slot="description" className="help-text">
+          {description}
+        </Text>
+        <TextArea
           name={name}
-          type={type}
-          className={inputClasses}
+          className={textAreaClasses}
           placeholder={placeholder}
           onChange={onChange}
           value={value}
           disabled={disabled}
           aria-describedby={ariaDescribedBy}
-          aria-label={ariaLabel}
         />
 
         {isInvalid && <FieldError className='error-message'>{errorMessage}</FieldError>}
@@ -84,4 +80,4 @@ const FormInput: React.FC<InputProps> = ({
   );
 };
 
-export default FormInput;
+export default FormTextArea;

--- a/components/Form/QuestionOptionsComponent/__tests__/index.spec.tsx
+++ b/components/Form/QuestionOptionsComponent/__tests__/index.spec.tsx
@@ -45,7 +45,7 @@ describe('QuestionOptionsComponent', () => {
   });
 
   it('should render initial rows correctly', () => {
-    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} />);
+    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} formSubmitted={true} setFormSubmitted={jest.fn()} />);
 
     expect(screen.getByLabelText('labels.order')).toBeInTheDocument();
     expect(screen.getByLabelText('labels.text')).toBeInTheDocument();
@@ -53,7 +53,7 @@ describe('QuestionOptionsComponent', () => {
   });
 
   it('should add a new row when the add button is clicked', () => {
-    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} />);
+    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} formSubmitted={true} setFormSubmitted={jest.fn()} />);
 
     const addButton = screen.getByRole('button', { name: /buttons.addRow/i });
     fireEvent.click(addButton);
@@ -62,7 +62,7 @@ describe('QuestionOptionsComponent', () => {
   });
 
   it('should update text field correctly', () => {
-    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} />);
+    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} formSubmitted={true} setFormSubmitted={jest.fn()} />);
 
     const textInput = screen.getByLabelText('labels.text');
     fireEvent.change(textInput, { target: { value: 'Updated Option' } });
@@ -71,7 +71,7 @@ describe('QuestionOptionsComponent', () => {
   });
 
   it('should set a row as default when checkbox is clicked', () => {
-    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} />);
+    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} formSubmitted={true} setFormSubmitted={jest.fn()} />);
 
     const defaultCheckbox = screen.getByLabelText('labels.default');
     fireEvent.click(defaultCheckbox);
@@ -80,7 +80,7 @@ describe('QuestionOptionsComponent', () => {
   });
 
   it('should remove a row when delete button is clicked', () => {
-    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} />);
+    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} formSubmitted={true} setFormSubmitted={jest.fn()} />);
 
     const deleteButton = screen.getByRole('button', { name: /buttons.deleteRow/i });
     fireEvent.click(deleteButton);

--- a/components/Form/QuestionOptionsComponent/__tests__/index.spec.tsx
+++ b/components/Form/QuestionOptionsComponent/__tests__/index.spec.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen, act, fireEvent } from '@/utils/test-utils';
+import { useTranslations as OriginalUseTranslations } from 'next-intl';
+import QuestionOptionsComponent from '@/components/Form/QuestionOptionsComponent';
+
+type UseTranslationsType = ReturnType<typeof OriginalUseTranslations>;
+
+// Mock useTranslations from next-intl
+jest.mock('next-intl', () => ({
+  useTranslations: jest.fn(() => {
+    const mockUseTranslations: UseTranslationsType = ((key: string) => key) as UseTranslationsType;
+
+    /*eslint-disable @typescript-eslint/no-explicit-any */
+    mockUseTranslations.rich = (
+      key: string,
+      values?: Record<string, any>
+    ) => {
+      // Handle rich text formatting
+      if (values?.p) {
+        return values.p(key); // Simulate rendering the `p` tag function
+      }
+      return key;
+    };
+
+    return mockUseTranslations;
+  }),
+}));
+
+type Row = {
+  id?: number | null;
+  orderNumber: number;
+  text: string;
+  isDefault?: boolean | null;
+  questionId: number;
+};
+
+describe('QuestionOptionsComponent', () => {
+  let rows: Row[], setRows: jest.Mock;
+
+  beforeEach(() => {
+    rows = [
+      { id: 1, orderNumber: 1, text: 'Option 1', isDefault: false, questionId: 123 },
+    ];
+    setRows = jest.fn();
+  });
+
+  it('should render initial rows correctly', () => {
+    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} />);
+
+    expect(screen.getByLabelText('labels.order')).toBeInTheDocument();
+    expect(screen.getByLabelText('labels.text')).toBeInTheDocument();
+    expect(screen.getByLabelText('labels.default')).toBeInTheDocument();
+  });
+
+  it('should add a new row when the add button is clicked', () => {
+    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} />);
+
+    const addButton = screen.getByRole('button', { name: /buttons.addRow/i });
+    fireEvent.click(addButton);
+
+    expect(setRows).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('should update text field correctly', () => {
+    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} />);
+
+    const textInput = screen.getByLabelText('labels.text');
+    fireEvent.change(textInput, { target: { value: 'Updated Option' } });
+
+    expect(setRows).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('should set a row as default when checkbox is clicked', () => {
+    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} />);
+
+    const defaultCheckbox = screen.getByLabelText('labels.default');
+    fireEvent.click(defaultCheckbox);
+
+    expect(setRows).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('should remove a row when delete button is clicked', () => {
+    render(<QuestionOptionsComponent rows={rows} setRows={setRows} questionId={123} />);
+
+    const deleteButton = screen.getByRole('button', { name: /buttons.deleteRow/i });
+    fireEvent.click(deleteButton);
+
+    expect(setRows).toHaveBeenCalledWith(expect.any(Function));
+  });
+});

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -105,8 +105,9 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
                 aria-checked={row.isDefault}
                 aria-label={`Set row ${index + 1} as default`}
                 onChange={() => setDefault(row.id)}
+                className={`${styles.optionsCheckbox} react-aria-Checkbox`}
               >
-                <div className="checkbox">
+                <div className={`${styles.checkBox} checkbox`}>
                   <svg viewBox="0 0 18 18" aria-hidden="true">
                     <polyline points="1 9 7 14 15 4" />
                   </svg>

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import {
   Checkbox,
 } from "react-aria-components";
+
+import { useTranslations } from 'next-intl';
 import styles from './optionsComponent.module.scss';
 
 
@@ -28,6 +30,9 @@ interface QuestionOptionsComponentProps {
 const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ rows, setRows, questionId }) => {
   const [announcement, setAnnouncement] = useState<string>("");
 
+  // localization keys
+  const Global = useTranslations('Global');
+  const QuestionOptions = useTranslations('QuestionOptions');
 
   // Add options row
   const addRow = () => {
@@ -91,7 +96,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
             </span>
 
             <div className={styles.cell}>
-              <label htmlFor={`order=${row.id}`}>Order</label>
+              <label htmlFor={`order=${row.id}`}>{QuestionOptions('labels.order')}</label>
               <input
                 type="text"
                 className={styles.orderNumber}
@@ -104,7 +109,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
               />
             </div>
             <div className={styles.cell}>
-              <label htmlFor={`text-${row.id}`}>Text (required)</label>
+              <label htmlFor={`text-${row.id}`}>{QuestionOptions('labels.text')}</label>
               <input
                 type="text"
                 className={styles.text}
@@ -117,7 +122,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
               />
             </div>
             <div className={`${styles.cell} ${styles.default}`}>
-              <label htmlFor={`default-${row.id}`}>Default</label>
+              <label htmlFor={`default-${row.id}`}>{QuestionOptions('labels.default')}</label>
               <Checkbox
                 id={`default-${row.id}`}
                 aria-checked={row.isDefault}
@@ -140,7 +145,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
                 aria-label={`Delete row ${index + 1}`}
                 className={`${styles.deleteButton} react-aria-Button secondary`}
               >
-                Remove
+                {Global('buttons.remove')}
               </button>
               {/**Screen readers will announce when a new row was added */}
               <p aria-live="polite" className='hidden-accessibly'>
@@ -153,7 +158,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
         )}
 
         <button type="button" onClick={addRow} aria-live="polite">
-          Add Row
+          {QuestionOptions('buttons.addRow')}
         </button>
       </div>
       {/** Hidden live region for screen readers */}

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -46,7 +46,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
 
       };
       setRows((prevRows) => [...prevRows, newRow]);
-      setAnnouncement(`Row ${newRow.orderNumber} added.`);
+      setAnnouncement(QuestionOptions('announcements.rowAdded', { orderNumber: newRow.orderNumber }));
     }
   };
 
@@ -54,7 +54,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
   const deleteRow = (id: number) => {
     if (id && id !== 0) {
       setRows((prevRows) => prevRows.filter(row => row.id !== id));
-      setAnnouncement(`Row with ID ${id} removed.`);
+      setAnnouncement(QuestionOptions('announcements.rowRemoved', { id: id }));
     }
   };
 
@@ -68,7 +68,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
           isDefault: row.id === id,
         }))
       );
-      setAnnouncement(`Row with ID ${id} set as default.`);
+      setAnnouncement(QuestionOptions('announcments.rowDefault', { id: id }));
     }
   };
 
@@ -92,11 +92,11 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
           <div key={row.id} className={styles.row} role="group">
             {/**Let screenreader know which row they are on */}
             <span id={`row-label-${row.id}`} className='hidden-accessibly'>
-              Row {index + 1}
+              {QuestionOptions('messages.rowInfo', { number: index + 1 })}
             </span>
 
             <div className={styles.cell}>
-              <label htmlFor={`order=${row.id}`}>{QuestionOptions('labels.order')}</label>
+              <label htmlFor={`order-${row.id}`}>{QuestionOptions('labels.order')}</label>
               <input
                 type="text"
                 className={styles.orderNumber}
@@ -142,14 +142,14 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
               <button
                 type="button"
                 onClick={() => deleteRow(row.id || 0)}
-                aria-label={`Delete row ${index + 1}`}
+                aria-label={QuestionOptions('buttons.deleteRow', { count: index + 1 })}
                 className={`${styles.deleteButton} react-aria-Button secondary`}
               >
                 {Global('buttons.remove')}
               </button>
               {/**Screen readers will announce when a new row was added */}
               <p aria-live="polite" className='hidden-accessibly'>
-                {rows.length > 0 ? `Row ${rows.length} added` : ""}
+                {rows.length > 0 ? QuestionOptions('messages.successAddingRow', { number: rows.length }) : ""}
               </p>
 
             </div>

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import styles from './optionsComponent.module.scss';
+import {
+  Checkbox,
+} from "react-aria-components";
+
+interface Row {
+  id: number;
+  order: number;
+  text: string;
+  isDefault: boolean;
+}
+
+interface QuestionOptionsComponentProps {
+  rows: Row[];
+  setRows: React.Dispatch<React.SetStateAction<Row[]>>;
+}
+
+
+/**This component is used to add question type fields that use options
+ * For example, radio buttons, check boxes and select drop-downs
+ */
+const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ rows, setRows }) => {
+
+  // Add options row
+  const addRow = () => {
+    const newRow = {
+      id: rows.length + 1,
+      order: rows.length + 1,
+      text: "",
+      isDefault: false,
+    };
+    setRows((prevRows) => [...prevRows, newRow]);
+  };
+
+  // Delete options row
+  const deleteRow = (id: number) => {
+    setRows((prevRows) => prevRows.filter(row => row.id !== id));
+  };
+
+
+  // Set one row as default (only one can be true)
+  const setDefault = (id: number) => {
+    setRows((prevRows) =>
+      prevRows.map((row) => ({
+        ...row,
+        isDefault: row.id === id,
+      }))
+    );
+  };
+
+  // Update rows state
+  const handleChange = (id: number, field: string, value: string) => {
+    setRows((prevRows) => {
+
+      // Update the specific field for the matching row
+      return prevRows.map((row) =>
+        row.id === id ? { ...row, [field]: value } : row
+      );
+    });
+  };
+
+  return (
+    <>
+      <div className={styles.tableContainer}>
+        {rows.map((row, index) => (
+
+          <div key={row.id} className={styles.row} role="group">
+            {/**Let screenreader know which row they are on */}
+            <span id={`row-label-${row.id}`} className='hidden-accessibly'>
+              Row {index + 1}
+            </span>
+
+            <div className={styles.cell}>
+              <label htmlFor={`order=${row.id}`}>Order</label>
+              <input
+                type="text"
+                className={styles.orderNumber}
+                id={`order-${row.id}`}
+                name="order"
+                value={row.order}
+                placeholder="Enter order #"
+                onChange={(e) => handleChange(row.id, "order", e.target.value)}
+                aria-label={index === 0 ? undefined : "Order"}
+              />
+            </div>
+            <div className={styles.cell}>
+              <label htmlFor={`text-${row.id}`}>Text (required)</label>
+              <input
+                type="text"
+                className={styles.text}
+                id={`text-${row.id}`}
+                name="text"
+                value={row.text}
+                placeholder="Enter text"
+                onChange={(e) => handleChange(row.id, "text", e.target.value)}
+                aria-label={index === 0 ? undefined : "Text"}
+              />
+            </div>
+            <div className={`${styles.cell} ${styles.default}`}>
+              <label htmlFor={`default-${row.id}`}>Default</label>
+              <Checkbox
+                id={`default-${row.id}`}
+                aria-checked={row.isDefault}
+                aria-label={`Set row ${index + 1} as default`}
+                onChange={() => setDefault(row.id)}
+              >
+                <div className="checkbox">
+                  <svg viewBox="0 0 18 18" aria-hidden="true">
+                    <polyline points="1 9 7 14 15 4" />
+                  </svg>
+                </div>
+              </Checkbox>
+            </div>
+            <div className={styles.remove}>
+              <button
+                type="button"
+                onClick={() => deleteRow(row.id)}
+                aria-label={`Delete row ${index + 1}`}
+                className={`${styles.deleteButton} react-aria-Button secondary`}
+              >
+                Remove
+              </button>
+              {/**Screen readers will announce when a new row was added */}
+              <p aria-live="polite" className='hidden-accessibly'>
+                {rows.length > 0 ? `Row ${rows.length} added` : ""}
+              </p>
+
+            </div>
+          </div >
+        )
+
+        )}
+
+        <button type="button" onClick={addRow} aria-live="polite">
+          Add Row
+        </button>
+      </div>
+    </>
+  );
+}
+
+export default QuestionOptionsComponent;

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -60,9 +60,10 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
   };
 
   // Update rows state
-  const handleChange = (id: number, field: string, value: string) => {
+  const handleChange = (id: number, field: string, value: string | number) => {
     if (id && id !== 0) {
       setRows((prevRows) => {
+
         // Update the specific field for the matching row
         return prevRows.map((row) =>
           row.id === id ? { ...row, [field]: value } : row
@@ -87,10 +88,10 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
                 type="text"
                 className={styles.orderNumber}
                 id={`order-${row.id}`}
-                name="order"
+                name="orderNumber"
                 value={row.orderNumber}
                 placeholder="Enter order #"
-                onChange={(e) => handleChange(row.id || 0, "order", e.target.value)}
+                onChange={(e) => handleChange(row.id || 0, "orderNumber", Number(e.target.value) || 0)}
                 aria-label={index === 0 ? undefined : "Order"}
               />
             </div>

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -32,7 +32,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
 
   // localization keys
   const Global = useTranslations('Global');
-  const QuestionOptions = useTranslations('QuestionOptions');
+  const QuestionOptions = useTranslations('QuestionOptionsComponent');
 
   // Add options row
   const addRow = () => {

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -22,13 +22,14 @@ interface QuestionOptionsComponentProps {
   rows: Row[] | null;
   setRows: React.Dispatch<React.SetStateAction<Row[]>>;
   questionId?: number;
+  formSubmitted?: boolean;
 }
 
 
 /**This component is used to add question type fields that use options
  * For example, radio buttons, check boxes and select drop-downs
  */
-const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ rows, setRows, questionId }) => {
+const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ rows, setRows, questionId, formSubmitted }) => {
   const [announcement, setAnnouncement] = useState<string>("");
 
   // localization keys
@@ -116,10 +117,13 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
                 type="text"
                 isRequired={true}
                 label={QuestionOptions('labels.text')}
+                labelClasses={styles.textFieldLabel}
                 value={row.text}
                 onChange={(e) => handleChange(row.id || '', "text", e.target.value)}
                 placeholder={QuestionOptions('placeholder.text')}
                 ariaLabel={index === 0 ? undefined : "Text"}
+                isInvalid={!row.text && formSubmitted}
+                errorMessage="Text field is required"
               />
             </div>
             <div className={`${styles.cell} ${styles.default}`}>

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -5,13 +5,14 @@ import {
   Checkbox,
 } from "react-aria-components";
 
+import FormInput from '@/components/Form/FormInput';
 import { useTranslations } from 'next-intl';
 import styles from './optionsComponent.module.scss';
 
 
 interface Row {
   id?: number | null;
-  orderNumber: number;
+  orderNumber: number | string;
   text: string;
   isDefault?: boolean | null;
   questionId: number;
@@ -73,13 +74,13 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
   };
 
   // Update rows state
-  const handleChange = (id: number, field: string, value: string | number) => {
-    if (id && id !== 0) {
+  const handleChange = (id: number | string, field: string, value: string | number) => {
+    if (id && Number(id) !== 0) {
       setRows((prevRows) => {
 
         // Update the specific field for the matching row
         return prevRows.map((row) =>
-          row.id === id ? { ...row, [field]: value } : row
+          row.id === Number(id) ? { ...row, [field]: value } : row
         );
       });
     }
@@ -96,29 +97,29 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
             </span>
 
             <div className={styles.cell}>
-              <label htmlFor={`order-${row.id}`}>{QuestionOptions('labels.order')}</label>
-              <input
-                type="text"
-                className={styles.orderNumber}
+              <FormInput
                 id={`order-${row.id}`}
                 name="orderNumber"
+                type="text"
+                isRequired={true}
+                label={QuestionOptions('labels.order')}
                 value={row.orderNumber}
-                placeholder="Enter order #"
-                onChange={(e) => handleChange(row.id || 0, "orderNumber", Number(e.target.value) || 0)}
-                aria-label={index === 0 ? undefined : "Order"}
+                onChange={(e) => handleChange(row.id || '', "orderNumber", Number(e.target.value) || '')}
+                placeholder={QuestionOptions('placeholder.orderNumber')}
+                ariaLabel={index === 0 ? undefined : "Order"}
               />
             </div>
             <div className={styles.cell}>
-              <label htmlFor={`text-${row.id}`}>{QuestionOptions('labels.text')}</label>
-              <input
-                type="text"
-                className={styles.text}
+              <FormInput
                 id={`text-${row.id}`}
                 name="text"
+                type="text"
+                isRequired={true}
+                label={QuestionOptions('labels.text')}
                 value={row.text}
-                placeholder="Enter text"
-                onChange={(e) => handleChange(row.id || 0, "text", e.target.value)}
-                aria-label={index === 0 ? undefined : "Text"}
+                onChange={(e) => handleChange(row.id || '', "text", e.target.value)}
+                placeholder={QuestionOptions('placeholder.text')}
+                ariaLabel={index === 0 ? undefined : "Text"}
               />
             </div>
             <div className={`${styles.cell} ${styles.default}`}>

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -6,14 +6,15 @@ import {
 } from "react-aria-components";
 
 interface Row {
-  id: number;
-  order: number;
+  id?: number | null;
+  orderNumber: number;
   text: string;
-  isDefault: boolean;
+  isDefault?: boolean | null;
+  questionId: number;
 }
 
 interface QuestionOptionsComponentProps {
-  rows: Row[];
+  rows: Row[] | null;
   setRows: React.Dispatch<React.SetStateAction<Row[]>>;
 }
 
@@ -25,47 +26,55 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
 
   // Add options row
   const addRow = () => {
-    const newRow = {
-      id: rows.length + 1,
-      order: rows.length + 1,
-      text: "",
-      isDefault: false,
-    };
-    setRows((prevRows) => [...prevRows, newRow]);
+    if (rows) {
+      const newRow = {
+        id: rows.length + 1,
+        orderNumber: rows.length + 1,
+        text: "",
+        isDefault: false,
+        questionId: 0,
+
+      };
+      setRows((prevRows) => [...prevRows, newRow]);
+    }
   };
 
   // Delete options row
   const deleteRow = (id: number) => {
-    setRows((prevRows) => prevRows.filter(row => row.id !== id));
+    if (id && id !== 0) {
+      setRows((prevRows) => prevRows.filter(row => row.id !== id));
+    }
   };
 
 
   // Set one row as default (only one can be true)
   const setDefault = (id: number) => {
-    setRows((prevRows) =>
-      prevRows.map((row) => ({
-        ...row,
-        isDefault: row.id === id,
-      }))
-    );
+    if (id && id !== 0) {
+      setRows((prevRows) =>
+        prevRows.map((row) => ({
+          ...row,
+          isDefault: row.id === id,
+        }))
+      );
+    }
   };
 
   // Update rows state
   const handleChange = (id: number, field: string, value: string) => {
-    setRows((prevRows) => {
-
-      // Update the specific field for the matching row
-      return prevRows.map((row) =>
-        row.id === id ? { ...row, [field]: value } : row
-      );
-    });
+    if (id && id !== 0) {
+      setRows((prevRows) => {
+        // Update the specific field for the matching row
+        return prevRows.map((row) =>
+          row.id === id ? { ...row, [field]: value } : row
+        );
+      });
+    }
   };
 
   return (
     <>
       <div className={styles.tableContainer}>
-        {rows.map((row, index) => (
-
+        {rows && rows.map((row, index) => (
           <div key={row.id} className={styles.row} role="group">
             {/**Let screenreader know which row they are on */}
             <span id={`row-label-${row.id}`} className='hidden-accessibly'>
@@ -79,9 +88,9 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
                 className={styles.orderNumber}
                 id={`order-${row.id}`}
                 name="order"
-                value={row.order}
+                value={row.orderNumber}
                 placeholder="Enter order #"
-                onChange={(e) => handleChange(row.id, "order", e.target.value)}
+                onChange={(e) => handleChange(row.id || 0, "order", e.target.value)}
                 aria-label={index === 0 ? undefined : "Order"}
               />
             </div>
@@ -94,7 +103,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
                 name="text"
                 value={row.text}
                 placeholder="Enter text"
-                onChange={(e) => handleChange(row.id, "text", e.target.value)}
+                onChange={(e) => handleChange(row.id || 0, "text", e.target.value)}
                 aria-label={index === 0 ? undefined : "Text"}
               />
             </div>
@@ -104,8 +113,9 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
                 id={`default-${row.id}`}
                 aria-checked={row.isDefault}
                 aria-label={`Set row ${index + 1} as default`}
-                onChange={() => setDefault(row.id)}
+                onChange={() => setDefault(row.id || 0)}
                 className={`${styles.optionsCheckbox} react-aria-Checkbox`}
+                isSelected={row.isDefault ? row.isDefault : false}
               >
                 <div className={`${styles.checkBox} checkbox`}>
                   <svg viewBox="0 0 18 18" aria-hidden="true">
@@ -117,7 +127,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
             <div className={styles.remove}>
               <button
                 type="button"
-                onClick={() => deleteRow(row.id)}
+                onClick={() => deleteRow(row.id || 0)}
                 aria-label={`Delete row ${index + 1}`}
                 className={`${styles.deleteButton} react-aria-Button secondary`}
               >

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -23,13 +23,14 @@ interface QuestionOptionsComponentProps {
   setRows: React.Dispatch<React.SetStateAction<Row[]>>;
   questionId?: number;
   formSubmitted?: boolean;
+  setFormSubmitted: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 
 /**This component is used to add question type fields that use options
  * For example, radio buttons, check boxes and select drop-downs
  */
-const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ rows, setRows, questionId, formSubmitted }) => {
+const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ rows, setRows, questionId, formSubmitted, setFormSubmitted }) => {
   const [announcement, setAnnouncement] = useState<string>("");
 
   // localization keys
@@ -49,6 +50,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
       };
       setRows((prevRows) => [...prevRows, newRow]);
       setAnnouncement(QuestionOptions('announcements.rowAdded', { orderNumber: newRow.orderNumber }));
+      setFormSubmitted(false);
     }
   };
 

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -40,9 +40,13 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
   // Add options row
   const addRow = () => {
     if (rows) {
+      // Either calculate next order number off of last orderNumber, if present, or just use the row.length to increment
+      const length = rows.length - 1;
+      const nextNum = rows[length] ? (rows[length].orderNumber + 1) : (length + 1)
+
       const newRow = {
-        id: rows.length + 1,
-        orderNumber: rows.length + 1,
+        id: nextNum, //if rows already has a set value, then increment from there
+        orderNumber: nextNum, //if rows already has a set value, then increment from there
         text: "",
         isDefault: false,
         questionId: questionId || 0 //If there is no questionId, then it won't update the question when set to 0

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -12,7 +12,7 @@ import styles from './optionsComponent.module.scss';
 
 interface Row {
   id?: number | null;
-  orderNumber: number | string;
+  orderNumber: number;
   text: string;
   isDefault?: boolean | null;
   questionId: number;
@@ -69,7 +69,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
           isDefault: row.id === id,
         }))
       );
-      setAnnouncement(QuestionOptions('announcments.rowDefault', { id: id }));
+      setAnnouncement(QuestionOptions('announcements.rowDefault', { id: id }));
     }
   };
 
@@ -101,10 +101,10 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
                 id={`order-${row.id}`}
                 name="orderNumber"
                 type="text"
+                disabled={true}
                 isRequired={true}
                 label={QuestionOptions('labels.order')}
                 value={row.orderNumber}
-                onChange={(e) => handleChange(row.id || '', "orderNumber", Number(e.target.value) || '')}
                 placeholder={QuestionOptions('placeholder.orderNumber')}
                 ariaLabel={index === 0 ? undefined : "Order"}
               />

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import styles from './optionsComponent.module.scss';
+import { useState } from "react";
 import {
   Checkbox,
 } from "react-aria-components";
+import styles from './optionsComponent.module.scss';
+
 
 interface Row {
   id?: number | null;
@@ -16,13 +18,16 @@ interface Row {
 interface QuestionOptionsComponentProps {
   rows: Row[] | null;
   setRows: React.Dispatch<React.SetStateAction<Row[]>>;
+  questionId?: number;
 }
 
 
 /**This component is used to add question type fields that use options
  * For example, radio buttons, check boxes and select drop-downs
  */
-const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ rows, setRows }) => {
+const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ rows, setRows, questionId }) => {
+  const [announcement, setAnnouncement] = useState<string>("");
+
 
   // Add options row
   const addRow = () => {
@@ -32,10 +37,11 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
         orderNumber: rows.length + 1,
         text: "",
         isDefault: false,
-        questionId: 0,
+        questionId: questionId || 0 //If there is no questionId, then it won't update the question when set to 0
 
       };
       setRows((prevRows) => [...prevRows, newRow]);
+      setAnnouncement(`Row ${newRow.orderNumber} added.`);
     }
   };
 
@@ -43,6 +49,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
   const deleteRow = (id: number) => {
     if (id && id !== 0) {
       setRows((prevRows) => prevRows.filter(row => row.id !== id));
+      setAnnouncement(`Row with ID ${id} removed.`);
     }
   };
 
@@ -56,6 +63,7 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
           isDefault: row.id === id,
         }))
       );
+      setAnnouncement(`Row with ID ${id} set as default.`);
     }
   };
 
@@ -142,13 +150,17 @@ const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ row
             </div>
           </div >
         )
-
         )}
 
         <button type="button" onClick={addRow} aria-live="polite">
           Add Row
         </button>
       </div>
+      {/** Hidden live region for screen readers */}
+      <p aria-live="polite" className="hidden-accessibly">
+        {announcement}
+      </p>
+
     </>
   );
 }

--- a/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
+++ b/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
@@ -17,6 +17,7 @@
   font-weight: 700;
   font-size:medium;
 }
+
 .row {
   display: flex;
   flex-wrap: wrap;
@@ -38,11 +39,6 @@
 
 .orderNumber {
   max-width: 30px;
-}
-
-.deleteButton,
-.react-aria-Button {
-
 }
 
 .dmpIcon {
@@ -69,4 +65,8 @@
   .checkBox {
     margin-top: 10px;
   }
+}
+
+.textFieldLabel {
+  white-space: nowrap;
 }

--- a/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
+++ b/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
@@ -1,0 +1,71 @@
+.optionsRow {
+  display: flex;
+  flex-direction: row;
+
+  .orderNumber {
+    max-width: 100px;
+  }
+}
+
+.formRow {
+  display: flex;
+  flex-direction: row;
+
+}
+
+.tableContainer {
+  // display: flex;
+  // flex-direction: column;
+  // flex-wrap: wrap; // Allow rows to wrap
+  margin-bottom: 2rem;
+}
+
+.tableHeader {
+  font-weight: 700;
+  font-size:medium;
+}
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.cell {
+  padding: 10px;
+  flex: 1;
+}
+
+.cellData {
+  border: 1px solid #ccc;
+}
+
+.text {
+  min-width: 200px;
+}
+
+.orderNumber {
+  max-width: 30px;
+}
+
+.deleteButton,
+.react-aria-Button {
+
+}
+
+.dmpIcon {
+  fill: black;
+}
+
+.dmpIcon:hover {
+  fill: red;
+}
+
+.remove {
+  display:flex;
+  align-items: center;
+  padding-top: 0.75rem;
+}
+
+.default {
+  margin-left: 20px;
+}

--- a/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
+++ b/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
@@ -13,13 +13,6 @@
 
 }
 
-.tableContainer {
-  // display: flex;
-  // flex-direction: column;
-  // flex-wrap: wrap; // Allow rows to wrap
-  margin-bottom: 2rem;
-}
-
 .tableHeader {
   font-weight: 700;
   font-size:medium;

--- a/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
+++ b/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
@@ -7,6 +7,10 @@
   }
 }
 
+.deleteButton {
+  margin-bottom: 1rem;
+}
+
 .formRow {
   display: flex;
   flex-direction: row;

--- a/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
+++ b/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
@@ -69,3 +69,11 @@
 .default {
   margin-left: 20px;
 }
+
+.optionsCheckbox {
+  margin-bottom: 0;
+
+  .checkBox {
+    margin-top: 10px;
+  }
+}

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -211,6 +211,40 @@ describe("QuestionAdd", () => {
     });
   })
 
+  it('should not display the useSampleTextAsDefault checkbox if the questionTypeId is Radio Button field', async () => {
+    (useAddQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+    const { container } = render(
+      <QuestionAdd
+        questionTypeId={3}
+        questionTypeName="Radio buttons"
+      />
+    );
+
+    const checkboxText = screen.queryByText('descriptions.sampleTextAsDefault');
+    expect(checkboxText).not.toBeInTheDocument();
+  })
+
+  it('should display the useSampleTextAsDefault checkbox if the questionTypeId is a Text field', async () => {
+    (useAddQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+    const { container } = render(
+      <QuestionAdd
+        questionTypeId={1}
+        questionTypeName="Radio buttons"
+      />
+    );
+
+    const checkboxText = screen.queryByText('descriptions.sampleTextAsDefault');
+    expect(checkboxText).toBeInTheDocument();
+  })
+
   it('should pass axe accessibility test', async () => {
     (useAddQuestionMutation as jest.Mock).mockReturnValue([
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -38,6 +38,13 @@ import { useToast } from '@/context/ToastContext';
 import styles from './questionAdd.module.scss';
 
 
+interface QuestionOptions {
+  id?: number | null;
+  text: string;
+  orderNumber: number;
+  isDefault?: boolean | null;
+  questionId: number;
+}
 
 // Sample data stub representing data fetched from a GraphQL server
 const sampleQuestion = {
@@ -71,7 +78,7 @@ const QuestionAdd = ({
 
   // State for managing form inputs
   const [question, setQuestion] = useState(sampleQuestion);
-  const [rows, setRows] = useState([{ id: 1, order: 1, text: "", isDefault: false }]);
+  const [rows, setRows] = useState<QuestionOptions[]>([{ id: 1, orderNumber: 1, text: "", isDefault: false, questionId: 0, }]);
   const [errors, setErrors] = useState<string[]>([]);
 
   // Initialize add and update question mutations
@@ -97,7 +104,7 @@ const QuestionAdd = ({
   const transformOptions = () => {
     // If duplicate order numbers or text, do we want to give the user an error message?
     const transformedRows = rows.map(option => {
-      return { text: option.text, orderNumber: option.order, isDefault: option.isDefault }
+      return { text: option.text, orderNumber: option.orderNumber, isDefault: option.isDefault }
     })
 
     return transformedRows;

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -205,7 +205,7 @@ const QuestionAdd = ({
                 {/**Question type fields here */}
                 {questionTypeId && [3, 4, 5].includes(questionTypeId) && (
                   <div className={styles.optionsWrapper}>
-                    <p className={styles.optionsDescription}>{QuestionAdd('Please enter answer choices for the', { questionTypeName })}</p>
+                    <p className={styles.optionsDescription}>{QuestionAdd('helpText.questionOptions', { questionTypeName })}</p>
                     <QuestionOptionsComponent rows={rows} setRows={setRows} />
                   </div>
                 )}

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -225,10 +225,10 @@ const QuestionAdd = ({
 
                 {/**Question type fields here */}
                 {questionTypeId && [3, 4, 5].includes(questionTypeId) && (
-                  <>
+                  <div className={styles.optionsWrapper}>
                     <p className={styles.optionsDescription}>Please enter answer choices for the {questionTypeName}</p>
                     <QuestionOptionsComponent rows={rows} setRows={setRows} />
-                  </>
+                  </div>
                 )}
 
                 <TextField

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -31,6 +31,7 @@ import {
 // Components
 import PageHeader from "@/components/PageHeader";
 import QuestionOptionsComponent from '@/components/Form/QuestionOptionsComponent';
+import FormInput from '@/components/Form/FormInput';
 
 //Other
 import { useToast } from '@/context/ToastContext';
@@ -127,14 +128,14 @@ const QuestionAdd = ({
       });
 
       if (response?.data) {
-        toastState.add('Question was successfully added', { type: 'success' });
+        toastState.add(QuestionAdd('messages.success.questionAdded'), { type: 'success' });
       }
     } catch (error) {
       if (error instanceof ApolloError) {
         //
       } else {
         // Handle other types of errors
-        setErrors(prevErrors => [...prevErrors, 'Error when updating profile']);
+        setErrors(prevErrors => [...prevErrors, QuestionAdd('messages.errors.questionAddingError')]);
       }
     }
 
@@ -143,7 +144,7 @@ const QuestionAdd = ({
   useEffect(() => {
     if (!questionTypeId) {
       // If questionTypeId is missing, return user to the Question Types selection page
-      toastState.add('Something went wrong. Please try again.', { type: 'error' });
+      toastState.add(Global('messaging.somethingWentWrong'), { type: 'error' });
       router.push(step1Url);
 
       // If the sectionId is missing, return user back to the Edit Template page
@@ -155,7 +156,7 @@ const QuestionAdd = ({
   return (
     <>
       <PageHeader
-        title={"Add New Question"}
+        title={QuestionAdd('title')}
         description=""
         showBackButton={true}
         breadcrumbs={
@@ -203,31 +204,28 @@ const QuestionAdd = ({
                 </TextField>
 
                 {/**Question type fields here */}
+                <p className={styles.optionsDescription}>{QuestionAdd('helpText.questionOptions', { questionTypeName })}</p>
+
                 {questionTypeId && [3, 4, 5].includes(questionTypeId) && (
                   <div className={styles.optionsWrapper}>
-                    <p className={styles.optionsDescription}>{QuestionAdd('helpText.questionOptions', { questionTypeName })}</p>
                     <QuestionOptionsComponent rows={rows} setRows={setRows} />
                   </div>
                 )}
 
-                <TextField
+                <FormInput
                   name="question_text"
                   type="text"
-                  isRequired
-                >
-                  <Label>{QuestionAdd('labels.questionText')}</Label>
-                  <Input
-                    value={question?.questionText ? question.questionText : ''}
-                    onChange={(e) => setQuestion({
-                      ...question,
-                      questionText: e.currentTarget.value
-                    })}
-                  />
-                  <Text slot="description" className="help-text">
-                    {QuestionAdd('helpText.questionText')}
-                  </Text>
-                  <FieldError />
-                </TextField>
+                  isRequired={true}
+                  label={QuestionAdd('labels.questionText')}
+                  value={question?.questionText ? question.questionText : ''}
+                  onChange={(e) => setQuestion({
+                    ...question,
+                    questionText: e.currentTarget.value
+                  })}
+                  helpMessage={QuestionAdd('helpText.questionText')}
+                  isInvalid={!question?.questionText}
+                  errorMessage={QuestionAdd('messages.errors.questionTextRequired')}
+                />
 
                 <TextField
                   name="question_requirements"
@@ -298,19 +296,14 @@ const QuestionAdd = ({
         </div >
 
         <div className="sidebar">
-          <h2>Preview</h2>
-          <p>See how this question will look to users.</p>
-          <Button>Preview question</Button>
+          <h2>{Global('headings.preview')}</h2>
+          <p>{QuestionAdd('descriptions.previewText')}</p>
+          <Button>{QuestionAdd('buttons.previewQuestion')}</Button>
 
-          <h3>Best practice by DMP Tool</h3>
-          <p>Keep the question concise and clear. Use the requirements or
-            guidance
-            to provide additional explanation.</p>
-          <p>Outline the requirements that a user must consider for this
-            question.</p>
-          <p>Researchers will be able to copy the sample text into the field as
-            a
-            starting point, as a way to speed up content entry.</p>
+          <h3>{QuestionAdd('headings.bestPractice')}</h3>
+          <p>{QuestionAdd('descriptions.bestPracticePara1')}</p>
+          <p>{QuestionAdd('descriptions.bestPracticePara2')}</p>
+          <p>{QuestionAdd('descriptions.bestPracticePara3')}</p>
         </div>
       </div >
     </>

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -143,6 +143,9 @@ const QuestionAdd = ({
 
       if (response?.data) {
         toastState.add(QuestionAdd('messages.success.questionAdded'), { type: 'success' });
+        //redirect user to the Edit Question view with their new question id after successfully adding the new question
+        const newQuestionId = response.data.addQuestion.id;
+        router.push(`/template/${templateId}/q/${newQuestionId}`)
       }
     } catch (error) {
       if (!(error instanceof ApolloError)) {

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -221,7 +221,7 @@ const QuestionAdd = ({
 
                 {questionTypeId && [3, 4, 5].includes(questionTypeId) && (
                   <div className={styles.optionsWrapper}>
-                    <QuestionOptionsComponent rows={rows} setRows={setRows} formSubmitted={formSubmitted} />
+                    <QuestionOptionsComponent rows={rows} setRows={setRows} formSubmitted={formSubmitted} setFormSubmitted={setFormSubmitted} />
                   </div>
                 )}
 

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { ApolloError } from '@apollo/client';
 import { useParams, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import {
   Breadcrumb,
   Breadcrumbs,
@@ -58,6 +59,10 @@ const QuestionAdd = ({
   const [question, setQuestion] = useState<Question>();
   const [rows, setRows] = useState<QuestionOptions[]>([{ id: 1, orderNumber: 1, text: "", isDefault: false, questionId: 0, }]);
   const [errors, setErrors] = useState<string[]>([]);
+
+  // localization keys
+  const Global = useTranslations('Global');
+  const QuestionAdd = useTranslations('QuestionAdd');
 
   // Initialize add and update question mutations
   const [addQuestionMutation] = useAddQuestionMutation();
@@ -155,9 +160,9 @@ const QuestionAdd = ({
         showBackButton={true}
         breadcrumbs={
           <Breadcrumbs>
-            <Breadcrumb><Link href="/">Home</Link></Breadcrumb>
-            <Breadcrumb><Link href={`/template/${templateId}`}>Edit Template</Link></Breadcrumb>
-            <Breadcrumb>Question</Breadcrumb>
+            <Breadcrumb><Link href="/">{Global('breadcrumbs.home')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={`/template/${templateId}`}>{Global('breadcrumbs.editTemplate')}</Link></Breadcrumb>
+            <Breadcrumb>{Global('breadcrumbs.question')}</Breadcrumb>
           </Breadcrumbs>
         }
         actions={null}
@@ -175,9 +180,9 @@ const QuestionAdd = ({
           }
           <Tabs>
             <TabList aria-label="Question editing">
-              <Tab id="edit">Edit Question</Tab>
-              <Tab id="options">Options</Tab>
-              <Tab id="logic">Logic</Tab>
+              <Tab id="edit">{Global('tabs.editQuestion')}</Tab>
+              <Tab id="options">{Global('tabs.options')}</Tab>
+              <Tab id="logic">{Global('tabs.logic')}</Tab>
             </TabList>
 
             <TabPanel id="edit">
@@ -189,18 +194,18 @@ const QuestionAdd = ({
                   isRequired
                   value={questionTypeName ? questionTypeName : ''}
                 >
-                  <Label className={`${styles.searchLabel} react-aria-Label`}>Type (required)</Label>
+                  <Label className={`${styles.searchLabel} react-aria-Label`}>{QuestionAdd('labels.type')}</Label>
                   <Input className={`${styles.searchInput} react-aria-Input`} disabled />
                   <Button className={`${styles.searchButton} react-aria-Button`} type="button" onPress={redirectToQuestionTypes}>Change type</Button>
                   <Text slot="description" className={`${styles.searchHelpText} help-text`}>
-                    Changing the question type, for example from Short question to Radio button, may result in some data being lost.
+                    {QuestionAdd('helpText.textField')}
                   </Text>
                 </TextField>
 
                 {/**Question type fields here */}
                 {questionTypeId && [3, 4, 5].includes(questionTypeId) && (
                   <div className={styles.optionsWrapper}>
-                    <p className={styles.optionsDescription}>Please enter answer choices for the {questionTypeName}</p>
+                    <p className={styles.optionsDescription}>{QuestionAdd('Please enter answer choices for the', { questionTypeName })}</p>
                     <QuestionOptionsComponent rows={rows} setRows={setRows} />
                   </div>
                 )}
@@ -210,7 +215,7 @@ const QuestionAdd = ({
                   type="text"
                   isRequired
                 >
-                  <Label>Question text (required)</Label>
+                  <Label>{QuestionAdd('labels.questionText')}</Label>
                   <Input
                     value={question?.questionText ? question.questionText : ''}
                     onChange={(e) => setQuestion({
@@ -219,7 +224,7 @@ const QuestionAdd = ({
                     })}
                   />
                   <Text slot="description" className="help-text">
-                    Keep the question text concise and clear. Use the requirements or guidance to provide additional explanation.
+                    {QuestionAdd('helpText.questionText')}
                   </Text>
                   <FieldError />
                 </TextField>
@@ -227,9 +232,9 @@ const QuestionAdd = ({
                 <TextField
                   name="question_requirements"
                 >
-                  <Label>Requirements plan writer must meet (optional but recommended)</Label>
+                  <Label>{QuestionAdd('labels.requirementText')}</Label>
                   <Text slot="description" className="help-text">
-                    Try to be precise and concise, so the plan writers won't miss any requirements. Question guidance is better for more general advice.
+                    {QuestionAdd('helpText.requirementText')}
                   </Text>
                   <TextArea
                     value={question?.requirementText ? question.requirementText : ''}
@@ -245,7 +250,7 @@ const QuestionAdd = ({
                 <TextField
                   name="question_guidance"
                 >
-                  <Label>Question guidance (optional but recommended)</Label>
+                  <Label>{QuestionAdd('labels.guidanceText')}</Label>
                   <TextArea
                     value={question?.guidanceText ? question?.guidanceText : ''}
                     onChange={(e) => setQuestion({
@@ -260,11 +265,9 @@ const QuestionAdd = ({
                 <TextField
                   name="sample_text"
                 >
-                  <Label>Sample text</Label>
+                  <Label>{QuestionAdd('labels.sampleText')}</Label>
                   <Text slot="description" className="help-text">
-                    Provide an example or template of expected answer (optional
-                    but
-                    recommended)
+                    {QuestionAdd('descriptions.sampleText')}
                   </Text>
                   <TextArea
                     value={question?.sampleText ? question.sampleText : ''}
@@ -276,19 +279,19 @@ const QuestionAdd = ({
                   />
                   <FieldError />
                   <Text slot="description" className="help-text">
-                    Plan creators will be able to copy the sample text into the field as a starting point, to speed up content entry.
+                    {QuestionAdd('helpText.sampleText')}
                   </Text>
                 </TextField>
 
-                <Button type="submit">Save</Button>
+                <Button type="submit">{Global('buttons.save')}</Button>
               </Form>
 
             </TabPanel>
             <TabPanel id="options">
-              <h2>Options</h2>
+              <h2>{Global('tabs.options')}</h2>
             </TabPanel>
             <TabPanel id="logic">
-              <h2>logic</h2>
+              <h2>{Global('tabs.logic')}</h2>
             </TabPanel>
           </Tabs>
 

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -32,6 +32,7 @@ import {
 import PageHeader from "@/components/PageHeader";
 import QuestionOptionsComponent from '@/components/Form/QuestionOptionsComponent';
 import FormInput from '@/components/Form/FormInput';
+import FormTextArea from '@/components/Form/FormTextArea';
 
 //Other
 import { useToast } from '@/context/ToastContext';
@@ -227,59 +228,45 @@ const QuestionAdd = ({
                   errorMessage={QuestionAdd('messages.errors.questionTextRequired')}
                 />
 
-                <TextField
+                <FormTextArea
                   name="question_requirements"
-                >
-                  <Label>{QuestionAdd('labels.requirementText')}</Label>
-                  <Text slot="description" className="help-text">
-                    {QuestionAdd('helpText.requirementText')}
-                  </Text>
-                  <TextArea
-                    value={question?.requirementText ? question.requirementText : ''}
-                    onChange={(e) => setQuestion({
-                      ...question,
-                      requirementText: e.currentTarget.value
-                    })}
-                    style={{ height: '100px' }}
-                  />
-                  <FieldError />
-                </TextField>
+                  isRequired={false}
+                  description={QuestionAdd('helpText.requirementText')}
+                  textAreaClasses={styles.questionFormField}
+                  label={QuestionAdd('labels.requirementText')}
+                  value={question?.requirementText ? question.requirementText : ''}
+                  onChange={(e) => setQuestion({
+                    ...question,
+                    requirementText: e.currentTarget.value
+                  })}
+                  helpMessage={QuestionAdd('helpText.requirementText')}
+                />
 
-                <TextField
+                <FormTextArea
                   name="question_guidance"
-                >
-                  <Label>{QuestionAdd('labels.guidanceText')}</Label>
-                  <TextArea
-                    value={question?.guidanceText ? question?.guidanceText : ''}
-                    onChange={(e) => setQuestion({
-                      ...question,
-                      guidanceText: e.currentTarget.value
-                    })}
-                    style={{ height: '150px' }}
-                  />
-                  <FieldError />
-                </TextField>
+                  isRequired={false}
+                  textAreaClasses={styles.questionFormField}
+                  label={QuestionAdd('labels.guidanceText')}
+                  value={question?.guidanceText ? question?.guidanceText : ''}
+                  onChange={(e) => setQuestion({
+                    ...question,
+                    guidanceText: e.currentTarget.value
+                  })}
+                />
 
-                <TextField
+                <FormTextArea
                   name="sample_text"
-                >
-                  <Label>{QuestionAdd('labels.sampleText')}</Label>
-                  <Text slot="description" className="help-text">
-                    {QuestionAdd('descriptions.sampleText')}
-                  </Text>
-                  <TextArea
-                    value={question?.sampleText ? question.sampleText : ''}
-                    onChange={(e) => setQuestion({
-                      ...question,
-                      sampleText: e.currentTarget.value
-                    })}
-                    style={{ height: '80px' }}
-                  />
-                  <FieldError />
-                  <Text slot="description" className="help-text">
-                    {QuestionAdd('helpText.sampleText')}
-                  </Text>
-                </TextField>
+                  isRequired={false}
+                  description={QuestionAdd('descriptions.sampleText')}
+                  textAreaClasses={styles.questionFormField}
+                  label={QuestionAdd('labels.sampleText')}
+                  value={question?.sampleText ? question.sampleText : ''}
+                  onChange={(e) => setQuestion({
+                    ...question,
+                    sampleText: e.currentTarget.value
+                  })}
+                  helpMessage={QuestionAdd('helpText.sampleText')}
+                />
 
                 <Button type="submit">{Global('buttons.save')}</Button>
               </Form>

--- a/components/QuestionAdd/questionAdd.module.scss
+++ b/components/QuestionAdd/questionAdd.module.scss
@@ -38,3 +38,7 @@
   padding: var(--space-4);
   margin-bottom: var(--space-4);
 }
+
+.questionFormField {
+  height: 100px;
+}

--- a/components/QuestionAdd/questionAdd.module.scss
+++ b/components/QuestionAdd/questionAdd.module.scss
@@ -32,3 +32,9 @@
   grid-area: help;
   width: fit-content;
 }
+
+.optionsWrapper {
+  border: 1px solid var(--border-color);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}

--- a/components/QuestionAdd/questionAdd.module.scss
+++ b/components/QuestionAdd/questionAdd.module.scss
@@ -1,5 +1,5 @@
 .optionsDescription {
-  font-size: var(--fs-lg);
+  font-size: var(--fs-sm);
   font-weight:600;
 }
 
@@ -7,7 +7,8 @@
   display: grid;
   grid-template-areas:
   "label label"
-  "input button";
+  "input button"
+  "help help";
   grid-template-columns: 1fr auto;
   max-width: 500px;
 }
@@ -24,5 +25,10 @@
 .searchButton {
   grid-area: button;
   margin-left: 10px;
+  width: fit-content;
+}
+
+.searchHelpText {
+  grid-area: help;
   width: fit-content;
 }

--- a/components/QuestionEdit/index.tsx
+++ b/components/QuestionEdit/index.tsx
@@ -206,13 +206,14 @@ const QuestionEditPage = ({
                 <TextField
                   name="type"
                   type="text"
+                  className={`${styles.searchField} react-aria-TextField`}
                   isRequired
                   value={questionTypeName ? questionTypeName : ''}
                 >
-                  <Label>Type (required)</Label>
-                  <Input disabled />
+                  <Label className={`${styles.searchLabel} react-aria-Label`}>Type (required)</Label>
+                  <Input className={`${styles.searchInput} react-aria-Input`} disabled />
+                  <Button className={`${styles.searchButton} react-aria-Button`} type="button" onPress={redirectToQuestionTypes}>Change type</Button>
                   <FieldError />
-                  <Button type="button" onPress={redirectToQuestionTypes}>Change type</Button>
                 </TextField>
 
                 {/**Question type fields here */}

--- a/components/QuestionEdit/questionEdit.module.scss
+++ b/components/QuestionEdit/questionEdit.module.scss
@@ -2,3 +2,27 @@
   font-size: var(--fs-lg);
   font-weight:600;
 }
+
+.searchField {
+  display: grid;
+  grid-template-areas:
+  "label label"
+  "input button";
+  grid-template-columns: 1fr auto;
+  max-width: 500px;
+}
+
+.searchLabel {
+  grid-area: label;
+}
+
+.searchInput {
+  grid-area: input;
+  
+}
+
+.searchButton {
+  grid-area: button;
+  margin-left: 10px;
+  width: fit-content;
+}

--- a/components/QuestionEdit/questionEdit.module.scss
+++ b/components/QuestionEdit/questionEdit.module.scss
@@ -1,0 +1,4 @@
+.optionsDescription {
+  font-size: var(--fs-lg);
+  font-weight:600;
+}

--- a/components/QuestionTypeCard/index.tsx
+++ b/components/QuestionTypeCard/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react';
 import { useTranslations } from 'next-intl';
 import {
@@ -21,7 +23,7 @@ import { QuestionTypesInterface } from '@/app/types';
 
 interface QuestionTypeCardProps {
   questionType: QuestionTypesInterface;
-  handleSelect: (id: number) => void;
+  handleSelect: (questionTypeId: number, questionTypeName: string) => void;
 }
 
 const QuestionTypeCard: React.FC<QuestionTypeCardProps> = ({ questionType, handleSelect }) => {
@@ -38,7 +40,7 @@ const QuestionTypeCard: React.FC<QuestionTypeCardProps> = ({ questionType, handl
         <Button
           className="button-link secondary"
           data-type={questionType.id}
-          onPress={() => handleSelect(questionType.id)}
+          onPress={() => handleSelect(questionType.id, questionType.name)}
         >
           {Global('buttons.select')}
         </Button>

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -2830,6 +2830,20 @@ export type QuestionsDisplayOrderQueryVariables = Exact<{
 
 export type QuestionsDisplayOrderQuery = { __typename?: 'Query', questions?: Array<{ __typename?: 'Question', displayOrder?: number | null } | null> | null };
 
+export type QuestionQueryVariables = Exact<{
+  questionId: Scalars['Int']['input'];
+}>;
+
+
+export type QuestionQuery = { __typename?: 'Query', question?: { __typename?: 'Question', id?: number | null, guidanceText?: string | null, errors?: Array<string> | null, displayOrder?: number | null, questionText?: string | null, requirementText?: string | null, sampleText?: string | null, sectionId: number, templateId: number, questionTypeId?: number | null, isDirty?: boolean | null, questionOptions?: Array<{ __typename?: 'QuestionOption', id?: number | null, isDefault?: boolean | null, orderNumber: number, text: string, questionId: number }> | null } | null };
+
+export type UpdateQuestionMutationVariables = Exact<{
+  input: UpdateQuestionInput;
+}>;
+
+
+export type UpdateQuestionMutation = { __typename?: 'Mutation', updateQuestion: { __typename?: 'Question', id?: number | null, guidanceText?: string | null, errors?: Array<string> | null, isDirty?: boolean | null, required?: boolean | null, requirementText?: string | null, sampleText?: string | null, sectionId: number, templateId: number, questionText?: string | null, questionOptions?: Array<{ __typename?: 'QuestionOption', id?: number | null, orderNumber: number, questionId: number, text: string, isDefault?: boolean | null }> | null } };
+
 export type SectionsDisplayOrderQueryVariables = Exact<{
   templateId: Scalars['Int']['input'];
 }>;
@@ -3493,6 +3507,112 @@ export type QuestionsDisplayOrderQueryHookResult = ReturnType<typeof useQuestion
 export type QuestionsDisplayOrderLazyQueryHookResult = ReturnType<typeof useQuestionsDisplayOrderLazyQuery>;
 export type QuestionsDisplayOrderSuspenseQueryHookResult = ReturnType<typeof useQuestionsDisplayOrderSuspenseQuery>;
 export type QuestionsDisplayOrderQueryResult = Apollo.QueryResult<QuestionsDisplayOrderQuery, QuestionsDisplayOrderQueryVariables>;
+export const QuestionDocument = gql`
+    query Question($questionId: Int!) {
+  question(questionId: $questionId) {
+    id
+    guidanceText
+    errors
+    displayOrder
+    questionText
+    requirementText
+    sampleText
+    sectionId
+    templateId
+    questionTypeId
+    questionOptions {
+      id
+      isDefault
+      orderNumber
+      text
+      questionId
+    }
+    isDirty
+  }
+}
+    `;
+
+/**
+ * __useQuestionQuery__
+ *
+ * To run a query within a React component, call `useQuestionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useQuestionQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useQuestionQuery({
+ *   variables: {
+ *      questionId: // value for 'questionId'
+ *   },
+ * });
+ */
+export function useQuestionQuery(baseOptions: Apollo.QueryHookOptions<QuestionQuery, QuestionQueryVariables> & ({ variables: QuestionQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<QuestionQuery, QuestionQueryVariables>(QuestionDocument, options);
+      }
+export function useQuestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<QuestionQuery, QuestionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<QuestionQuery, QuestionQueryVariables>(QuestionDocument, options);
+        }
+export function useQuestionSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<QuestionQuery, QuestionQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<QuestionQuery, QuestionQueryVariables>(QuestionDocument, options);
+        }
+export type QuestionQueryHookResult = ReturnType<typeof useQuestionQuery>;
+export type QuestionLazyQueryHookResult = ReturnType<typeof useQuestionLazyQuery>;
+export type QuestionSuspenseQueryHookResult = ReturnType<typeof useQuestionSuspenseQuery>;
+export type QuestionQueryResult = Apollo.QueryResult<QuestionQuery, QuestionQueryVariables>;
+export const UpdateQuestionDocument = gql`
+    mutation UpdateQuestion($input: UpdateQuestionInput!) {
+  updateQuestion(input: $input) {
+    id
+    guidanceText
+    errors
+    isDirty
+    required
+    requirementText
+    sampleText
+    sectionId
+    templateId
+    questionText
+    questionOptions {
+      id
+      orderNumber
+      questionId
+      text
+      isDefault
+    }
+  }
+}
+    `;
+export type UpdateQuestionMutationFn = Apollo.MutationFunction<UpdateQuestionMutation, UpdateQuestionMutationVariables>;
+
+/**
+ * __useUpdateQuestionMutation__
+ *
+ * To run a mutation, you first call `useUpdateQuestionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateQuestionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateQuestionMutation, { data, loading, error }] = useUpdateQuestionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateQuestionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateQuestionMutation, UpdateQuestionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateQuestionMutation, UpdateQuestionMutationVariables>(UpdateQuestionDocument, options);
+      }
+export type UpdateQuestionMutationHookResult = ReturnType<typeof useUpdateQuestionMutation>;
+export type UpdateQuestionMutationResult = Apollo.MutationResult<UpdateQuestionMutation>;
+export type UpdateQuestionMutationOptions = Apollo.BaseMutationOptions<UpdateQuestionMutation, UpdateQuestionMutationVariables>;
 export const SectionsDisplayOrderDocument = gql`
     query SectionsDisplayOrder($templateId: Int!) {
   sections(templateId: $templateId) {

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -2365,6 +2365,8 @@ export type UpdateQuestionInput = {
   questionOptions?: InputMaybe<Array<InputMaybe<UpdateQuestionOptionInput>>>;
   /** This will be used as a sort of title for the Question */
   questionText?: InputMaybe<Scalars['String']['input']>;
+  /** The type of question, such as text field, select box, radio buttons, etc */
+  questionTypeId?: InputMaybe<Scalars['Int']['input']>;
   /** To indicate whether the question is required to be completed */
   required?: InputMaybe<Scalars['Boolean']['input']>;
   /** Requirements associated with the Question */
@@ -2741,6 +2743,13 @@ export type AddQuestionMutationVariables = Exact<{
 
 export type AddQuestionMutation = { __typename?: 'Mutation', addQuestion: { __typename?: 'Question', errors?: Array<string> | null, id?: number | null, displayOrder?: number | null, questionText?: string | null, questionTypeId?: number | null, requirementText?: string | null, guidanceText?: string | null, sampleText?: string | null, useSampleTextAsDefault?: boolean | null, required?: boolean | null, questionOptions?: Array<{ __typename?: 'QuestionOption', isDefault?: boolean | null, id?: number | null, questionId: number, orderNumber: number, text: string }> | null } };
 
+export type UpdateQuestionMutationVariables = Exact<{
+  input: UpdateQuestionInput;
+}>;
+
+
+export type UpdateQuestionMutation = { __typename?: 'Mutation', updateQuestion: { __typename?: 'Question', id?: number | null, questionTypeId?: number | null, guidanceText?: string | null, errors?: Array<string> | null, isDirty?: boolean | null, required?: boolean | null, requirementText?: string | null, sampleText?: string | null, useSampleTextAsDefault?: boolean | null, sectionId: number, templateId: number, questionText?: string | null, questionOptions?: Array<{ __typename?: 'QuestionOption', id?: number | null, orderNumber: number, questionId: number, text: string, isDefault?: boolean | null }> | null } };
+
 export type AddSectionMutationVariables = Exact<{
   input: AddSectionInput;
 }>;
@@ -2845,13 +2854,6 @@ export type QuestionQueryVariables = Exact<{
 
 export type QuestionQuery = { __typename?: 'Query', question?: { __typename?: 'Question', id?: number | null, guidanceText?: string | null, errors?: Array<string> | null, displayOrder?: number | null, questionText?: string | null, requirementText?: string | null, sampleText?: string | null, useSampleTextAsDefault?: boolean | null, sectionId: number, templateId: number, questionTypeId?: number | null, isDirty?: boolean | null, questionOptions?: Array<{ __typename?: 'QuestionOption', id?: number | null, isDefault?: boolean | null, orderNumber: number, text: string, questionId: number }> | null } | null };
 
-export type UpdateQuestionMutationVariables = Exact<{
-  input: UpdateQuestionInput;
-}>;
-
-
-export type UpdateQuestionMutation = { __typename?: 'Mutation', updateQuestion: { __typename?: 'Question', id?: number | null, guidanceText?: string | null, errors?: Array<string> | null, isDirty?: boolean | null, required?: boolean | null, requirementText?: string | null, sampleText?: string | null, useSampleTextAsDefault?: boolean | null, sectionId: number, templateId: number, questionText?: string | null, questionOptions?: Array<{ __typename?: 'QuestionOption', id?: number | null, orderNumber: number, questionId: number, text: string, isDefault?: boolean | null }> | null } };
-
 export type SectionsDisplayOrderQueryVariables = Exact<{
   templateId: Scalars['Int']['input'];
 }>;
@@ -2955,6 +2957,57 @@ export function useAddQuestionMutation(baseOptions?: Apollo.MutationHookOptions<
 export type AddQuestionMutationHookResult = ReturnType<typeof useAddQuestionMutation>;
 export type AddQuestionMutationResult = Apollo.MutationResult<AddQuestionMutation>;
 export type AddQuestionMutationOptions = Apollo.BaseMutationOptions<AddQuestionMutation, AddQuestionMutationVariables>;
+export const UpdateQuestionDocument = gql`
+    mutation UpdateQuestion($input: UpdateQuestionInput!) {
+  updateQuestion(input: $input) {
+    id
+    questionTypeId
+    guidanceText
+    errors
+    isDirty
+    required
+    requirementText
+    sampleText
+    useSampleTextAsDefault
+    sectionId
+    templateId
+    questionText
+    questionOptions {
+      id
+      orderNumber
+      questionId
+      text
+      isDefault
+    }
+  }
+}
+    `;
+export type UpdateQuestionMutationFn = Apollo.MutationFunction<UpdateQuestionMutation, UpdateQuestionMutationVariables>;
+
+/**
+ * __useUpdateQuestionMutation__
+ *
+ * To run a mutation, you first call `useUpdateQuestionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateQuestionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateQuestionMutation, { data, loading, error }] = useUpdateQuestionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateQuestionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateQuestionMutation, UpdateQuestionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateQuestionMutation, UpdateQuestionMutationVariables>(UpdateQuestionDocument, options);
+      }
+export type UpdateQuestionMutationHookResult = ReturnType<typeof useUpdateQuestionMutation>;
+export type UpdateQuestionMutationResult = Apollo.MutationResult<UpdateQuestionMutation>;
+export type UpdateQuestionMutationOptions = Apollo.BaseMutationOptions<UpdateQuestionMutation, UpdateQuestionMutationVariables>;
 export const AddSectionDocument = gql`
     mutation AddSection($input: AddSectionInput!) {
   addSection(input: $input) {
@@ -3575,56 +3628,6 @@ export type QuestionQueryHookResult = ReturnType<typeof useQuestionQuery>;
 export type QuestionLazyQueryHookResult = ReturnType<typeof useQuestionLazyQuery>;
 export type QuestionSuspenseQueryHookResult = ReturnType<typeof useQuestionSuspenseQuery>;
 export type QuestionQueryResult = Apollo.QueryResult<QuestionQuery, QuestionQueryVariables>;
-export const UpdateQuestionDocument = gql`
-    mutation UpdateQuestion($input: UpdateQuestionInput!) {
-  updateQuestion(input: $input) {
-    id
-    guidanceText
-    errors
-    isDirty
-    required
-    requirementText
-    sampleText
-    useSampleTextAsDefault
-    sectionId
-    templateId
-    questionText
-    questionOptions {
-      id
-      orderNumber
-      questionId
-      text
-      isDefault
-    }
-  }
-}
-    `;
-export type UpdateQuestionMutationFn = Apollo.MutationFunction<UpdateQuestionMutation, UpdateQuestionMutationVariables>;
-
-/**
- * __useUpdateQuestionMutation__
- *
- * To run a mutation, you first call `useUpdateQuestionMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateQuestionMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [updateQuestionMutation, { data, loading, error }] = useUpdateQuestionMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useUpdateQuestionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateQuestionMutation, UpdateQuestionMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateQuestionMutation, UpdateQuestionMutationVariables>(UpdateQuestionDocument, options);
-      }
-export type UpdateQuestionMutationHookResult = ReturnType<typeof useUpdateQuestionMutation>;
-export type UpdateQuestionMutationResult = Apollo.MutationResult<UpdateQuestionMutation>;
-export type UpdateQuestionMutationOptions = Apollo.BaseMutationOptions<UpdateQuestionMutation, UpdateQuestionMutationVariables>;
 export const SectionsDisplayOrderDocument = gql`
     query SectionsDisplayOrder($templateId: Int!) {
   sections(templateId: $templateId) {

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -2726,6 +2726,13 @@ export type UpdateUserProfileInput = {
   surName: Scalars['String']['input'];
 };
 
+export type AddQuestionMutationVariables = Exact<{
+  input: AddQuestionInput;
+}>;
+
+
+export type AddQuestionMutation = { __typename?: 'Mutation', addQuestion: { __typename?: 'Question', errors?: Array<string> | null, id?: number | null, displayOrder?: number | null, questionText?: string | null, questionTypeId?: number | null, required?: boolean | null, requirementText?: string | null, guidanceText?: string | null, questionOptions?: Array<{ __typename?: 'QuestionOption', isDefault?: boolean | null, id?: number | null, questionId: number, orderNumber: number, text: string }> | null } };
+
 export type AddSectionMutationVariables = Exact<{
   input: AddSectionInput;
 }>;
@@ -2870,6 +2877,53 @@ export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id?: number | null, givenName?: string | null, surName?: string | null, languageId: string, errors?: Array<string> | null, emails?: Array<{ __typename?: 'UserEmail', id?: number | null, email: string, isPrimary: boolean, isConfirmed: boolean } | null> | null, affiliation?: { __typename?: 'Affiliation', id?: number | null, name: string, searchName: string, uri: string } | null } | null };
 
 
+export const AddQuestionDocument = gql`
+    mutation AddQuestion($input: AddQuestionInput!) {
+  addQuestion(input: $input) {
+    errors
+    id
+    displayOrder
+    questionText
+    questionTypeId
+    required
+    requirementText
+    guidanceText
+    questionOptions {
+      isDefault
+      id
+      questionId
+      orderNumber
+      text
+    }
+  }
+}
+    `;
+export type AddQuestionMutationFn = Apollo.MutationFunction<AddQuestionMutation, AddQuestionMutationVariables>;
+
+/**
+ * __useAddQuestionMutation__
+ *
+ * To run a mutation, you first call `useAddQuestionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddQuestionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addQuestionMutation, { data, loading, error }] = useAddQuestionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useAddQuestionMutation(baseOptions?: Apollo.MutationHookOptions<AddQuestionMutation, AddQuestionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddQuestionMutation, AddQuestionMutationVariables>(AddQuestionDocument, options);
+      }
+export type AddQuestionMutationHookResult = ReturnType<typeof useAddQuestionMutation>;
+export type AddQuestionMutationResult = Apollo.MutationResult<AddQuestionMutation>;
+export type AddQuestionMutationOptions = Apollo.BaseMutationOptions<AddQuestionMutation, AddQuestionMutationVariables>;
 export const AddSectionDocument = gql`
     mutation AddSection($input: AddSectionInput!) {
   addSection(input: $input) {

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -140,6 +140,8 @@ export type AddQuestionInput = {
   sectionId: Scalars['Int']['input'];
   /** The unique id of the Template that the question belongs to */
   templateId: Scalars['Int']['input'];
+  /** Boolean indicating whether we should use content from sampleText as the default answer */
+  useSampleTextAsDefault?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type AddQuestionOptionInput = {
@@ -1933,6 +1935,8 @@ export type Question = {
   sourceQestionId?: Maybe<Scalars['Int']['output']>;
   /** The unique id of the Template that the question belongs to */
   templateId: Scalars['Int']['output'];
+  /** Boolean indicating whether we should use content from sampleText as the default answer */
+  useSampleTextAsDefault?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /**
@@ -2367,6 +2371,8 @@ export type UpdateQuestionInput = {
   requirementText?: InputMaybe<Scalars['String']['input']>;
   /** Sample text to possibly provide a starting point or example to answer question */
   sampleText?: InputMaybe<Scalars['String']['input']>;
+  /** Boolean indicating whether we should use content from sampleText as the default answer */
+  useSampleTextAsDefault?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type UpdateQuestionOptionInput = {
@@ -2733,7 +2739,7 @@ export type AddQuestionMutationVariables = Exact<{
 }>;
 
 
-export type AddQuestionMutation = { __typename?: 'Mutation', addQuestion: { __typename?: 'Question', errors?: Array<string> | null, id?: number | null, displayOrder?: number | null, questionText?: string | null, questionTypeId?: number | null, required?: boolean | null, requirementText?: string | null, guidanceText?: string | null, questionOptions?: Array<{ __typename?: 'QuestionOption', isDefault?: boolean | null, id?: number | null, questionId: number, orderNumber: number, text: string }> | null } };
+export type AddQuestionMutation = { __typename?: 'Mutation', addQuestion: { __typename?: 'Question', errors?: Array<string> | null, id?: number | null, displayOrder?: number | null, questionText?: string | null, questionTypeId?: number | null, requirementText?: string | null, guidanceText?: string | null, sampleText?: string | null, useSampleTextAsDefault?: boolean | null, required?: boolean | null, questionOptions?: Array<{ __typename?: 'QuestionOption', isDefault?: boolean | null, id?: number | null, questionId: number, orderNumber: number, text: string }> | null } };
 
 export type AddSectionMutationVariables = Exact<{
   input: AddSectionInput;
@@ -2837,14 +2843,14 @@ export type QuestionQueryVariables = Exact<{
 }>;
 
 
-export type QuestionQuery = { __typename?: 'Query', question?: { __typename?: 'Question', id?: number | null, guidanceText?: string | null, errors?: Array<string> | null, displayOrder?: number | null, questionText?: string | null, requirementText?: string | null, sampleText?: string | null, sectionId: number, templateId: number, questionTypeId?: number | null, isDirty?: boolean | null, questionOptions?: Array<{ __typename?: 'QuestionOption', id?: number | null, isDefault?: boolean | null, orderNumber: number, text: string, questionId: number }> | null } | null };
+export type QuestionQuery = { __typename?: 'Query', question?: { __typename?: 'Question', id?: number | null, guidanceText?: string | null, errors?: Array<string> | null, displayOrder?: number | null, questionText?: string | null, requirementText?: string | null, sampleText?: string | null, useSampleTextAsDefault?: boolean | null, sectionId: number, templateId: number, questionTypeId?: number | null, isDirty?: boolean | null, questionOptions?: Array<{ __typename?: 'QuestionOption', id?: number | null, isDefault?: boolean | null, orderNumber: number, text: string, questionId: number }> | null } | null };
 
 export type UpdateQuestionMutationVariables = Exact<{
   input: UpdateQuestionInput;
 }>;
 
 
-export type UpdateQuestionMutation = { __typename?: 'Mutation', updateQuestion: { __typename?: 'Question', id?: number | null, guidanceText?: string | null, errors?: Array<string> | null, isDirty?: boolean | null, required?: boolean | null, requirementText?: string | null, sampleText?: string | null, sectionId: number, templateId: number, questionText?: string | null, questionOptions?: Array<{ __typename?: 'QuestionOption', id?: number | null, orderNumber: number, questionId: number, text: string, isDefault?: boolean | null }> | null } };
+export type UpdateQuestionMutation = { __typename?: 'Mutation', updateQuestion: { __typename?: 'Question', id?: number | null, guidanceText?: string | null, errors?: Array<string> | null, isDirty?: boolean | null, required?: boolean | null, requirementText?: string | null, sampleText?: string | null, useSampleTextAsDefault?: boolean | null, sectionId: number, templateId: number, questionText?: string | null, questionOptions?: Array<{ __typename?: 'QuestionOption', id?: number | null, orderNumber: number, questionId: number, text: string, isDefault?: boolean | null }> | null } };
 
 export type SectionsDisplayOrderQueryVariables = Exact<{
   templateId: Scalars['Int']['input'];
@@ -2908,9 +2914,11 @@ export const AddQuestionDocument = gql`
     displayOrder
     questionText
     questionTypeId
-    required
     requirementText
     guidanceText
+    sampleText
+    useSampleTextAsDefault
+    required
     questionOptions {
       isDefault
       id
@@ -3519,6 +3527,7 @@ export const QuestionDocument = gql`
     questionText
     requirementText
     sampleText
+    useSampleTextAsDefault
     sectionId
     templateId
     questionTypeId
@@ -3576,6 +3585,7 @@ export const UpdateQuestionDocument = gql`
     required
     requirementText
     sampleText
+    useSampleTextAsDefault
     sectionId
     templateId
     questionText

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -989,7 +989,7 @@ export type MutationRemoveQuestionConditionArgs = {
 
 
 export type MutationRemoveQuestionOptionArgs = {
-  questionOptionId: Scalars['Int']['input'];
+  id: Scalars['Int']['input'];
 };
 
 
@@ -1606,7 +1606,7 @@ export type Query = {
   question?: Maybe<Question>;
   /** Get the QuestionConditions that belong to a specific question */
   questionConditions?: Maybe<Array<Maybe<QuestionCondition>>>;
-  /** Get the specific Question Option based on questionOptionId */
+  /** Get the specific Question Option based on question option id */
   questionOption?: Maybe<QuestionOption>;
   /** Get the Question Options that belong to the associated questionId */
   questionOptions?: Maybe<Array<Maybe<QuestionOption>>>;
@@ -1824,7 +1824,7 @@ export type QueryQuestionConditionsArgs = {
 
 
 export type QueryQuestionOptionArgs = {
-  questionOptionId: Scalars['Int']['input'];
+  id: Scalars['Int']['input'];
 };
 
 
@@ -2370,14 +2370,14 @@ export type UpdateQuestionInput = {
 };
 
 export type UpdateQuestionOptionInput = {
+  /** The id of the QuestionOption */
+  id?: InputMaybe<Scalars['Int']['input']>;
   /** Whether the option is the default selected one */
   isDefault?: InputMaybe<Scalars['Boolean']['input']>;
   /** The option order number */
   orderNumber: Scalars['Int']['input'];
   /** id of parent question */
   questionId?: InputMaybe<Scalars['Int']['input']>;
-  /** The id of the QuestionOption */
-  questionOptionId?: InputMaybe<Scalars['Int']['input']>;
   /** The option text */
   text: Scalars['String']['input'];
 };

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -2823,6 +2823,13 @@ export type QuestionTypesQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type QuestionTypesQuery = { __typename?: 'Query', questionTypes?: Array<{ __typename?: 'QuestionType', id?: number | null, errors?: Array<string> | null, name: string, usageDescription: string } | null> | null };
 
+export type QuestionsDisplayOrderQueryVariables = Exact<{
+  sectionId: Scalars['Int']['input'];
+}>;
+
+
+export type QuestionsDisplayOrderQuery = { __typename?: 'Query', questions?: Array<{ __typename?: 'Question', displayOrder?: number | null } | null> | null };
+
 export type SectionsDisplayOrderQueryVariables = Exact<{
   templateId: Scalars['Int']['input'];
 }>;
@@ -3446,6 +3453,46 @@ export type QuestionTypesQueryHookResult = ReturnType<typeof useQuestionTypesQue
 export type QuestionTypesLazyQueryHookResult = ReturnType<typeof useQuestionTypesLazyQuery>;
 export type QuestionTypesSuspenseQueryHookResult = ReturnType<typeof useQuestionTypesSuspenseQuery>;
 export type QuestionTypesQueryResult = Apollo.QueryResult<QuestionTypesQuery, QuestionTypesQueryVariables>;
+export const QuestionsDisplayOrderDocument = gql`
+    query QuestionsDisplayOrder($sectionId: Int!) {
+  questions(sectionId: $sectionId) {
+    displayOrder
+  }
+}
+    `;
+
+/**
+ * __useQuestionsDisplayOrderQuery__
+ *
+ * To run a query within a React component, call `useQuestionsDisplayOrderQuery` and pass it any options that fit your needs.
+ * When your component renders, `useQuestionsDisplayOrderQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useQuestionsDisplayOrderQuery({
+ *   variables: {
+ *      sectionId: // value for 'sectionId'
+ *   },
+ * });
+ */
+export function useQuestionsDisplayOrderQuery(baseOptions: Apollo.QueryHookOptions<QuestionsDisplayOrderQuery, QuestionsDisplayOrderQueryVariables> & ({ variables: QuestionsDisplayOrderQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<QuestionsDisplayOrderQuery, QuestionsDisplayOrderQueryVariables>(QuestionsDisplayOrderDocument, options);
+      }
+export function useQuestionsDisplayOrderLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<QuestionsDisplayOrderQuery, QuestionsDisplayOrderQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<QuestionsDisplayOrderQuery, QuestionsDisplayOrderQueryVariables>(QuestionsDisplayOrderDocument, options);
+        }
+export function useQuestionsDisplayOrderSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<QuestionsDisplayOrderQuery, QuestionsDisplayOrderQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<QuestionsDisplayOrderQuery, QuestionsDisplayOrderQueryVariables>(QuestionsDisplayOrderDocument, options);
+        }
+export type QuestionsDisplayOrderQueryHookResult = ReturnType<typeof useQuestionsDisplayOrderQuery>;
+export type QuestionsDisplayOrderLazyQueryHookResult = ReturnType<typeof useQuestionsDisplayOrderLazyQuery>;
+export type QuestionsDisplayOrderSuspenseQueryHookResult = ReturnType<typeof useQuestionsDisplayOrderSuspenseQuery>;
+export type QuestionsDisplayOrderQueryResult = Apollo.QueryResult<QuestionsDisplayOrderQuery, QuestionsDisplayOrderQueryVariables>;
 export const SectionsDisplayOrderDocument = gql`
     query SectionsDisplayOrder($templateId: Int!) {
   sections(templateId: $templateId) {

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -2374,6 +2374,8 @@ export type UpdateQuestionOptionInput = {
   isDefault?: InputMaybe<Scalars['Boolean']['input']>;
   /** The option order number */
   orderNumber: Scalars['Int']['input'];
+  /** id of parent question */
+  questionId?: InputMaybe<Scalars['Int']['input']>;
   /** The id of the QuestionOption */
   questionOptionId?: InputMaybe<Scalars['Int']['input']>;
   /** The option text */

--- a/graphql/mutations/questions.mutation.graphql
+++ b/graphql/mutations/questions.mutation.graphql
@@ -19,3 +19,27 @@ mutation AddQuestion($input: AddQuestionInput!) {
     }
   }
 }
+
+mutation UpdateQuestion($input: UpdateQuestionInput!) {
+  updateQuestion(input: $input) {
+    id
+    questionTypeId
+    guidanceText
+    errors
+    isDirty
+    required
+    requirementText
+    sampleText
+    useSampleTextAsDefault
+    sectionId
+    templateId
+    questionText
+    questionOptions {
+      id
+      orderNumber
+      questionId
+      text
+      isDefault
+    }
+  }
+}

--- a/graphql/mutations/questions.mutation.graphql
+++ b/graphql/mutations/questions.mutation.graphql
@@ -5,9 +5,11 @@ mutation AddQuestion($input: AddQuestionInput!) {
     displayOrder
     questionText
     questionTypeId
-    required
     requirementText
     guidanceText
+    sampleText
+    useSampleTextAsDefault
+    required
     questionOptions {
       isDefault
       id

--- a/graphql/mutations/questions.mutation.graphql
+++ b/graphql/mutations/questions.mutation.graphql
@@ -1,0 +1,19 @@
+mutation AddQuestion($input: AddQuestionInput!) {
+  addQuestion(input: $input) {
+    errors
+    id
+    displayOrder
+    questionText
+    questionTypeId
+    required
+    requirementText
+    guidanceText
+    questionOptions {
+      isDefault
+      id
+      questionId
+      orderNumber
+      text
+    }
+  }
+}

--- a/graphql/queries/questions.query.graphql
+++ b/graphql/queries/questions.query.graphql
@@ -1,0 +1,5 @@
+query QuestionsDisplayOrder($sectionId: Int!) {
+  questions(sectionId: $sectionId) {
+    displayOrder
+  }
+}

--- a/graphql/queries/questions.query.graphql
+++ b/graphql/queries/questions.query.graphql
@@ -27,26 +27,3 @@ query Question($questionId: Int!) {
     isDirty
   }
 }
-
-mutation UpdateQuestion($input: UpdateQuestionInput!) {
-  updateQuestion(input: $input) {
-    id
-    guidanceText
-    errors
-    isDirty
-    required
-    requirementText
-    sampleText
-    useSampleTextAsDefault
-    sectionId
-    templateId
-    questionText
-    questionOptions {
-      id
-      orderNumber
-      questionId
-      text
-      isDefault
-    }
-  }
-}

--- a/graphql/queries/questions.query.graphql
+++ b/graphql/queries/questions.query.graphql
@@ -3,3 +3,48 @@ query QuestionsDisplayOrder($sectionId: Int!) {
     displayOrder
   }
 }
+
+query Question($questionId: Int!) {
+  question(questionId: $questionId) {
+    id
+    guidanceText
+    errors
+    displayOrder
+    questionText
+    requirementText
+    sampleText
+    sectionId
+    templateId
+    questionTypeId
+    questionOptions {
+      id
+      isDefault
+      orderNumber
+      text
+      questionId
+    }
+    isDirty
+  }
+}
+
+mutation UpdateQuestion($input: UpdateQuestionInput!) {
+  updateQuestion(input: $input) {
+    id
+    guidanceText
+    errors
+    isDirty
+    required
+    requirementText
+    sampleText
+    sectionId
+    templateId
+    questionText
+    questionOptions {
+      id
+      orderNumber
+      questionId
+      text
+      isDefault
+    }
+  }
+}

--- a/graphql/queries/questions.query.graphql
+++ b/graphql/queries/questions.query.graphql
@@ -13,6 +13,7 @@ query Question($questionId: Int!) {
     questionText
     requirementText
     sampleText
+    useSampleTextAsDefault
     sectionId
     templateId
     questionTypeId
@@ -36,6 +37,7 @@ mutation UpdateQuestion($input: UpdateQuestionInput!) {
     required
     requirementText
     sampleText
+    useSampleTextAsDefault
     sectionId
     templateId
     questionText

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -23,12 +23,16 @@ const config: Config = {
         fetch: global.fetch //added this to be able to mock 'fetch' in tests
     },
     collectCoverage: true,
+    collectCoverageFrom: [
+        "app/**",  // Include all pages
+        "components/**"// Include components
+    ],
     coverageThreshold: {
         global: {
-            branches: 50,
-            functions: 50,
-            lines: 80,
-            statements: 80,
+            branches: 60,
+            functions: 60,
+            lines: 60,
+            statements: 60,
         }
     },
     coverageDirectory: "coverage",

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -150,6 +150,9 @@
       "editQuestion": "Edit Question",
       "options": "Options",
       "logic": "Logic"
+    },
+    "headings": {
+      "preview": "Preview"
     }
   }
 }

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -127,16 +127,15 @@
     "buttons": {
       "search": "Search",
       "select": "Select",
-      "next": "Next"
+      "next": "Next",
+      "save": "Save",
+      "remove": "Remove"
     },
     "labels": {
       "searchByKeyword": "Search by keyword"
     },
     "helpText": {
       "searchHelpText": "Search by research organization, field station or lab, template description, etc."
-    },
-    "labels": {
-      "searchByKeyword": "Search by keyword"
     },
     "links": {
       "clearFilter": "clear filter"
@@ -146,6 +145,11 @@
       "noItemsFound": "No items found",
       "somethingWentWrong": "Something went wrong. Please try again.",
       "resultsText": "{name} results match your search"
+    },
+    "tabs": {
+      "editQuestion": "Edit Question",
+      "options": "Options",
+      "logic": "Logic"
     }
   }
 }

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -197,5 +197,59 @@
     "messages": {
       "additionalGuidance": "Your research organization has additional guidance"
     }
+  },
+  "QuestionEdit": {
+    "buttons": {
+      "changeType": "Change type"
+    },
+    "descriptions": {
+      "sampleText": "Provide an example or template of expected answer (optional but recommended)"
+    },
+    "helpText": {
+      "textField": "Changing the question type, for example from Short question to Radio button, may result in some data being lost.",
+      "questionOptions": "Please enter answer choices for the {questionType}",
+      "questionText": "Keep the question text concise and clear. Use the requirements or guidance to provide additional explanation.",
+      "requirementText": "Try to be precise and concise, so the plan writers won't miss any requirements. Question guidance is better for more general advice.",
+      "sampleText": "Plan creators will be able to copy the sample text into the field as a starting point, to speed up content entry."
+    },
+    "labels": {
+      "type": "Type (required)",
+      "questionText": "Question text (required)",
+      "requirementText": "Requirements plan writer must meet (optional but recommended)",
+      "guidanceText": "Question guidance (optional but recommended)",
+      "sampleText": "Sample text"
+    }
+  },
+  "QuestionOptionsComponent": {
+    "labels": {
+      "order": "Order",
+      "text": "Text (required)",
+      "default": "Default"
+    },
+    "buttons": {
+      "addRow": "Add Row"
+    }
+  },
+  "QuestionAdd": {
+    "labels": {
+      "order": "Order",
+      "text": "Text (required)",
+      "default": "Default",
+      "type": "Type (required)",
+      "questionText": "Question text (required)",
+      "requirementText": "Requirements plan writer must meet (optional but recommended)",
+      "guidanceText": "Question guidance (optional but recommended)",
+      "sampleText": "Sample text"
+    },
+    "buttons": {
+      "addRow": "Add Row"
+    },
+    "helpText": {
+      "textField": "Changing the question type, for example from Short question to Radio button, may result in some data being lost.",
+      "questionOptions": "Please enter answer choices for the {questionTypeName}",
+      "questionText": "Keep the question text concise and clear. Use the requirements or guidance to provide additional explanation.",
+      "requirementText": "Try to be precise and concise, so the plan writers won't miss any requirements. Question guidance is better for more general advice.",
+      "sampleText": "Plan creators will be able to copy the sample text into the field as a starting point, to speed up content entry."
+    }
   }
 }

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -231,6 +231,9 @@
     }
   },
   "QuestionAdd": {
+    "descriptions": {
+      "sampleText": "Provide an example or template of expected answer (optional but recommended)"
+    },
     "labels": {
       "order": "Order",
       "text": "Text (required)",

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -199,11 +199,17 @@
     }
   },
   "QuestionEdit": {
+    "title": "Edit: {title}",
     "buttons": {
-      "changeType": "Change type"
+      "changeType": "Change type",
+      "previewQuestion": "Preview question"
     },
     "descriptions": {
-      "sampleText": "Provide an example or template of expected answer (optional but recommended)"
+      "sampleText": "Provide an example or template of expected answer (optional but recommended)",
+      "previewText": "See how this question will look to users.",
+      "bestPracticePara1": "Keep the question concise and clear. Use the requirements or guidance to provide additional explanation.",
+      "bestPracticePara2": "Outline the requirements that a user must consider for this question.",
+      "bestPracticePara3": "Researchers will be able to copy the sample text into the field as a starting point, as a way to speed up content entry."
     },
     "helpText": {
       "textField": "Changing the question type, for example from Short question to Radio button, may result in some data being lost.",
@@ -218,6 +224,18 @@
       "requirementText": "Requirements plan writer must meet (optional but recommended)",
       "guidanceText": "Question guidance (optional but recommended)",
       "sampleText": "Sample text"
+    },
+    "messages": {
+      "errors": {
+        "questionTextRequired": "Question text field is required.",
+        "questionUpdateError": "Error when updating question"
+      },
+      "success": {
+        "questionUpdated": "Question was successfully updated"
+      }
+    },
+    "headings": {
+      "bestPractice": "Best practice by DMP Tool"
     }
   },
   "QuestionOptionsComponent": {
@@ -227,12 +245,27 @@
       "default": "Default"
     },
     "buttons": {
-      "addRow": "Add Row"
+      "addRow": "Add Row",
+      "deleteRow": "Delete row {count}"
+    },
+    "messages": {
+      "successAddingRow": "Row {number} added",
+      "rowInfo": "Row {number}"
+    },
+    "announcements": {
+      "rowDefault": "Row with ID {id} set as default.",
+      "rowRemoved": "Row with ID {id} removed.",
+      "rowAdded": "Row {orderNumber} added."
     }
   },
   "QuestionAdd": {
+    "title": "Add New Question",
     "descriptions": {
-      "sampleText": "Provide an example or template of expected answer (optional but recommended)"
+      "sampleText": "Provide an example or template of expected answer (optional but recommended)",
+      "previewText": "See how this question will look to users.",
+      "bestPracticePara1": "Keep the question concise and clear. Use the requirements or guidance to provide additional explanation.",
+      "bestPracticePara2": "Outline the requirements that a user must consider for this question.",
+      "bestPracticePara3": "Researchers will be able to copy the sample text into the field as a starting point, as a way to speed up content entry."
     },
     "labels": {
       "order": "Order",
@@ -245,7 +278,8 @@
       "sampleText": "Sample text"
     },
     "buttons": {
-      "addRow": "Add Row"
+      "addRow": "Add Row",
+      "previewQuestion": "Preview question"
     },
     "helpText": {
       "textField": "Changing the question type, for example from Short question to Radio button, may result in some data being lost.",
@@ -253,6 +287,18 @@
       "questionText": "Keep the question text concise and clear. Use the requirements or guidance to provide additional explanation.",
       "requirementText": "Try to be precise and concise, so the plan writers won't miss any requirements. Question guidance is better for more general advice.",
       "sampleText": "Plan creators will be able to copy the sample text into the field as a starting point, to speed up content entry."
+    },
+    "headings": {
+      "bestPractice": "Best practice by DMP Tool"
+    },
+    "messages": {
+      "errors": {
+        "questionTextRequired": "Question text field is required.",
+        "questionAddingError": "Error when adding question."
+      },
+      "success": {
+        "questionAdded": "Question was successfully added."
+      }
     }
   }
 }

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -256,6 +256,10 @@
       "rowDefault": "Row with ID {id} set as default.",
       "rowRemoved": "Row with ID {id} removed.",
       "rowAdded": "Row {orderNumber} added."
+    },
+    "placeholder": {
+      "orderNumber": "Enter order #",
+      "text": "Enter text"
     }
   },
   "QuestionAdd": {

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -165,7 +165,10 @@
   "QuestionTypeSelectPage": {
     "title": "What type of question would you like to add?",
     "description": "As you create your template, you can choose different types of questions to add to it, depending on the type of information you require from the plan creator.",
-    "searchHelpText": "Search by field type or description."
+    "searchHelpText": "Search by field type or description.",
+    "links": {
+      "clearFilter": "clear filter"
+    }
   },
   "TemplateCreatePage": {
     "helpText": "Don't worry, you can change this later.",
@@ -206,6 +209,7 @@
     },
     "descriptions": {
       "sampleText": "Provide an example or template of expected answer (optional but recommended)",
+      "sampleTextAsDefault": "Have this answer entered into the DMP by default",
       "previewText": "See how this question will look to users.",
       "bestPracticePara1": "Keep the question concise and clear. Use the requirements or guidance to provide additional explanation.",
       "bestPracticePara2": "Outline the requirements that a user must consider for this question.",
@@ -266,6 +270,7 @@
     "title": "Add New Question",
     "descriptions": {
       "sampleText": "Provide an example or template of expected answer (optional but recommended)",
+      "sampleTextAsDefault": "Have this answer entered into the DMP by default",
       "previewText": "See how this question will look to users.",
       "bestPracticePara1": "Keep the question concise and clear. Use the requirements or guidance to provide additional explanation.",
       "bestPracticePara2": "Outline the requirements that a user must consider for this question.",

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -122,30 +122,37 @@
       "editTemplate": "Editar Modelo",
       "question": "Pergunta"
     },
-    "lastRevisedBy": "Última revisão por",
+    "lastRevisedBy": "Last revised by",
     "lastUpdated": "Últimas atualizações",
     "buttons": {
       "search": "Buscar",
       "select": "Select",
-      "next": "Seguinte"
+      "next": "Seguinte",
+      "save": "Salvar",
+      "remove": "Remover"
     },
     "labels": {
-      "searchByKeyword": ""
+      "searchByKeyword": "Pesquisar por palavra-chave"
     },
     "helpText": {
       "searchHelpText": "Pesquisar por organização de pesquisa, estação de campo ou laboratório, descrição de modelo, etc."
     },
-    "labels": {
-      "searchByKeyword": ""
-    },
     "links": {
-      "clearFilter": "clear filter"
+      "clearFilter": "limpar filtro"
     },
     "messaging": {
       "loading": "Baixar",
       "noItemsFound": "Nenhum item encontrado",
       "somethingWentWrong": "Ocorreu um erro. Tente novamente.",
-      "resultsText": "{name} results match your search"
+      "resultsText": "Os resultados {name} correspondem à sua pesquisa"
+    },
+    "tabs": {
+      "editQuestion": "Editar Pergunta",
+      "options": "Opções",
+      "logic": "Lógica"
+    },
+    "headings": {
+      "preview": "Pré-visualizar"
     }
   }
 }

--- a/messages/pt-BR/messaging.json
+++ b/messages/pt-BR/messaging.json
@@ -1,6 +1,6 @@
 {
   "Messaging": {
     "loading": "Baixar",
-    "successfullyUpdated": "Successfully updated."
+    "successfullyUpdated": "Atualizado com sucesso."
   }
 }

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -46,7 +46,8 @@
     },
     "errors": {
       "archiveTemplateError": "Erro ao arquivar template",
-      "saveTemplateError": "Erro ao salvar modelo"
+      "saveTemplateError": "Erro ao salvar modelo",
+      "getTemplatesError": "Erro ao obter modelos"
     }
   },
   "PublishTemplate": {
@@ -123,25 +124,20 @@
     "questionsCount": "<p>Esta seção inclui:</p><p>{count} questões pré-criadas</p>"
   },
   "Section": {
-    "Section": {
-      "tabs": {
-        "editSection": "Editar seção",
-        "options": "Opções",
-        "logic": "Lógica"
-      },
-      "labels": {
-        "sectionName": "Nome da seção",
-        "sectionIntroduction": "Introdução à seção",
-        "sectionRequirements": "Requisitos da seção",
-        "sectionGuidance": "Orientação em Seção",
-        "bestPracticeTags": "Seção das melhores práticas para incluir"
-      },
-      "helpText": {
-        "bestPracticeTagsDesc": "Selecione uma ou mais tags para associar a orientação de boas práticas globais escrita pela Ferramenta DMP."
-      }
+    "tabs": {
+      "editSection": "Editar seção",
+      "options": "Opções",
+      "logic": "Lógica"
     },
-    "CreateSectionPage": {
-      "title": "Criar seção"
+    "labels": {
+      "sectionName": "Nome da seção",
+      "sectionIntroduction": "Introdução à seção",
+      "sectionRequirements": "Requisitos da seção",
+      "sectionGuidance": "Orientação em Seção",
+      "bestPracticeTags": "Seção das melhores práticas para incluir"
+    },
+    "helpText": {
+      "bestPracticeTagsDesc": "Selecione uma ou mais tags para associar a orientação de boas práticas globais escrita pela Ferramenta DMP."
     }
   },
   "CreateSectionPage": {
@@ -162,7 +158,7 @@
     },
     "messages": {
       "fieldLengthValidation": "O nome precisa ter pelo menos 3 caracteres",
-      "errorCreatingSection": "Erro ao criar a seção.",
+      "errorUpdatingSection": "Erro ao criar a seção.",
       "success": "Seção criada com sucesso."
     }
   },
@@ -179,7 +175,7 @@
     }
   },
   "TemplateSelectTemplatePage": {
-    "title": "Selecionar um modelo existente",
+    "title": "Iniciar com uma cópia de um modelo existente",
     "resultsText": "Os resultados {name} correspondem à sua pesquisa",
     "numDisplaying": "Mostrando {num} de {total}",
     "clearFilter": "filtros transparentes",
@@ -192,14 +188,121 @@
       "publicTemplates": "Use um dos modelos públicos"
     },
     "messages": {
-      "noItemsFound": "Nenhum item encontrado",
-      "missingTemplateName": "Faltando nome de modelo",
+      "noItemsFound": "Nenhum “item” encontrado",
+      "missingTemplateName": "Nome do modelo não pode ser vazio.",
       "loadingError": "Erro ao carregar modelos. Tente novamente mais tarde."
     }
   },
   "TemplateSelectListItem": {
     "messages": {
-      "additionalGuidance": "Sua organização de pesquisa tem orientação adicional"
+      "additionalGuidance": "Your research organization has additional guidance"
+    }
+  },
+  "QuestionEdit": {
+    "title": "Sua organização de pesquisa tem orientação adicional.",
+    "buttons": {
+      "changeType": "",
+      "previewQuestion": "Pergunta de visualização"
+    },
+    "descriptions": {
+      "sampleText": "Forneça um exemplo ou modelo de resposta esperada (opcional, mas recomendado)",
+      "previewText": "Veja como esta pergunta ficará para os usuários.",
+      "bestPracticePara1": "Mantenha a pergunta concisa e clara. Use os requisitos ou orientações para fornecer explicações adicionais.",
+      "bestPracticePara2": "Esboça os requisitos que um usuário deve considerar para esta pergunta.",
+      "bestPracticePara3": "Pesquisadores poderão copiar o texto de amostra para o campo como ponto de partida, como uma maneira de acelerar a entrada de conteúdo."
+    },
+    "helpText": {
+      "textField": "Alterar o tipo de questão, por exemplo, da pergunta curta para o botão Rádio, pode resultar na perda de alguns dados.",
+      "questionOptions": "Por favor, insira as opções de resposta para o {questionType}",
+      "questionText": "Mantenha a pergunta concisa e clara. Use os requisitos ou orientações para fornecer explicações adicionais.",
+      "requirementText": "Tente ser preciso e conciso, para que os autores do plano não faltem a quaisquer requisitos. Orientação às perguntas é melhor para conselhos mais gerais.",
+      "sampleText": "Pesquisadores poderão copiar o texto de amostra para o campo como ponto de partida, como uma maneira de acelerar a entrada de conteúdo."
+    },
+    "labels": {
+      "type": "Tipo (obrigatório)",
+      "questionText": "Conjunto de perguntas (obrigatório)",
+      "requirementText": "Escritor do plano de requisitos deve atender (opcional, mas recomendado)",
+      "guidanceText": "Orientação para perguntas (opcional mas recomendado)",
+      "sampleText": "Texto de amostra"
+    },
+    "messages": {
+      "errors": {
+        "questionTextRequired": "Conjunto de perguntas (obrigatório.",
+        "questionUpdateError": "Erro ao criar a seção"
+      },
+      "success": {
+        "questionUpdated": "A pergunta foi atualizada com sucesso"
+      }
+    },
+    "headings": {
+      "bestPractice": "Melhores práticas da Ferramenta DMP"
+    }
+  },
+  "QuestionOptionsComponent": {
+    "labels": {
+      "order": "Ordem",
+      "text": "Texto (obrigatório)",
+      "default": "Padrão"
+    },
+    "buttons": {
+      "addRow": "Adicionar linha",
+      "deleteRow": "Excluir linha {count}"
+    },
+    "messages": {
+      "successAddingRow": "Linha {number} adicionada",
+      "rowInfo": "Linha {number}"
+    },
+    "announcements": {
+      "rowDefault": "Linha com ID {id} definida como padrão.",
+      "rowRemoved": "Linha com ID {id} removida.",
+      "rowAdded": "Linha {orderNumber} adicionada."
+    },
+    "placeholder": {
+      "orderNumber": "Insira o pedido #",
+      "text": "Digite o texto"
+    }
+  },
+  "QuestionAdd": {
+    "title": "Adicionar nova pergunta",
+    "descriptions": {
+      "sampleText": "Forneça um exemplo ou modelo de resposta esperada (opcional, mas recomendado)",
+      "previewText": "Veja como esta pergunta ficará para os usuários.",
+      "bestPracticePara1": "Mantenha a pergunta concisa e clara. Use os requisitos ou orientações para fornecer explicações adicionais.",
+      "bestPracticePara2": "Esboça os requisitos que um usuário deve considerar para esta pergunta.",
+      "bestPracticePara3": "Researchers will be able to copy the sample text into the field as a starting point, as a way to speed up content entry."
+    },
+    "labels": {
+      "order": "Ordem",
+      "text": "Texto (obrigatório)",
+      "default": "Padrão",
+      "type": "Tipo (obrigatório)",
+      "questionText": "Conjunto de perguntas (obrigatório)",
+      "requirementText": "Escritor do plano de requisitos deve atender (opcional, mas recomendado)",
+      "guidanceText": "Orientação para perguntas (opcional mas recomendado)",
+      "sampleText": "Texto de amostra"
+    },
+    "buttons": {
+      "addRow": "Adicionar linha",
+      "previewQuestion": "Pergunta de visualização"
+    },
+    "helpText": {
+      "textField": "Alterar o tipo de questão, por exemplo, da pergunta curta para o botão Rádio, pode resultar na perda de alguns dados.",
+      "questionOptions": "Por favor, insira as opções de resposta para o {questionTypeName}",
+      "questionText": "Mantenha a pergunta concisa e clara. Use os requisitos ou orientações para fornecer explicações adicionais.",
+      "requirementText": "Tente ser preciso e conciso, para que os autores do plano não faltem a quaisquer requisitos. Orientação às perguntas é melhor para conselhos mais gerais.",
+      "sampleText": "Os criadores de planos poderão copiar o texto da amostra para o campo como ponto de partida, para acelerar a entrada de conteúdo."
+    },
+    "headings": {
+      "bestPractice": "Melhores práticas pela Ferramenta DMP"
+    },
+    "messages": {
+      "errors": {
+        "questionTextRequired": "Campo texto da pergunta é obrigatório.",
+        "questionAddingError": "Erro ao adicionar pergunta."
+      },
+      "success": {
+        "questionAdded": "A pergunta foi adicionada com sucesso."
+      }
     }
   }
 }

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -12,6 +12,9 @@
 .help-text {
   display: block;
   font-size: var(--fs-small);
+  margin: var(--space-2) var(--space-2);
+  max-width: 600px;
+
 }
 
 .form-row {


### PR DESCRIPTION
## Description

- Updated the Edit Question `template/[templateId]/q/[q_slug]/page.tsx` with actual data from backend and added functionality for `options` and text question types
- Updated the Add Question`template/[templateId]/q/new/page.tsx` page with actual data from backend and added functionality to accomodate `option` and text question types.
- Added new Question and QuestionOption types
- Added useSampleTextAsDefault checkbox to both the Edit and Add Question pages, which should only display when the user selects the `Text Area` or `Text Field` question types
- Updated the shared FormInput component, and added a new FormTextArea component
- Added new QuestionOptionsComponent for handling the `options` question types in the form
- Added new QuestionAdd component for adding a new question
- Added unit tests and translations
- Added new `QuestionsDisplayOrder` and `Question` queries and `AddQuestion` and `UpdateQuestion` mutations

Fixes # ([188](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/188))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I added unit tests and also tested manually with the backend to make sure data was being updated as expected


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/1aea35f5-d2e1-45a2-90fe-bbc3753779a3" />

<img width="985" alt="image" src="https://github.com/user-attachments/assets/1442523a-3a6d-43d7-b470-4d00e0333fd7" />

<img width="990" alt="image" src="https://github.com/user-attachments/assets/e94e84ec-23e2-460f-961a-e954fcfd44d2" />
