### PR TITLE
Explicitly updated nextJS version to 14.2.25 due to an Authorization …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Updated
 - Explicitly updated nextJS version to 14.2.25 due to an Authorization Bypass vulnerability in middleware (CVE-2025-29927) [#388]
+- Added `white-space: pre-wrap` for Prosemirror due to warnings [#388]
 - Update `Edit Member Details` page. Added mutation and queries, translations, and unit test [#367]
 - Updated `PlanCreate` component so that it hooks up to real data. The functionality of the page is a little complicated, so I added a `CreatePlan.md` file to summarize what functionality is expected in the page. [#361]
 - Updated the `Project Members` page with real data [#360]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 - 
 ### Added
 - Add central "named routes" and helper function
-
-### Added
 - Project Create Flow [#299]
 - Project Upload [#299]
 - Project Funder [#299]
@@ -25,6 +23,7 @@
 - QuestionPreview component [#224]
 
 ### Updated
+- Explicitly updated nextJS version to 14.2.25 due to an Authorization Bypass vulnerability in middleware (CVE-2025-29927) [#388]
 - Update `Edit Member Details` page. Added mutation and queries, translations, and unit test [#367]
 - Updated `PlanCreate` component so that it hooks up to real data. The functionality of the page is a little complicated, so I added a `CreatePlan.md` file to summarize what functionality is expected in the page. [#361]
 - Updated the `Project Members` page with real data [#360]

--- a/components/Editor/editor.module.scss
+++ b/components/Editor/editor.module.scss
@@ -18,6 +18,7 @@
     overflow-y: auto;
     border-radius: 0 0 5px 5px;
     border: 2px solid var(--gray-100);
+    white-space: pre-wrap;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jose": "^5.6.2",
         "jsonwebtoken": "^9.0.2",
         "loglevel": "^1.9.1",
-        "next": "^14.2.22",
+        "next": "^14.2.25",
         "next-intl": "^3.23.5",
         "pino": "^7.0.0",
         "pino-pretty": "^11.0.0",
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.13.4",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.4.tgz",
-      "integrity": "sha512-Ot3RaN2M/rhIKDqXBdOVlN0dQbHydUrYJ9lTxkvd6x7W1pAjwduUccfoz2gsO4U9by7oWtRj/ySF0MFNUp+9Aw==",
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.5.tgz",
+      "integrity": "sha512-ceHa1lApLAiGmUur4V+G/CrjwVwHYujfB7U5HM++poCgHpfGn6eet8YGM93fgeWjYX85SaqwdZbQk18IVwhRHg==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -1422,57 +1422,57 @@
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
     },
     "node_modules/@fontsource/material-symbols-outlined": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-symbols-outlined/-/material-symbols-outlined-5.2.7.tgz",
-      "integrity": "sha512-rzdqi+MsR4QB0D4tb7/oFDyGpVZrmVgVvoby8kNfrbCVbQtvfwQ3lXkLHzuGKU/M+NGb2GUXTizf6V3zo2REBg==",
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-symbols-outlined/-/material-symbols-outlined-5.2.8.tgz",
+      "integrity": "sha512-wSieV92VAeBudYjUt2cOjZ1QH6ClXVrCiGfqtpMhlkGUu7K9+0sXR73FrPo19IWI+XpAMekV/nqu1fakP7m2fQ==",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.3.tgz",
-      "integrity": "sha512-pJT1OkhplSmvvr6i3CWTPvC/FGC06MbN5TNBfRO6Ox62AEz90eMq+dVvtX9Bl3jxCEkS0tATzDarRZuOLw7oFg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
       "dependencies": {
-        "@formatjs/fast-memoize": "2.2.6",
-        "@formatjs/intl-localematcher": "0.6.0",
-        "decimal.js": "10",
-        "tslib": "2"
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.6.tgz",
-      "integrity": "sha512-luIXeE2LJbQnnzotY1f2U2m7xuQNj2DA8Vq4ce1BY9ebRZaoPB1+8eZ6nXpLzsxuW5spQxr7LdCg+CApZwkqkw==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
       "dependencies": {
-        "tslib": "2"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.1.tgz",
-      "integrity": "sha512-o0AhSNaOfKoic0Sn1GkFCK4MxdRsw7mPJ5/rBpIqdvcC7MIuyUSW8WChUEvrK78HhNpYOgqCQbINxCTumJLzZA==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.3",
-        "@formatjs/icu-skeleton-parser": "1.8.13",
-        "tslib": "2"
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.13",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.13.tgz",
-      "integrity": "sha512-N/LIdTvVc1TpJmMt2jVg0Fr1F7Q1qJPdZSCs19unMskCmVQ/sa0H9L8PWt13vq+gLdLg1+pPsvBLydL1Apahjg==",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.3",
-        "tslib": "2"
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.0.tgz",
-      "integrity": "sha512-4rB4g+3hESy1bHSBG3tDFaMY2CH67iT7yne1e+0CLTsGLDcmoEWWpJjjpWVaYgYfYuohIRuo0E+N536gd2ZHZA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
       "dependencies": {
-        "tslib": "2"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
@@ -2139,12 +2139,12 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.13.tgz",
-      "integrity": "sha512-CgxmfhMv/QYsZMKhmMOMLM5pt/8VaH/fbgebn/9eHQ5nik3qC5U3GD/mHh6Udxz29Rt0UdmHPH2Wo29+pIgsLg==",
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.14.tgz",
+      "integrity": "sha512-B7qDM/n4lBLfJ2Cd74PAt0OMoJq1hRrVVKMfw9i4+RZ8RNgzmspGZIZx4HHnsCGQ4/rUQLCeDCjL1oY4x+0K8g==",
       "dependencies": {
         "@graphql-tools/utils": "^10.8.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
+        "@whatwg-node/promise-helpers": "^1.2.5",
         "dataloader": "^2.2.3",
         "tslib": "^2.8.1"
       },
@@ -2174,16 +2174,16 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "10.2.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.14.tgz",
-      "integrity": "sha512-s0m5ArQQS66IXnKjegIpNkevt9Md5LhDL55xwFSHttJYgo31PT5N6Z/PWvaOj7OKuGZLzua4rJOAzdfA9YRlhA==",
+      "version": "10.2.15",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.15.tgz",
+      "integrity": "sha512-4qwgzt2VDXHZ+I0xUuZ1BCGu1Wn/QqYwz75fdj71J8VzHj0Zu4Kl4Ka59hoPdG+wq4ekW27MXvFhKmVISq02cw==",
       "dependencies": {
-        "@graphql-tools/batch-execute": "^9.0.13",
+        "@graphql-tools/batch-execute": "^9.0.14",
         "@graphql-tools/executor": "^1.3.10",
         "@graphql-tools/schema": "^10.0.11",
         "@graphql-tools/utils": "^10.8.1",
         "@repeaterjs/repeater": "^3.0.6",
-        "@whatwg-node/promise-helpers": "^1.0.0",
+        "@whatwg-node/promise-helpers": "^1.2.5",
         "dataloader": "^2.2.3",
         "dset": "^3.1.2",
         "tslib": "^2.8.1"
@@ -2245,9 +2245,9 @@
       }
     },
     "node_modules/@graphql-tools/executor-graphql-ws": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.4.tgz",
-      "integrity": "sha512-FRNAFqHPOaiGqtc4GcXzGTOpJx01BK3CPtblTaUE90aauZIYU/P3/3z8TvakHL6k05dVq78nNxBBhgTA2hnFOA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.5.tgz",
+      "integrity": "sha512-gI/D9VUzI1Jt1G28GYpvm5ckupgJ5O8mi5Y657UyuUozX34ErfVdZ81g6oVcKFQZ60LhCzk7jJeykK48gaLhDw==",
       "dependencies": {
         "@graphql-tools/executor-common": "^0.0.4",
         "@graphql-tools/utils": "^10.8.1",
@@ -2265,16 +2265,16 @@
       }
     },
     "node_modules/@graphql-tools/executor-http": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.0.tgz",
-      "integrity": "sha512-0NVrpUTvPRuvD5txm494xBJuxIHStYAuL9y6cURrJ0YCX6TpwmVhY8jFFAs67GAEDgVuOTq/BxRDoKMo6j0EAg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.1.tgz",
+      "integrity": "sha512-Fg0/EZKdzMKMn4cnoFcYUn6udsOgmCZIC2h2xQVLkvIkaYv2fT53RXBKBUoxNaX+VDg6zKysh19ZJqjC2+K0cg==",
       "dependencies": {
         "@graphql-tools/executor-common": "^0.0.4",
         "@graphql-tools/utils": "^10.8.1",
         "@repeaterjs/repeater": "^3.0.4",
         "@whatwg-node/disposablestack": "^0.0.6",
         "@whatwg-node/fetch": "^0.10.4",
-        "@whatwg-node/promise-helpers": "^1.0.0",
+        "@whatwg-node/promise-helpers": "^1.2.5",
         "meros": "^1.2.1",
         "tslib": "^2.8.1"
       },
@@ -2564,14 +2564,14 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "10.0.32",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.32.tgz",
-      "integrity": "sha512-IQRzsmT5Q/NJW9zS+Vz9KClGckbJ7Qz71pDhENuk/pQAY9RLMM58Z+3AtXJFfXg0pCA9m6IZ8nu54UrrbY1jfQ==",
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.33.tgz",
+      "integrity": "sha512-pFF439LHkRhdFOAbVewgfFFzeA502NM4mqs4z1Lq5eMNdVlV/nAFgAzd0ocAyHBPG8ife3NixdJR8DO+UAZUoQ==",
       "dependencies": {
-        "@graphql-tools/delegate": "^10.2.14",
+        "@graphql-tools/delegate": "^10.2.15",
         "@graphql-tools/schema": "^10.0.11",
         "@graphql-tools/utils": "^10.8.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
+        "@whatwg-node/promise-helpers": "^1.2.5",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -7601,9 +7601,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
-      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "version": "20.17.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.27.tgz",
+      "integrity": "sha512-U58sbKhDrthHlxHRJw7ZLiLDZGmAUOZUbpw0S6nL27sYUdhvgBLCRu/keSd6qcTsfArd1sRFCCBxzWATGr/0UA==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -7644,9 +7644,9 @@
       "integrity": "sha512-7d6OQK6pJ//zE32XLK3vI6GHYhBDcYooaRco9cKFGNu59GVatL5+u7rkiAViq44DxDTd/7QQNBWSDHfJGBz/Pw=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "version": "18.3.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
+      "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -7978,9 +7978,9 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "node_modules/@unrs/rspack-resolver-binding-darwin-arm64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-arm64/-/rspack-resolver-binding-darwin-arm64-1.2.1.tgz",
-      "integrity": "sha512-xgSjy64typsn/lhQk/uKaS363H7ZeIBlWSh25FJFWXSCeLMHpEZ0umDo5Vzqi5iS26OZ5R1SpQkwiS78GhQRjw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-arm64/-/rspack-resolver-binding-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha512-i7z0B+C0P8Q63O/5PXJAzeFtA1ttY3OR2VSJgGv18S+PFNwD98xHgAgPOT1H5HIV6jlQP8Avzbp09qxJUdpPNw==",
       "cpu": [
         "arm64"
       ],
@@ -7991,9 +7991,9 @@
       ]
     },
     "node_modules/@unrs/rspack-resolver-binding-darwin-x64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-x64/-/rspack-resolver-binding-darwin-x64-1.2.1.tgz",
-      "integrity": "sha512-3maDtW0vehzciEbuLxc2g+0FmDw5LGfCt+yMN1ZDn0lW0ikEBEFp6ul3h2fRphtfuCc7IvBJE9WWTt1UHkS7Nw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-x64/-/rspack-resolver-binding-darwin-x64-1.2.2.tgz",
+      "integrity": "sha512-YEdFzPjIbDUCfmehC6eS+AdJYtFWY35YYgWUnqqTM2oe/N58GhNy5yRllxYhxwJ9GcfHoNc6Ubze1yjkNv+9Qg==",
       "cpu": [
         "x64"
       ],
@@ -8004,9 +8004,9 @@
       ]
     },
     "node_modules/@unrs/rspack-resolver-binding-freebsd-x64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-freebsd-x64/-/rspack-resolver-binding-freebsd-x64-1.2.1.tgz",
-      "integrity": "sha512-aN6ifws9rNLjK2+6sIU9wvHyjXEf3S5+EZTHRarzd4jfa8i5pA7Mwt28un2DZVrBtIxhWDQvUPVKGI7zSBfVCA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-freebsd-x64/-/rspack-resolver-binding-freebsd-x64-1.2.2.tgz",
+      "integrity": "sha512-TU4ntNXDgPN2giQyyzSnGWf/dVCem5lvwxg0XYvsvz35h5H19WrhTmHgbrULMuypCB3aHe1enYUC9rPLDw45mA==",
       "cpu": [
         "x64"
       ],
@@ -8017,9 +8017,9 @@
       ]
     },
     "node_modules/@unrs/rspack-resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm-gnueabihf/-/rspack-resolver-binding-linux-arm-gnueabihf-1.2.1.tgz",
-      "integrity": "sha512-tKqu9VQyCO1yEUX6n6jgOHi7SJA9e6lvHczK60gur4VBITxnPmVYiCj2aekrOOIavvvjjuWAL2rqPQuc4g7RHQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm-gnueabihf/-/rspack-resolver-binding-linux-arm-gnueabihf-1.2.2.tgz",
+      "integrity": "sha512-ik3w4/rU6RujBvNWiDnKdXi1smBhqxEDhccNi/j2rHaMjm0Fk49KkJ6XKsoUnD2kZ5xaMJf9JjailW/okfUPIw==",
       "cpu": [
         "arm"
       ],
@@ -8030,9 +8030,9 @@
       ]
     },
     "node_modules/@unrs/rspack-resolver-binding-linux-arm64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-gnu/-/rspack-resolver-binding-linux-arm64-gnu-1.2.1.tgz",
-      "integrity": "sha512-+xDI0kvwPiCR7334O83TPfaUXSe0UMVi5srQpQxP4+SDVYuONWsbwAC1IXe+yfOwRVGZsUdW9wE0ZiWs4Z+egw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-gnu/-/rspack-resolver-binding-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha512-fp4Azi8kHz6TX8SFmKfyScZrMLfp++uRm2srpqRjsRZIIBzH74NtSkdEUHImR4G7f7XJ+sVZjCc6KDDK04YEpQ==",
       "cpu": [
         "arm64"
       ],
@@ -8043,9 +8043,9 @@
       ]
     },
     "node_modules/@unrs/rspack-resolver-binding-linux-arm64-musl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-musl/-/rspack-resolver-binding-linux-arm64-musl-1.2.1.tgz",
-      "integrity": "sha512-fcrVHlw+6UgQliMbI0znFD4ASWKuyY17FdH67ZmyNH62b0hRhhxQuJE0D6N3410m8lKVu4QW4EzFiHxYFUC0cg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-musl/-/rspack-resolver-binding-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha512-gMiG3DCFioJxdGBzhlL86KcFgt9HGz0iDhw0YVYPsShItpN5pqIkNrI+L/Q/0gfDiGrfcE0X3VANSYIPmqEAlQ==",
       "cpu": [
         "arm64"
       ],
@@ -8056,9 +8056,9 @@
       ]
     },
     "node_modules/@unrs/rspack-resolver-binding-linux-x64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-gnu/-/rspack-resolver-binding-linux-x64-gnu-1.2.1.tgz",
-      "integrity": "sha512-xISTyUJ2PiAT4x9nlh8FdciDcdKbsatgK9qO7EEsILt9VB7Y1mHYGaszj3ouxfZnaKQ13WwW+dFLGxkZLP/WVg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-gnu/-/rspack-resolver-binding-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha512-n/4n2CxaUF9tcaJxEaZm+lqvaw2gflfWQ1R9I7WQgYkKEKbRKbpG/R3hopYdUmLSRI4xaW1Cy0Bz40eS2Yi4Sw==",
       "cpu": [
         "x64"
       ],
@@ -8069,9 +8069,9 @@
       ]
     },
     "node_modules/@unrs/rspack-resolver-binding-linux-x64-musl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-musl/-/rspack-resolver-binding-linux-x64-musl-1.2.1.tgz",
