### PR TITLE
[Bug] - Fix 'EvalError: Code generation from strings' error when trying to access pages in app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 - Added useSampleTextAsDefault checkbox for text field question types [#188]
 
 ### Fixed
-
+- Fixed `EvalError: Code generation from strings ` bug that was occurring because I set the environment in docker-compose.yml to production
 
 ====================================================================================================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,9 @@ services:
       dockerfile: Dockerfile.dev
     ports:
       - "3000:3000"
-    environment:
-      - NODE_ENV=production
-    #volumes:
-    #  - .:/app
-    #  - /app/node_modules
+    volumes:
+    - .:/app
+    - /app/node_modules
     # this next line was needed to populate some missing modules in /app/node_modules when starting docker container
-    #command: /bin/sh -c "npm install && npm run dev"
+    command: /bin/sh -c "npm install && npm run dev"
+


### PR DESCRIPTION
## Description

I recently made some changes to `docker-compose.yml` file, and forgot to revert a change to it where I set the environment to `production`.

This caused the `EvalError`. It is working now.

## Fixed ([355](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/355))
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran existing unit tests and checked that I could access pages


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules