### PR TITLE
removed unused var from /projects/[projectId]/dmp/[dmpId]/download which broke the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Renamed previous `QuestionEdit` component to `QuestionEditCard` for more specificity [#220]
 
 ### Fixed
+- Fixed bug in `/projects/[projectId]/dmp/[dmpId]/download` because of unused `FileIcon` [#376]
 - Fixed bug where `/template` page was continuosly refreshed when no data was returned [#351]
 
 ### Added

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/download/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/download/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, {ChangeEvent, useState} from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import {
   Breadcrumb,
   Breadcrumbs,
@@ -36,15 +36,6 @@ interface SettingsState {
 }
 
 type FileFormatType = 'pdf' | 'doc' | 'html' | 'csv' | 'json';
-
-interface FileIconProps {
-  type?: FileFormatType;
-}
-
-// Icons for file formats
-const FileIcon: React.FC<FileIconProps> = () => {
-  return <span className={styles.icon}></span>;
-};
 
 const ProjectsProjectPlanDownloadPage: React.FC = () => {
   // State for form values
@@ -120,12 +111,12 @@ const ProjectsProjectPlanDownloadPage: React.FC = () => {
               Choose file format
             </h3>
             <div>
-                <RadioGroup
-                  className={styles.radioGroup}
-                  aria-label="File format"
-                  value={selectedFormat}
-                  onChange={(value: string) => setSelectedFormat(value as FileFormatType)}
-                >
+              <RadioGroup
+                className={styles.radioGroup}
+                aria-label="File format"
+                value={selectedFormat}
+                onChange={(value: string) => setSelectedFormat(value as FileFormatType)}
+              >
                 <Radio value="pdf">
                   {/* <FileIcon type="pdf"/> */}
                   PDF
@@ -170,7 +161,7 @@ const ProjectsProjectPlanDownloadPage: React.FC = () => {
               >
                 <div className={"checkbox"}>
                   <svg viewBox="0 0 18 18" aria-hidden="true">
-                    <polyline points="1 9 7 14 15 4"/>
+                    <polyline points="1 9 7 14 15 4" />
                   </svg>
                 </div>
                 Include a project details coversheet
@@ -186,7 +177,7 @@ const ProjectsProjectPlanDownloadPage: React.FC = () => {
               >
                 <div className={"checkbox"}>
                   <svg viewBox="0 0 18 18" aria-hidden="true">
-                    <polyline points="1 9 7 14 15 4"/>
+                    <polyline points="1 9 7 14 15 4" />
                   </svg>
                 </div>
                 Include the section headings
@@ -202,7 +193,7 @@ const ProjectsProjectPlanDownloadPage: React.FC = () => {
               >
                 <div className={"checkbox"}>
                   <svg viewBox="0 0 18 18" aria-hidden="true">
-                    <polyline points="1 9 7 14 15 4"/>
+                    <polyline points="1 9 7 14 15 4" />
                   </svg>
                 </div>
                 Include the question text
@@ -218,7 +209,7 @@ const ProjectsProjectPlanDownloadPage: React.FC = () => {
               >
                 <div className={"checkbox"}>
                   <svg viewBox="0 0 18 18" aria-hidden="true">
-                    <polyline points="1 9 7 14 15 4"/>
+                    <polyline points="1 9 7 14 15 4" />
                   </svg>
                 </div>
                 Include any unanswered questions
@@ -234,7 +225,7 @@ const ProjectsProjectPlanDownloadPage: React.FC = () => {
               >
                 <div className={"checkbox"}>
                   <svg viewBox="0 0 18 18" aria-hidden="true">
-                    <polyline points="1 9 7 14 15 4"/>
+                    <polyline points="1 9 7 14 15 4" />
                   </svg>
                 </div>
                 Remove HTML tags


### PR DESCRIPTION
## Description

Fixed bug that was breaking the build.  The fix was in `/projects/[projectId]/dmp/[dmpId]/download` because of the unused `FileIcon` variable.

Fixes # ([376](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/376))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested that build now passes


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules