### PR TITLE
[Bug] - fixed wrong term used for import of material-symbols-outlined in layo…

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -16,7 +16,7 @@ import { AuthProvider } from "@/context/AuthContext";
 import { CsrfProvider } from "@/context/CsrfContext";
 
 //Styles
-import '@fontsource/material-symbols-outlined/400.css';
+import '@fontsource/material-symbols-outlined';
 import '@fortawesome/fontawesome-svg-core/styles.css'
 import "@/styles/globals.scss";
 


### PR DESCRIPTION

## Description
Fixed wrong term used for import of material-symbols-outlined. I introduced it when I was fixing linting issues.



## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