-      "integrity": "sha512-LE8EjE/iPlvSsFbZ6P9c0Jh5/pifAi03UYeXYwOnQqt1molKAPMB0R4kGWOM7dnDYaNgkk1MN9MOTCLsqe97Fw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-musl/-/rspack-resolver-binding-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha512-cHyhAr6rlYYbon1L2Ag449YCj3p6XMfcYTP0AQX+KkQo025d1y/VFtPWvjMhuEsE2lLvtHm7GdJozj6BOMtzVg==",
       "cpu": [
         "x64"
       ],
@@ -8082,9 +8082,9 @@
       ]
     },
     "node_modules/@unrs/rspack-resolver-binding-wasm32-wasi": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-wasm32-wasi/-/rspack-resolver-binding-wasm32-wasi-1.2.1.tgz",
-      "integrity": "sha512-XERT3B88+G55RgG96May8QvAdgGzHr8qtQ70cIdbuWTpIcA0I76cnxSZ8Qwx33y73jE5N/myX2YKDlFksn4z6w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-wasm32-wasi/-/rspack-resolver-binding-wasm32-wasi-1.2.2.tgz",
+      "integrity": "sha512-eogDKuICghDLGc32FtP+WniG38IB1RcGOGz0G3z8406dUdjJvxfHGuGs/dSlM9YEp/v0lEqhJ4mBu6X2nL9pog==",
       "cpu": [
         "wasm32"
       ],
@@ -8098,9 +8098,9 @@
       }
     },
     "node_modules/@unrs/rspack-resolver-binding-win32-arm64-msvc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-arm64-msvc/-/rspack-resolver-binding-win32-arm64-msvc-1.2.1.tgz",
-      "integrity": "sha512-I8OLI6JbmNx2E/SG8MOEuo/d6rNx8dwgL09rcItSMcP82v1oZ8AY8HNA+axxuxEH95nkb6MPJU09p63isDvzrA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-arm64-msvc/-/rspack-resolver-binding-win32-arm64-msvc-1.2.2.tgz",
+      "integrity": "sha512-7sWRJumhpXSi2lccX8aQpfFXHsSVASdWndLv8AmD8nDRA/5PBi8IplQVZNx2mYRx6+Bp91Z00kuVqpXO9NfCTg==",
       "cpu": [
         "arm64"
       ],
@@ -8111,9 +8111,9 @@
       ]
     },
     "node_modules/@unrs/rspack-resolver-binding-win32-x64-msvc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-x64-msvc/-/rspack-resolver-binding-win32-x64-msvc-1.2.1.tgz",
-      "integrity": "sha512-s5WvCljhFqiE3McvaD3lDIsQpmk7gEJRUHy1PRwLPzEB7snq9P2xQeqgzdjGhJQq62jBFz7NDy7NbMkocWr2pw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-x64-msvc/-/rspack-resolver-binding-win32-x64-msvc-1.2.2.tgz",
+      "integrity": "sha512-hewo/UMGP1a7O6FG/ThcPzSJdm/WwrYDNkdGgWl6M18H6K6MSitklomWpT9MUtT5KGj++QJb06va/14QBC4pvw==",
       "cpu": [
         "x64"
       ],
@@ -8148,9 +8148,9 @@
       }
     },
     "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.13.tgz",
-      "integrity": "sha512-kbkLNDmPZ87tU8uItkuUXh/gtbS1YNvXASM7QI7pn2uNPkiIxjTEUc/Lfh6XrnmfGohZ1R2qs3SPuRtWUgLGpQ==",
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.14.tgz",
+      "integrity": "sha512-GMCUrFq3gXQSgWMnEBMaQUxh1rd1vi3Kp4MRQT6UKbnRycm4QmUSxp8ZIySxLQ96cpyBvonEH0BYmdQe/pWy8A==",
       "dependencies": {
         "@whatwg-node/disposablestack": "^0.0.6",
         "@whatwg-node/promise-helpers": "^1.2.5",
@@ -9255,9 +9255,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001706",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz",
-      "integrity": "sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==",
+      "version": "1.0.30001707",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
+      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
       "funding": [
         {
           "type": "opencollective",
@@ -10668,9 +10668,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.120",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.120.tgz",
-      "integrity": "sha512-oTUp3gfX1gZI+xfD2djr2rzQdHCwHzPQrrK0CD7WpTdF0nPdQ/INcRVjWgLdCT4a9W3jFObR9DAfsuyFQnI8CQ=="
+      "version": "1.5.123",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.123.tgz",
+      "integrity": "sha512-refir3NlutEZqlKaBLK0tzlVLe5P2wDKS7UQt/3SpibizgsRAPOsqQC3ffw1nlv3ze5gjRQZYHoPymgVZkplFA=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -12981,14 +12981,14 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.7.15",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.15.tgz",
-      "integrity": "sha512-LRyExsEsefQSBjU2p47oAheoKz+EOJxSLDdjOaEjdriajfHsMXOmV/EhMvYSg9bAgCUHasuAC+mcUBe/95PfIg==",
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.3",
-        "@formatjs/fast-memoize": "2.2.6",
-        "@formatjs/icu-messageformat-parser": "2.11.1",
-        "tslib": "2"
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/invariant": {
@@ -15822,9 +15822,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.10.tgz",
-      "integrity": "sha512-vSJJTG+t/dIKAUhUDw/dLdZ9s//5OxcHqLaDWWrW4Cdq7o6tdLIczUkMXt2MBNmk6sJRZBZRXVixs7URY1CmIg==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
@@ -17933,25 +17933,25 @@
       }
     },
     "node_modules/rspack-resolver": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rspack-resolver/-/rspack-resolver-1.2.1.tgz",
-      "integrity": "sha512-yTaWGUvHOjcoyFMdVTdYt2nq2Hu8sw6ia3X9szloXFJlWLQZnQ9g/4TPhL3Bb3qN58Mkye8mFG7MCaKhya7fOw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rspack-resolver/-/rspack-resolver-1.2.2.tgz",
+      "integrity": "sha512-Fwc19jMBA3g+fxDJH2B4WxwZjE0VaaOL7OX/A4Wn5Zv7bOD/vyPZhzXfaO73Xc2GAlfi96g5fGUa378WbIGfFw==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/JounQin"
       },
       "optionalDependencies": {
-        "@unrs/rspack-resolver-binding-darwin-arm64": "1.2.1",
-        "@unrs/rspack-resolver-binding-darwin-x64": "1.2.1",
-        "@unrs/rspack-resolver-binding-freebsd-x64": "1.2.1",
-        "@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "1.2.1",
-        "@unrs/rspack-resolver-binding-linux-arm64-gnu": "1.2.1",
-        "@unrs/rspack-resolver-binding-linux-arm64-musl": "1.2.1",
-        "@unrs/rspack-resolver-binding-linux-x64-gnu": "1.2.1",
-        "@unrs/rspack-resolver-binding-linux-x64-musl": "1.2.1",
-        "@unrs/rspack-resolver-binding-wasm32-wasi": "1.2.1",
-        "@unrs/rspack-resolver-binding-win32-arm64-msvc": "1.2.1",
-        "@unrs/rspack-resolver-binding-win32-x64-msvc": "1.2.1"
+        "@unrs/rspack-resolver-binding-darwin-arm64": "1.2.2",
+        "@unrs/rspack-resolver-binding-darwin-x64": "1.2.2",
+        "@unrs/rspack-resolver-binding-freebsd-x64": "1.2.2",
+        "@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "1.2.2",
+        "@unrs/rspack-resolver-binding-linux-arm64-gnu": "1.2.2",
+        "@unrs/rspack-resolver-binding-linux-arm64-musl": "1.2.2",
+        "@unrs/rspack-resolver-binding-linux-x64-gnu": "1.2.2",
+        "@unrs/rspack-resolver-binding-linux-x64-musl": "1.2.2",
+        "@unrs/rspack-resolver-binding-wasm32-wasi": "1.2.2",
+        "@unrs/rspack-resolver-binding-win32-arm64-msvc": "1.2.2",
+        "@unrs/rspack-resolver-binding-win32-x64-msvc": "1.2.2"
       }
     },
     "node_modules/run-async": {
@@ -18079,9 +18079,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanitize-html": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.14.0.tgz",
-      "integrity": "sha512-CafX+IUPxZshXqqRaG9ZClSlfPVjSxI0td7n07hk8QO2oO+9JDnlcL8iM8TWeOXOIBFgIOx6zioTzM53AOMn3g==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.15.0.tgz",
+      "integrity": "sha512-wIjst57vJGpLyBP8ioUbg6ThwJie5SuSIjHxJg53v5Fg+kUK+AXlb7bK3RNXpp315MvwM+0OBGCV6h5pPHsVhA==",
       "dev": true,
       "dependencies": {
         "deepmerge": "^4.2.2",
@@ -19146,21 +19146,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.84",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.84.tgz",
-      "integrity": "sha512-aRGIbCIF3teodtUFAYSdQONVmDRy21REM3o6JnqWn5ZkQBJJ4gHxhw6OfwQ+WkSAi3ASamrS4N4nyazWx6uTYg==",
+      "version": "6.1.85",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.85.tgz",
+      "integrity": "sha512-gBdZ1RjCSevRPFix/hpaUWeak2/RNUZB4/8frF1r5uYMHjFptkiT0JXIebWvgI/0ZHXvxaUDDJshiA0j6GdL3w==",
       "dev": true,
       "dependencies": {
-        "tldts-core": "^6.1.84"
+        "tldts-core": "^6.1.85"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.84",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.84.tgz",
-      "integrity": "sha512-NaQa1W76W2aCGjXybvnMYzGSM4x8fvG2AN/pla7qxcg0ZHbooOPhA8kctmOZUDfZyhDL27OGNbwAeig8P4p1vg==",
+      "version": "6.1.85",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.85.tgz",
+      "integrity": "sha512-DTjUVvxckL1fIoPSb3KE7ISNtkWSawZdpfxGxwiIrZoO6EbHVDXXUIlIuWympPaeS+BLGyggozX/HTMsRAdsoA==",
       "dev": true
     },
     "node_modules/tmp": {
@@ -19245,9 +19245,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.2.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.6.tgz",
-      "integrity": "sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==",
+      "version": "29.3.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.0.tgz",
+      "integrity": "sha512-4bfGBX7Gd1Aqz3SyeDS9O276wEU/BInZxskPrbhZLyv+c1wskDCqDFMJQJLWrIr/fKoAH4GE5dKUlrdyvo+39A==",
       "dev": true,
       "dependencies": {
         "bs-logger": "^0.2.6",
@@ -19258,6 +19258,7 @@
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
         "semver": "^7.7.1",
+        "type-fest": "^4.37.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -19302,6 +19303,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.38.0.tgz",
+      "integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-log": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jose": "^5.6.2",
     "jsonwebtoken": "^9.0.2",
     "loglevel": "^1.9.1",
-    "next": "^14.2.22",
+    "next": "^14.2.25",
     "next-intl": "^3.23.5",
     "pino": "^7.0.0",
     "pino-pretty": "^11.0.0",


### PR DESCRIPTION

## Description

Explicitly updated nextJS version to 14.2.25 due to an Authorization Bypass vulnerability in middleware (CVE-2025-29927)

According to the blog, we can fix the vulnerability by just patching to 14.2.25. Although we should just get that patch for free due to us using the `caret` in package.json for v14.2.22, I made an explicit update just in case.

Also, added `white-space: pre-wrap` due to a warning. It preserves spaces and line breaks.

Fixes # ([388](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/388))

## Type of change
- [X] Chore

## How Has This Been Tested?
Ran unit tests after the update and did manual testing of pages.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules