### PR TITLE
Fixed missing 'as deps' in Dockerfile.prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - Removed unused component `EditQuestionPage` to avoid confusion with other components. This is a legacy component. [#379]
 
 ### Fixed
+- Fixed missing `as deps` in `Dockerfile.prod`.
 - Fixed wrong node image in `Dockerfile.prd`. Also fixed a number of linting issues.
 - Fixed bug in `/projects/[projectId]/dmp/[dmpId]/download` because of unused `FileIcon` [#376]
 - Fixed bug where `/template` page was continuosly refreshed when no data was returned [#351]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,6 +1,6 @@
 # Stage 1: Dependencies
 # preferred node version chosen here (Active LTS = 22 as of 10/2024)
-FROM public.ecr.aws/docker/library/node:22.1.0-alpine3.19
+FROM public.ecr.aws/docker/library/node:22.1.0-alpine3.19 as deps
 WORKDIR /app
 
 # Copy package.json and package-lock.json


### PR DESCRIPTION
## Description

Pipeline build failed again. This time I made sure to test that I could build `docker build -f Dockerfile.prod -t test-image .`, and it worked when I added back the missing `as deps`.