### PR TITLE
Added a script for running a typescript check to add to the pre-commi…

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 npm run lint
 npm test --coverage
+npm run type-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Plan Downloads [#299]
 - 
 ### Added
+- Added type check to pre-commit hook and fixed some issues in the app [#391]
 - Add central "named routes" and helper function
 - Project Create Flow [#299]
 - Project Upload [#299]

--- a/app/[locale]/login/__tests__/page.spec.tsx
+++ b/app/[locale]/login/__tests__/page.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor, } from '@/utils/test-utils';
+import { fireEvent, render, screen, waitFor, } from '@testing-library/react';
 import logECS from '@/utils/clientLogger';
 
 import LoginPage from '../page';
@@ -40,19 +40,6 @@ jest.mock('@/context/CsrfContext', () => ({
   useCsrf: jest.fn(),
 }));
 
-
-jest.mock('next-intl', () => ({
-  // useFormatter: jest.fn(() => ({
-  //   dateTime: jest.fn(() => '01-01-2023'),
-  // })),
-  useTranslations: jest.fn(() => (key) => {
-    const translations = {
-      "LoginPage.pageTitle": "Login",
-    };
-    return translations[key] || key;
-  }),
-  useLocale: jest.fn(() => 'en-US'),
-}));
 
 
 // Create a mock for scrollIntoView and focus

--- a/app/[locale]/projects/[projectId]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/__tests__/page.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {render, screen} from '@testing-library/react';
-import {useParams} from 'next/navigation';
-import {axe, toHaveNoViolations} from 'jest-axe';
-import {useProjectQuery} from '@/generated/graphql';
+import { render, screen } from '@testing-library/react';
+import { useParams } from 'next/navigation';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { useProjectQuery } from '@/generated/graphql';
 import ProjectOverviewPage from '../page';
-import {mockScrollIntoView, mockScrollTo} from "@/__mocks__/common";
+import { mockScrollIntoView, mockScrollTo } from "@/__mocks__/common";
 
 expect.extend(toHaveNoViolations);
 
@@ -23,7 +23,6 @@ jest.mock('next-intl', () => ({
     dateTime: jest.fn(() => '01-01-2023'),
   })),
   useTranslations: jest.fn(() => jest.fn((key) => key)), // Mock `useTranslations`,
-  useLocale: jest.fn(() => 'en-US'), // Return a default locale
 }));
 
 const mockProjectData = {

--- a/app/[locale]/projects/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/__tests__/page.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
-import {useMyProjectsQuery} from '@/generated/graphql';
-import {axe, toHaveNoViolations} from 'jest-axe';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useMyProjectsQuery } from '@/generated/graphql';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import ProjectsListPage from '../page';
-import {useFormatter, useTranslations} from 'next-intl';
-import {mockScrollIntoView, mockScrollTo} from "@/__mocks__/common";
+import { useFormatter, useTranslations } from 'next-intl';
+import { mockScrollIntoView, mockScrollTo } from "@/__mocks__/common";
 
 expect.extend(toHaveNoViolations);
 
@@ -72,7 +72,7 @@ describe('ProjectsListPage', () => {
     });
 
     (useTranslations as jest.Mock).mockImplementation((namespace) => {
-      return (key) => `${namespace}.${key}`;
+      return (key: string) => `${namespace}.${key}`;
     });
   });
 

--- a/app/[locale]/signup/__tests__/page.spec.tsx
+++ b/app/[locale]/signup/__tests__/page.spec.tsx
@@ -6,7 +6,6 @@ import logECS from '@/utils/clientLogger';
 //Need to import this useRouter after the jest.mock is in place
 import { useRouter } from 'next/navigation';
 import { fetchCsrfToken } from "@/utils/authHelper";
-import { useTranslations as OriginalUseTranslations } from 'next-intl';
 
 
 // Mock TypeAheadWithOther component
@@ -64,40 +63,6 @@ jest.mock('@/context/CsrfContext', () => ({
   ),
   useCsrf: jest.fn(),
 }));
-
-
-jest.mock('next-intl', () => ({
-  useTranslations: jest.fn(() => (key) => {
-    const translations = {
-      "LoginPage.pageTitle": "Login",
-    };
-    return translations[key] || key;
-  }),
-  useLocale: jest.fn(() => 'en-US'),
-}));
-
-
-// Mock useTranslations from next-intl
-type UseTranslationsType = ReturnType<typeof OriginalUseTranslations>;
-
-jest.mock('next-intl', () => ({
-  useTranslations: jest.fn(() => {
-    const mockUseTranslations: UseTranslationsType = ((key: string) => key) as UseTranslationsType;
-    /*eslint-disable @typescript-eslint/no-explicit-any */
-    mockUseTranslations.rich = (
-      key: string,
-      values?: Record<string, any>
-    ) => {
-      // Handle rich text formatting
-      if (values?.p) {
-        return values.p(key); // Simulate rendering the `p` tag function
-      }
-      return key;
-    };
-    return mockUseTranslations;
-  }),
-}));
-
 
 // Create a mock for scrollIntoView and focus
 const mockScrollIntoView = jest.fn();

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -1,10 +1,10 @@
 // template/[templateId]/section/page.tsx
 'use client';
 
-import React, {useEffect, useRef, useState} from 'react';
-import {useTranslations} from 'next-intl';
-import {useParams} from 'next/navigation';
-import {ApolloError} from "@apollo/client";
+import React, { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useParams } from 'next/navigation';
+import { ApolloError } from "@apollo/client";
 import {
   Breadcrumb,
   Breadcrumbs,
@@ -41,9 +41,9 @@ import AddQuestionButton from "@/components/AddQuestionButton";
 import AddSectionButton from "@/components/AddSectionButton";
 import ErrorMessages from '@/components/ErrorMessages';
 
-import {useFormatDate} from '@/hooks/useFormatDate';
+import { useFormatDate } from '@/hooks/useFormatDate';
 import logECS from '@/utils/clientLogger';
-import {useToast} from '@/context/ToastContext';
+import { useToast } from '@/context/ToastContext';
 import styles from './templateEditPage.module.scss';
 
 interface QuestionsInterface {
@@ -401,7 +401,9 @@ const TemplateEditPage: React.FC = () => {
       </div>
 
 
-      <Modal isDismissable
+      <Modal
+        isDismissable
+        onOpenChange={setPublishModalOpen}
         isOpen={isPublishModalOpen}
         data-testid="modal"
       >

--- a/components/ErrorMessages/index.tsx
+++ b/components/ErrorMessages/index.tsx
@@ -14,16 +14,28 @@ const ErrorMessages = forwardRef<HTMLDivElement, ErrorMessagesProps>(
       }
     }, [errors, ref]);
 
-    if (!errors || Object.keys(errors).length === 0) return null;
+
+    // Filter out empty or invalid errors
+    const hasValidErrors = (): boolean => {
+      if (Array.isArray(errors)) {
+        return errors.some((error) => error && error.trim() !== "");
+      }
+
+      return Object.values(errors).some((error) => error && error.trim() !== "");
+    };
+
+    if (!errors || !hasValidErrors()) return null;
 
     const renderErrors = (): ReactNode => {
       if (Array.isArray(errors)) {
-        return errors.map((error, index) => error && <p key={index}>{error}</p>);
+        return errors
+          .filter((error) => error && error.trim() !== "")
+          .map((error, index) => <p key={index}>{error}</p>);
       }
 
-      return Object.entries(errors).map(([key, error]) =>
-        error ? <p key={key}>{error}</p> : null
-      );
+      return Object.entries(errors)
+        .filter(([_, error]) => error && error.trim() !== "")
+        .map(([key, error]) => <p key={key}>{error}</p>);
     };
 
     return (

--- a/components/Form/FormSelect/__tests__/index.spec.tsx
+++ b/components/Form/FormSelect/__tests__/index.spec.tsx
@@ -21,13 +21,13 @@ describe('FormSelect', () => {
       {(item) => <MyItem key={item.id}>{item.name}</MyItem>}
     </FormSelect>);
     const container = getByTestId('hidden-select-container');
-    const select = container.querySelector('select');
+    const select = container.querySelector('select')!;
 
     // Find the option with text "Option 1"
     const option = Array.from(select.options).find(opt => opt.text === 'Option 1');
 
     expect(option).toBeTruthy();
-    expect(option.value).toBe('1');
+    expect(option?.value).toBe('1');
 
   });
 

--- a/components/Form/TypeAheadWithOther/index.tsx
+++ b/components/Form/TypeAheadWithOther/index.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import React, {useEffect, useRef, useState} from 'react';
-import {DocumentNode} from '@apollo/client';
+import React, { useEffect, useRef, useState } from 'react';
+import { DocumentNode } from '@apollo/client';
 import {
-  FieldError,
-  Input,
-  Label,
-  Text,
-  TextField,
+    FieldError,
+    Input,
+    Label,
+    Text,
+    TextField,
 } from "react-aria-components";
-import {createApolloClient} from '@/lib/graphql/client/apollo-client';
+import { createApolloClient } from '@/lib/graphql/client/apollo-client';
 import Spinner from '@/components/Spinner';
 import classNames from 'classnames';
 import styles from './typeaheadWithOther.module.scss';
@@ -237,7 +237,7 @@ const TypeAheadWithOther = ({
 
                 if (!signal.aborted) {
                     if (!resultsKey) {
-                      throw Error("'resultsKey' property is missing on typeahead field, please provide the key that contain the results data.");
+                        throw Error("'resultsKey' property is missing on typeahead field, please provide the key that contain the results data.");
                     }
                     setSuggestions(data[resultsKey]);
                     setOpen(true);
@@ -307,7 +307,6 @@ const TypeAheadWithOther = ({
                     autoComplete="off"
                 />
                 {/*<FieldError className={`${styles.errorMessage} react-aria-FieldError`}>{errorMessage}</FieldError>*/}
-                {error ? (<div className={styles.errorMessage}>{error}</div>) : <FieldError className={`${styles.errorMessage} react-aria-FieldError`}>{errorMessage}</FieldError>}
                 {helpText && (
                     <Text slot="description" className={styles.helpText}>
                         {helpText}

--- a/components/TypeAheadInput/__tests__/index.spec.tsx
+++ b/components/TypeAheadInput/__tests__/index.spec.tsx
@@ -35,6 +35,7 @@ describe('TypeAheadInput', () => {
     it('should render initial state correctly', () => {
         render(
             <TypeAheadInput
+                fieldName="institution"
                 graphqlQuery={GET_AFFILIATIONS}
                 label="Institution"
                 helpText="Search for an institution"
@@ -49,6 +50,7 @@ describe('TypeAheadInput', () => {
     it('should pass axe accessibility test', async () => {
         const { container } = render(
             <TypeAheadInput
+                fieldName="institution"
                 graphqlQuery={GET_AFFILIATIONS}
                 label="Institution"
                 helpText="Search for an institution"
@@ -72,6 +74,7 @@ describe('TypeAheadInput', () => {
 
         render(
             <TypeAheadInput
+                fieldName="institution"
                 graphqlQuery={GET_AFFILIATIONS}
                 label="Institution"
                 helpText="Search for an institution"
@@ -109,6 +112,7 @@ describe('TypeAheadInput', () => {
 
         render(
             <TypeAheadInput
+                fieldName="institution"
                 graphqlQuery={GET_AFFILIATIONS}
                 label="Institution"
                 helpText="Search for an institution"
@@ -136,6 +140,7 @@ describe('TypeAheadInput', () => {
 
         render(
             <TypeAheadInput
+                fieldName="institution"
                 graphqlQuery={GET_AFFILIATIONS}
                 label="Institution"
                 helpText="Search for an institution"
@@ -177,6 +182,7 @@ describe('TypeAheadInput', () => {
 
         render(
             <TypeAheadInput
+                fieldName="institution"
                 graphqlQuery={GET_AFFILIATIONS}
                 label="Institution"
                 helpText="Search for an institution"
@@ -217,6 +223,7 @@ describe('TypeAheadInput', () => {
 
         render(
             <TypeAheadInput
+                fieldName="institution"
                 graphqlQuery={GET_AFFILIATIONS}
                 label="Institution"
                 helpText="Search for an institution"
@@ -242,6 +249,7 @@ describe('TypeAheadInput', () => {
         });
         render(
             <TypeAheadInput
+                fieldName="institution"
                 graphqlQuery={GET_AFFILIATIONS}
                 label="Institution"
                 helpText="Search for an institution"

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -1160,8 +1160,10 @@ export type MutationUpdatePasswordArgs = {
 
 
 export type MutationUpdatePlanContributorArgs = {
+  contributorRoleIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  isPrimaryContact?: InputMaybe<Scalars['Boolean']['input']>;
   planContributorId: Scalars['Int']['input'];
-  roleIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  planId: Scalars['Int']['input'];
 };
 
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import { useTranslations as OriginalUseTranslations } from 'next-intl';
 import dotenv from 'dotenv';
 
 
@@ -13,28 +12,21 @@ jest.mock('@/context/ToastContext', () => ({
   })),
 }));
 
-// Mock the useTranslations hook
-type UseTranslationsType = ReturnType<typeof OriginalUseTranslations>;
-
-jest.mock('next-intl', () => ({
-  useTranslations: jest.fn(() => {
-    const mockUseTranslations: UseTranslationsType = ((key: string) => key) as UseTranslationsType;
-
-    /*eslint-disable @typescript-eslint/no-explicit-any */
-    mockUseTranslations.rich = (
-      key: string,
-      values?: Record<string, any>
-    ) => {
-      // Handle rich text formatting
-      if (values?.p) {
-        return values.p(key); // Simulate rendering the `p` tag function
-      }
-      return key;
-    };
-
-    return mockUseTranslations;
-  }),
-}));
+jest.mock('next-intl', () => {
+  return {
+    useTranslations: jest.fn(() => {
+      const mockUseTranslations = (key: string) => key;
+      /*eslint-disable-next-line @typescript-eslint/no-explicit-any*/
+      mockUseTranslations.rich = (key: string, values?: Record<string, any>) => {
+        if (values?.p) {
+          return values.p(key);
+        }
+        return key;
+      };
+      return mockUseTranslations;
+    }),
+  };
+});
 
 // Mock the clientLogger
 jest.mock('@/utils/clientLogger', () => jest.fn());

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "clean-build": "rm -rf node_modules/.cache && rm -rf .next && next build",
     "start": "next start",
     "lint": "next lint && npx eslint .",
+    "type-check": "tsc --noEmit",
     "generate": "graphql-codegen --config codegen.ts",
     "prepare": "husky",
     "test": "jest --coverage",


### PR DESCRIPTION

## Description
We recently noticed that some typescript errors were not being caught by husky's pre-commit.

When we run `npm run build` there are some specific typescript error checks that happen, that don't happen with linting.

Added a script for running a typescript check to add to the pre-commit hook so that typescript errors will not be missed when pushing up changes.

- Added a `type-check` script to package.json
- Updated husky's pre-commit hook with the script.
- Fixed the typescript errors that were identified with the new script.

Fixes # ([391](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/391))

## Type of change
- [ ] Chore

## How Has This Been Tested?
Tested manually by going through template and projects flow, and by running existing unit tests.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules