### PR TITLE
Add change title functionality on Template Overview page

### DIFF
--- a/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
@@ -1,25 +1,27 @@
 import React from "react";
-import {act, fireEvent, render, screen, waitFor} from '@/utils/test-utils';
+import { act, fireEvent, render, screen, waitFor } from '@/utils/test-utils';
 import {
   useArchiveTemplateMutation,
   useCreateTemplateVersionMutation,
-  useTemplateQuery
+  useTemplateQuery,
 } from '@/generated/graphql';
 
-import {useParams} from 'next/navigation';
+import { useParams } from 'next/navigation';
 import TemplateEditPage from '../page';
-import {mockScrollIntoView, mockScrollTo} from "@/__mocks__/common";
+import { mockScrollIntoView, mockScrollTo } from "@/__mocks__/common";
 
 // Mock the useTemplateQuery hook
 jest.mock("@/generated/graphql", () => ({
   useTemplateQuery: jest.fn(),
   useArchiveTemplateMutation: jest.fn(),
   useCreateTemplateVersionMutation: jest.fn(),
-  TemplateVersionType: { Draft: 'DRAFT', Published: 'PUBLISHED' }
+  TemplateVersionType: { Draft: 'DRAFT', Published: 'PUBLISHED' },
+  TemplateVisibility: { Private: 'PRIVATE', Public: 'PUBLIC' },
 }));
 
 jest.mock('next/navigation', () => ({
   useParams: jest.fn(),
+  useRouter: jest.fn()
 }))
 
 // Mock useFormatter and useTranslations from next-intl

--- a/app/[locale]/template/[templateId]/actions/index.tsx
+++ b/app/[locale]/template/[templateId]/actions/index.tsx
@@ -1,0 +1,1 @@
+export { updateTemplateAction } from './updateTemplateAction';

--- a/app/[locale]/template/[templateId]/actions/updateTemplateAction.ts
+++ b/app/[locale]/template/[templateId]/actions/updateTemplateAction.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { executeGraphQLMutation } from "@/utils/graphqlServerActionHandler";
+import logger from "@/utils/server/logger";
+import { ActionResponse } from "@/app/types";
+import { UpdateTemplateDocument, TemplateVisibility } from "@/generated/graphql";
+
+export async function updateTemplateAction({
+  templateId,
+  name,
+  visibility,
+  bestPractice
+}: {
+  templateId: number;
+  name: string;
+  bestPractice: boolean;
+  visibility: TemplateVisibility;
+}): Promise<ActionResponse> {
+  try {
+    // Execute the mutation using the shared handler
+    return executeGraphQLMutation({
+      document: UpdateTemplateDocument,
+      variables: { templateId, name, visibility, bestPractice },
+      dataPath: "updateTemplate"
+    });
+
+  } catch (error) {
+    logger.error(`[Update Template Error]: ${error}`, { error });
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
+}

--- a/app/[locale]/template/[templateId]/actions/updateTemplateAction.ts
+++ b/app/[locale]/template/[templateId]/actions/updateTemplateAction.ts
@@ -9,18 +9,16 @@ export async function updateTemplateAction({
   templateId,
   name,
   visibility,
-  bestPractice
 }: {
   templateId: number;
   name: string;
-  bestPractice: boolean;
   visibility: TemplateVisibility;
 }): Promise<ActionResponse> {
   try {
     // Execute the mutation using the shared handler
     return executeGraphQLMutation({
       document: UpdateTemplateDocument,
-      variables: { templateId, name, visibility, bestPractice },
+      variables: { templateId, name, visibility },
       dataPath: "updateTemplate"
     });
 

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -295,6 +295,10 @@ const TemplateEditPage: React.FC = () => {
     return <div>{EditTemplate('errors.noTemplateFound')}</div>;
   }
 
+  // Format the latest publish date if it exists
+  const formattedPublishDate = template.latestPublishDate ? formatDate(template.latestPublishDate) : null;
+
+
   const sortedSections = template.sections
     ? sortSections(template.sections.filter((section): section is Section => section !== null))
     : [];
@@ -303,7 +307,7 @@ const TemplateEditPage: React.FC = () => {
     <div>
       <PageHeaderWithTitleChange
         title={newTitle || template.name}
-        description={`by ${template.owner?.displayName} - Version: ${template.latestPublishVersion} - Published: ${formatDate(template.latestPublishDate)}`}
+        description={`by ${template?.name} - ${Global('version')}: ${template?.latestPublishVersion} - ${Global('lastUpdated')}: ${formattedPublishDate || template?.latestPublishDate}`}
         showBackButton={false}
         breadcrumbs={
           <Breadcrumbs>
@@ -370,20 +374,22 @@ const TemplateEditPage: React.FC = () => {
 
             </div>
 
-            <div className="sidebar-section">
-              <h5 className="sidebar-section-title">{EditTemplate('button.publishTemplate')}</h5>
-              <div className="status">
-                <p>
-                  {EditTemplate('draft')} <Link href='#' onPress={() => setPublishModalOpen(true)}>{EditTemplate('links.edit')}</Link>
-                </p>
+            {template.isDirty && (
+              <div className="sidebar-section">
+                <h5 className="sidebar-section-title">{EditTemplate('button.publishTemplate')}</h5>
+                <div className="status">
+                  <p>
+                    {EditTemplate('draft')} <Link href='#' onPress={() => setPublishModalOpen(true)}>{EditTemplate('links.edit')}</Link>
+                  </p>
+                </div>
               </div>
-            </div>
+            )}
 
             <div className="sidebar-section">
               <h5 className="sidebar-section-title">{EditTemplate('heading.visibilitySettings')}</h5>
               <div className="status">
                 <p>
-                  {EditTemplate('notPublished')}{' '}<Link href='#' onPress={() => setPublishModalOpen(true)}>{EditTemplate('links.edit')}</Link>
+                  {template.isDirty ? EditTemplate('notPublished') : EditTemplate('published')}{' '}<Link href='#' onPress={() => setPublishModalOpen(true)}>{EditTemplate('links.edit')}</Link>
                 </p>
               </div>
             </div>

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -302,8 +302,6 @@ const TemplateEditPage: React.FC = () => {
         newTitle={newTitle}
       />
 
-
-
       {pageErrors.length > 0 && (
         <div className="error" role="alert" aria-live="assertive" ref={pageErrorRef}>
           {pageErrors.map((error, index) => (

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -1,9 +1,8 @@
-// template/[templateId]/section/page.tsx
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { ApolloError } from "@apollo/client";
 import {
   Breadcrumb,
@@ -24,7 +23,6 @@ import {
 } from 'react-aria-components';
 
 import {
-  Question,
   Section,
   TemplateVersionType,
   TemplateVisibility,
@@ -36,61 +34,37 @@ import {
 // Components
 import SectionHeaderEdit from "@/components/SectionHeaderEdit";
 import QuestionEditCard from "@/components/QuestionEditCard";
-import PageHeader from "@/components/PageHeader";
+import PageHeaderWithTitleChange from "@/components/PageHeaderWithTitleChange";
 import AddQuestionButton from "@/components/AddQuestionButton";
 import AddSectionButton from "@/components/AddSectionButton";
 import ErrorMessages from '@/components/ErrorMessages';
+import { FormInput } from '@/components/Form';
 
 import { useFormatDate } from '@/hooks/useFormatDate';
 import logECS from '@/utils/clientLogger';
 import { useToast } from '@/context/ToastContext';
+import { routePath } from '@/utils/routes';
+import { updateTemplateAction } from './actions';
 import styles from './templateEditPage.module.scss';
-
-interface QuestionsInterface {
-  displayOrder?: number | null;
-  guidanceText?: string | null;
-  id?: number | null;
-  questionText: string | null | undefined;
-}
-
-interface SectionInterface {
-  id?: number | null;
+interface TemplateInfoInterface {
+  templateId: number | null;
   name: string;
-  displayOrder?: number | null;
-  questions?: QuestionsInterface[] | null;
+  visibility: TemplateVisibility;
+  bestPracice: boolean;
 }
-
-interface OwnerInterface {
-  displayName: string;
-  id: number;
-}
-interface TemplateEditPageInterface {
-  name: string;
-  description?: string | null;
-  latestPublishVersion?: string | null;
-  latestPublishDate?: string | null;
-  created?: string | null;
-  sections?: SectionInterface[] | null;
-  owner: OwnerInterface
-}
-
-
 const TemplateEditPage: React.FC = () => {
   const [isPublishModalOpen, setPublishModalOpen] = useState(false);
-  const toastState = useToast(); // Access the toast state from context
-  const [template, setTemplate] = useState<TemplateEditPageInterface>({
-    name: '',
-    description: null,
-    latestPublishVersion: null,
-    latestPublishDate: null,
-    created: null,
-    sections: [],
-    owner: { displayName: '', id: 0 },
-  });
-
-  // Errors returned from request
-  const [errors, setErrors] = useState<string[]>([]);
+  const toastState = useToast();
+  const [errorMessages, setErrorMessages] = useState<string[]>([]);
   const [pageErrors, setPageErrors] = useState<string[]>([]);
+  const [templateInfo, setTemplateInfoState] = useState<TemplateInfoInterface>({
+    templateId: null,
+    name: '',
+    visibility: TemplateVisibility.Private,
+    bestPracice: false
+  });
+  const [isEditing, setIsEditing] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
   const formatDate = useFormatDate();
 
   // localization keys
@@ -102,7 +76,10 @@ const TemplateEditPage: React.FC = () => {
 
   // Get templateId param
   const params = useParams();
-  const { templateId } = params; // From route /template/:templateId
+  const router = useRouter();
+  //const { templateId } = params; // From route /template/:templateId
+  const templateId = String(params.templateId);
+
   //For scrolling to error in modal window
   const errorRef = useRef<HTMLDivElement | null>(null);
 
@@ -114,7 +91,7 @@ const TemplateEditPage: React.FC = () => {
   const [archiveTemplateMutation] = useArchiveTemplateMutation();
 
   // Run template query to get all templates under the given templateId
-  const { data, loading, error: templateQueryErrors } = useTemplateQuery(
+  const { data, loading, error: templateQueryErrors, refetch } = useTemplateQuery(
     {
       variables: { templateId: Number(templateId) },
       notifyOnNetworkStatusChange: true
@@ -124,30 +101,28 @@ const TemplateEditPage: React.FC = () => {
   const sortSections = (sections: Section[]) => {
     // Create a new array with the spread operator before sorting
     return [...sections].sort((a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0));
-  }
+  };
 
-  // Show Success Message
   const showSuccessToast = () => {
     const successMessage = Messaging('successfullyUpdated');
     toastState.add(successMessage, { type: 'success' });
-  }
+  };
 
-  // Archive current template
   const handleArchiveTemplate = async () => {
     try {
       await archiveTemplateMutation({
         variables: {
           templateId: Number(templateId),
         },
-      })
+      });
     } catch (err) {
       setPageErrors(prevErrors => [...prevErrors, EditTemplate('errors.archiveTemplateError')]);
       logECS('error', 'handleArchiveTemplate', {
         error: err,
         url: { path: '/template/[templateId]' }
       });
-    };
-  }
+    }
+  };
 
   // Save either 'DRAFT' or 'PUBLISHED' based on versionType passed into function
   const saveTemplate = async (versionType: TemplateVersionType, comment: string | undefined, visibility: TemplateVisibility) => {
@@ -159,7 +134,7 @@ const TemplateEditPage: React.FC = () => {
           versionType,
           visibility
         },
-      })
+      });
 
       if (response) {
         const responseErrors = response.data?.createTemplateVersion?.errors;
@@ -176,14 +151,14 @@ const TemplateEditPage: React.FC = () => {
         //close modal
         setPublishModalOpen(false);
       } else {
-        setErrors(prevErrors => [...prevErrors, EditTemplate('errors.saveTemplateError')]);
+        setErrorMessages(prevErrors => [...prevErrors, EditTemplate('errors.saveTemplateError')]);
         logECS('error', 'saveTemplate', {
           error: err,
           url: { path: '/template/[templateId]' }
         });
-      };
+      }
     }
-  }
+  };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -193,47 +168,89 @@ const TemplateEditPage: React.FC = () => {
 
     // Extract the selected radio button value, and make it upper case to match TemplateVisibility enum values
     const visibility = formData.get('visibility')?.toString().toUpperCase() as TemplateVisibility;
-    const changeLog = formData.get('change_log')?.toString(); // Extract the textarea value
+    const changeLog = formData.get('change_log')?.toString();
 
     await saveTemplate(TemplateVersionType.Published, changeLog, visibility);
   };
 
-  useEffect(() => {
-    // When data from backend changes, set template data in state
-    if (data && data.template) {
-      const sortedSections = data.template.sections
-        ? sortSections(data.template.sections.filter((section): section is Section => section !== null)) //Filter out null sections
-        : [];
-
-      setTemplate({
-        name: data.template.name ?? '',
-        description: data.template.description ?? null,
-        latestPublishVersion: data.template.latestPublishVersion ?? null,
-        latestPublishDate: formatDate(data.template.latestPublishDate) ?? null,
-        created: data.template.created ?? null,
-        sections: sortedSections.map((section) => ({
-          id: section.id,
-          name: section.name ?? '',
-          displayOrder: section.displayOrder,
-          questions: section.questions
-            ?.filter((question): question is Question => question !== null) // Filter out null
-            ?.map((question) => ({
-              errors: question.errors,
-              displayOrder: question.displayOrder,
-              guidanceText: question.guidanceText,
-              id: question.id,
-              questionText: question.questionText,
-            })),
-        })),
-        owner: {
-          displayName: data.template.owner?.displayName ?? '',
-          id: data.template.owner?.id ?? 0,
+  // Call Server Action updateTemplateAction
+  const updateTemplate = async (templateInfo: TemplateInfoInterface) => {
+    if (templateInfo.templateId === null) {
+      // Handle the case where templateId is null (e.g., log an error or return early)
+      logECS('error', 'updateTemplate', {
+        error: 'templateId is null',
+        url: {
+          path: routePath('template.show', { templateId: 'unknown' }),
         },
       });
+      return {
+        success: false,
+        errors: [Global('messaging.somethingWentWrong')],
+        data: null,
+      };
     }
-  }, [data]);
+    try {
+      const response = await updateTemplateAction({
+        templateId: templateInfo.templateId,
+        name: newTitle,
+        visibility: templateInfo.visibility,
+        bestPractice: templateInfo.bestPracice,
+      });
 
-  // If page-level errors that we need to scroll to
+      if (response.redirect) {
+        router.push(response.redirect);
+      }
+
+      return {
+        success: response.success,
+        errors: response.errors,
+        data: response.data
+      }
+    } catch (error) {
+      logECS('error', 'updateTemplate', {
+        error,
+        url: {
+          path: routePath('template.show', { templateId })
+        }
+      });
+    }
+    return {
+      success: false,
+      errors: [Global('messaging.somethingWentWrong')],
+      data: null
+    };
+  }
+
+  const handleTitleChange = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    setIsEditing(false);
+    const result = await updateTemplate(templateInfo);
+
+    if (!result.success) {
+      const errors = result.errors;
+
+      //Check if errors is an array or an object
+      if (Array.isArray(errors)) {
+        setErrorMessages(errors.length > 0 ? errors : [Global('messaging.somethingWentWrong')])
+      }
+    } else {
+      if (
+        result.data?.errors &&
+        typeof result.data.errors === 'object' &&
+        typeof result.data.errors.general === 'string') {
+        // Handle errors as an object with general or field-level errors
+        setErrorMessages(prev => [...prev, result.data?.errors?.general || Global('messaging.somethingWentWrong')]);
+      }
+      //Need to refetch plan data to refresh the info that was changed
+      await refetch();
+    }
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNewTitle(e.target.value)
+  };
+
   useEffect(() => {
     if (pageErrors.length > 0 && pageErrorRef.current) {
       pageErrorRef.current.scrollIntoView({
@@ -243,48 +260,73 @@ const TemplateEditPage: React.FC = () => {
     }
   }, [pageErrors]);
 
+  // Need to set this info to update template title
+  useEffect(() => {
+    if (data?.template) {
+      setTemplateInfoState({
+        templateId: Number(data.template.id),
+        name: data.template.name || '',
+        visibility: data.template.visibility || null,
+        bestPracice: data.template.bestPractice || false,
+      });
+    }
+  }, [data]);
+
   if (loading) {
     return <div>{Global('messaging.loading')}...</div>;
   }
+
   if (templateQueryErrors) {
     return <div>{EditTemplate('errors.getTemplatesError')}</div>;
   }
 
+  const template = data?.template;
+
+  if (!template) {
+    return <div>{EditTemplate('errors.noTemplateFound')}</div>;
+  }
+
+  const sortedSections = template.sections
+    ? sortSections(template.sections.filter((section): section is Section => section !== null))
+    : [];
+
   return (
     <div>
-
-      <PageHeader
-        title={template?.name ? template?.name : 'Template'}
-        description={`by ${template?.name} - Version: ${template?.latestPublishVersion} - Published: ${template?.latestPublishDate}`}
+      <PageHeaderWithTitleChange
+        title={newTitle || template.name}
+        description={`by ${template.owner?.displayName} - Version: ${template.latestPublishVersion} - Published: ${formatDate(template.latestPublishDate)}`}
         showBackButton={false}
         breadcrumbs={
           <Breadcrumbs>
             <Breadcrumb><Link href="/">{BreadCrumbs('home')}</Link></Breadcrumb>
             <Breadcrumb><Link href="/template">{BreadCrumbs('templates')}</Link></Breadcrumb>
-            <Breadcrumb>{template?.name}</Breadcrumb>
+            <Breadcrumb>{template.name}</Breadcrumb>
           </Breadcrumbs>
         }
-
         className="page-template-overview"
+        handleTitleChange={handleTitleChange}
+        handleInputChange={handleInputChange}
+        newTitle={newTitle}
       />
 
-      {pageErrors && pageErrors.length > 0 &&
+
+
+      {pageErrors.length > 0 && (
         <div className="error" role="alert" aria-live="assertive" ref={pageErrorRef}>
           {pageErrors.map((error, index) => (
             <p key={index}>{error}</p>
           ))}
-        </div>}
+        </div>
+      )}
+
       <h2>{EditTemplate('title')}</h2>
 
       <div className="template-editor-container">
         <div className="main-content">
-
-          {(template?.sections && template?.sections.length > 0) && (
-            <div className="">
-              {template.sections.map((section, index) => (
-                <div key={section.id} role="list" aria-label="Questions list"
-                  style={{ marginBottom: '40px' }}>
-
+          {sortedSections.length > 0 && (
+            <div>
+              {sortedSections.map((section, index) => (
+                <div key={section.id} role="list" aria-label="Questions list" style={{ marginBottom: '40px' }}>
                   <SectionHeaderEdit
                     key={section.id}
                     sectionNumber={index + 1}
@@ -293,30 +335,20 @@ const TemplateEditPage: React.FC = () => {
                     onMoveUp={() => null}
                     onMoveDown={() => null}
                   />
-
-                  {(section?.questions && section?.questions.length > 0) && (
-                    section.questions.map((question) => (
-                      <QuestionEditCard
-                        key={question.id}
-                        id={question.id ? question.id.toString() : ''}
-                        text={question?.questionText ? question.questionText : ''}
-                        link={`/template/${templateId}/q/${question.id}`}
-                      />
-                    ))
-                  )}
-                  <AddQuestionButton
-                    href={`/template/${templateId}/q/new?section_id=${section.id}`}
-                  />
+                  {section.questions?.map((question) => (
+                    <QuestionEditCard
+                      key={question.id}
+                      id={question.id ? question.id.toString() : ''}
+                      text={question.questionText || ''}
+                      link={`/template/${templateId}/q/${question.id}`}
+                    />
+                  ))}
+                  <AddQuestionButton href={`/template/${templateId}/q/new?section_id=${section.id}`} />
                 </div>
-
               ))}
-
             </div>
           )}
-
           <AddSectionButton href={`/template/${templateId}/section/new`} />
-
-
         </div>
         <aside className="sidebar">
           <div className="sidebar-inner">
@@ -418,7 +450,7 @@ const TemplateEditPage: React.FC = () => {
           <div>
             <Form onSubmit={e => handleSubmit(e)} data-testid="publishForm">
 
-              <ErrorMessages errors={errors} ref={errorRef} />
+              <ErrorMessages errors={errorMessages} ref={errorRef} />
               <Heading slot="title">{PublishTemplate('heading.publish')}</Heading>
 
               <RadioGroup name="visibility">
@@ -494,6 +526,6 @@ const TemplateEditPage: React.FC = () => {
 
     </div >
   );
-}
+};
 
 export default TemplateEditPage;

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -49,7 +49,6 @@ interface TemplateInfoInterface {
   templateId: number | null;
   name: string;
   visibility: TemplateVisibility;
-  bestPracice: boolean;
 }
 const TemplateEditPage: React.FC = () => {
   const [isPublishModalOpen, setPublishModalOpen] = useState(false);
@@ -60,7 +59,6 @@ const TemplateEditPage: React.FC = () => {
     templateId: null,
     name: '',
     visibility: TemplateVisibility.Private,
-    bestPracice: false
   });
   const [newTitle, setNewTitle] = useState('');
   const formatDate = useFormatDate();
@@ -192,7 +190,6 @@ const TemplateEditPage: React.FC = () => {
         templateId: templateInfo.templateId,
         name: newTitle,
         visibility: templateInfo.visibility,
-        bestPractice: templateInfo.bestPracice,
       });
 
       if (response.redirect) {
@@ -264,7 +261,6 @@ const TemplateEditPage: React.FC = () => {
         templateId: Number(data.template.id),
         name: data.template.name || '',
         visibility: data.template.visibility || null,
-        bestPracice: data.template.bestPractice || false,
       });
     }
   }, [data]);

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -312,8 +312,6 @@ const TemplateEditPage: React.FC = () => {
         </div>
       )}
 
-      <h2>{EditTemplate('title')}</h2>
-
       <div className="template-editor-container">
         <div className="main-content">
           {sortedSections.length > 0 && (

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -38,7 +38,6 @@ import PageHeaderWithTitleChange from "@/components/PageHeaderWithTitleChange";
 import AddQuestionButton from "@/components/AddQuestionButton";
 import AddSectionButton from "@/components/AddSectionButton";
 import ErrorMessages from '@/components/ErrorMessages';
-import { FormInput } from '@/components/Form';
 
 import { useFormatDate } from '@/hooks/useFormatDate';
 import logECS from '@/utils/clientLogger';
@@ -63,7 +62,6 @@ const TemplateEditPage: React.FC = () => {
     visibility: TemplateVisibility.Private,
     bestPracice: false
   });
-  const [isEditing, setIsEditing] = useState(false);
   const [newTitle, setNewTitle] = useState('');
   const formatDate = useFormatDate();
 
@@ -224,7 +222,6 @@ const TemplateEditPage: React.FC = () => {
   const handleTitleChange = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    setIsEditing(false);
     const result = await updateTemplate(templateInfo);
 
     if (!result.success) {

--- a/components/PageHeader/index.tsx
+++ b/components/PageHeader/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, {ReactNode, useEffect} from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import BackButton from "@/components/BackButton";
 import './pageheader.scss';
 

--- a/components/PageHeaderWithTitleChange/__tests__/index.spec.tsx
+++ b/components/PageHeaderWithTitleChange/__tests__/index.spec.tsx
@@ -25,7 +25,7 @@ describe('PageHeaderWithTitleChange', () => {
     newTitle: 'New Test Title',
   };
 
-  it('renders the component with default props', () => {
+  it('should render the component with default props', () => {
     render(<PageHeaderWithTitleChange {...defaultProps} />);
 
     // Check if the title is rendered
@@ -41,7 +41,7 @@ describe('PageHeaderWithTitleChange', () => {
     expect(screen.getByText('Mock Action')).toBeInTheDocument();
   });
 
-  it('allows editing the title', () => {
+  it('should allow editing of the title', () => {
     render(<PageHeaderWithTitleChange {...defaultProps} />);
 
     // Click the "Edit template name" button
@@ -56,7 +56,7 @@ describe('PageHeaderWithTitleChange', () => {
     expect(mockHandleInputChange).toHaveBeenCalled();
   });
 
-  it('calls handleTitleChange on form submission', () => {
+  it('should call handleTitleChange on form submission', () => {
     render(<PageHeaderWithTitleChange {...defaultProps} />);
 
     // Click the "Edit template name" button
@@ -70,7 +70,7 @@ describe('PageHeaderWithTitleChange', () => {
     expect(mockHandleTitleChange).toHaveBeenCalled();
   });
 
-  it('cancels editing when the cancel button is clicked', () => {
+  it('should cancel editing when the cancel button is clicked', () => {
     render(<PageHeaderWithTitleChange {...defaultProps} />);
 
     // Click the "Edit template name" button
@@ -84,7 +84,7 @@ describe('PageHeaderWithTitleChange', () => {
     expect(screen.queryByPlaceholderText('Enter new template title')).not.toBeInTheDocument();
   });
 
-  it('renders without crashing', () => {
+  it('should render without crashing', () => {
     render(<PageHeaderWithTitleChange title="Test Title" />);
   });
 

--- a/components/PageHeaderWithTitleChange/__tests__/index.spec.tsx
+++ b/components/PageHeaderWithTitleChange/__tests__/index.spec.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import PageHeaderWithTitleChange from '../index';
+
+expect.extend(toHaveNoViolations);
+
+describe('PageHeaderWithTitleChange', () => {
+
+  beforeEach(() => {
+    window.scrollTo = jest.fn(); // Called by the wrapping PageHeader
+  });
+  const mockHandleTitleChange = jest.fn();
+  const mockHandleInputChange = jest.fn();
+
+  const defaultProps = {
+    title: 'Test Title',
+    description: 'This is a test description.',
+    showBackButton: true,
+    breadcrumbs: <div>Mock Breadcrumbs</div>,
+    actions: <button>Mock Action</button>,
+    className: 'test-class',
+    handleTitleChange: mockHandleTitleChange,
+    handleInputChange: mockHandleInputChange,
+    newTitle: 'New Test Title',
+  };
+
+  it('renders the component with default props', () => {
+    render(<PageHeaderWithTitleChange {...defaultProps} />);
+
+    // Check if the title is rendered
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+
+    // Check if the description is rendered
+    expect(screen.getByText('This is a test description.')).toBeInTheDocument();
+
+    // Check if the breadcrumbs are rendered
+    expect(screen.getByText('Mock Breadcrumbs')).toBeInTheDocument();
+
+    // Check if the actions are rendered
+    expect(screen.getByText('Mock Action')).toBeInTheDocument();
+  });
+
+  it('allows editing the title', () => {
+    render(<PageHeaderWithTitleChange {...defaultProps} />);
+
+    // Click the "Edit template name" button
+    fireEvent.click(screen.getByText('Edit template name'));
+
+    // Check if the input field is rendered
+    const input = screen.getByPlaceholderText('Enter new template title');
+    expect(input).toBeInTheDocument();
+
+    // Simulate typing in the input field
+    fireEvent.change(input, { target: { value: 'Updated Title' } });
+    expect(mockHandleInputChange).toHaveBeenCalled();
+  });
+
+  it('calls handleTitleChange on form submission', () => {
+    render(<PageHeaderWithTitleChange {...defaultProps} />);
+
+    // Click the "Edit template name" button
+    fireEvent.click(screen.getByText('Edit template name'));
+
+    // Submit the form
+    const saveButton = screen.getByText('buttons.save');
+    fireEvent.click(saveButton);
+
+    // Check if handleTitleChange was called
+    expect(mockHandleTitleChange).toHaveBeenCalled();
+  });
+
+  it('cancels editing when the cancel button is clicked', () => {
+    render(<PageHeaderWithTitleChange {...defaultProps} />);
+
+    // Click the "Edit template name" button
+    fireEvent.click(screen.getByText('Edit template name'));
+
+    // Click the cancel button
+    const cancelButton = screen.getByText('buttons.cancel');
+    fireEvent.click(cancelButton);
+
+    // Check if the input field is no longer rendered
+    expect(screen.queryByPlaceholderText('Enter new template title')).not.toBeInTheDocument();
+  });
+
+  it('renders without crashing', () => {
+    render(<PageHeaderWithTitleChange title="Test Title" />);
+  });
+
+  it('should pass axe accessibility test', async () => {
+    const { container } = render(
+      <PageHeaderWithTitleChange {...defaultProps} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  })
+});

--- a/components/PageHeaderWithTitleChange/index.tsx
+++ b/components/PageHeaderWithTitleChange/index.tsx
@@ -75,7 +75,7 @@ const PageHeaderWithTitleChange: React.FC<PageHeaderProps> = ({
       <div className="pageheader-container">
         {/* Title and description section */}
         <div>
-          <Form onSubmit={handleFormSubmit}>
+          <Form onSubmit={handleFormSubmit} className="pageheader-title-form">
             {isEditing ? (
               <FormInput
                 name={title}

--- a/components/PageHeaderWithTitleChange/index.tsx
+++ b/components/PageHeaderWithTitleChange/index.tsx
@@ -46,23 +46,17 @@ const PageHeaderWithTitleChange: React.FC<PageHeaderProps> = ({
   const [isEditing, setIsEditing] = useState(false);
   const Global = useTranslations('Global');
 
-  // const handleTitleChange = async (e: FormEvent<HTMLFormElement>) => {
-  //   e.preventDefault();
-  //   console.log('Title changed');
-  // };
 
-  // const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   setNewTitle(e.target.value)
-  // };
+  const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsEditing(false);
+    handleTitleChange?.(event);
+  }
 
   useEffect(() => {
     document.title = `${title} | DMPTool`;
     window.scrollTo(0, 0);
   }, [title]);
-
-  useEffect(() => {
-    console.log("New Title:", newTitle);
-  }, [newTitle]);
 
   return (
     <div className={`template-editor-header ${className}`.trim()}>
@@ -81,7 +75,7 @@ const PageHeaderWithTitleChange: React.FC<PageHeaderProps> = ({
       <div className="pageheader-container">
         {/* Title and description section */}
         <div>
-          <Form onSubmit={handleTitleChange}>
+          <Form onSubmit={handleFormSubmit}>
             {isEditing ? (
               <FormInput
                 name={title}

--- a/components/PageHeaderWithTitleChange/index.tsx
+++ b/components/PageHeaderWithTitleChange/index.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import React, { FormEvent, ReactNode, useEffect, useState } from 'react';
+import BackButton from "@/components/BackButton";
+import {
+  Button,
+  Form,
+} from "react-aria-components";
+import { useTranslations } from 'next-intl';
+import { FormInput } from '@/components/Form';
+import './pageheaderWithTitle.scss';
+
+interface PageHeaderProps {
+  /** The main title of the page */
+  title: string;
+  /** Optional description text below the title */
+  description?: string;
+  /** Whether to show the back button - defaults to true */
+  showBackButton?: boolean;
+  /** Optional breadcrumbs component */
+  breadcrumbs?: ReactNode;
+  /** Optional actions (buttons) to be displayed */
+  actions?: ReactNode;
+  /** Additional CSS classes */
+  className?: string;
+  /**Function to handle title change */
+  handleTitleChange?: ((event: FormEvent<HTMLFormElement>) => void) | undefined;
+  /**Function to handle input change */
+  handleInputChange?: ((event: React.ChangeEvent<HTMLInputElement>) => void) | undefined;
+  /**New title */
+  newTitle?: string;
+}
+
+const PageHeaderWithTitleChange: React.FC<PageHeaderProps> = ({
+  title,
+  description,
+  showBackButton = true,
+  breadcrumbs,
+  actions,
+  className = '',
+  handleInputChange,
+  handleTitleChange,
+  newTitle = '',
+}: PageHeaderProps) => {
+
+  const [isEditing, setIsEditing] = useState(false);
+  const Global = useTranslations('Global');
+
+  // const handleTitleChange = async (e: FormEvent<HTMLFormElement>) => {
+  //   e.preventDefault();
+  //   console.log('Title changed');
+  // };
+
+  // const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   setNewTitle(e.target.value)
+  // };
+
+  useEffect(() => {
+    document.title = `${title} | DMPTool`;
+    window.scrollTo(0, 0);
+  }, [title]);
+
+  useEffect(() => {
+    console.log("New Title:", newTitle);
+  }, [newTitle]);
+
+  return (
+    <div className={`template-editor-header ${className}`.trim()}>
+      {/* Breadcrumbs slot */}
+      {breadcrumbs && (
+        <div className="mb-4">
+          {breadcrumbs}
+        </div>
+      )}
+
+      {/* Back button */}
+      {showBackButton && (
+        <BackButton />
+      )}
+
+      <div className="pageheader-container">
+        {/* Title and description section */}
+        <div>
+          <Form onSubmit={handleTitleChange}>
+            {isEditing ? (
+              <FormInput
+                name={title}
+                type="text"
+                label="Template title"
+                value={newTitle}
+                inputClasses="titleChange-input"
+                placeholder="Enter new template title"
+                onChange={handleInputChange}
+              />
+            ) : (
+              <div className="pageheader-title-container">
+                <h1 className="pageheader-title">{title}</h1>
+                <Button
+                  className='link'
+                  onPress={() => setIsEditing(true)}
+                >
+                  Edit template name
+                </Button>
+              </div>
+            )}
+            {isEditing && (
+              <div className="button-container">
+                <Button type="submit" className="secondary" onPress={() => setIsEditing(false)}>{Global('buttons.cancel')}</Button>
+                <Button type="submit" className="primary">{Global('buttons.save')}</Button>
+              </div>
+            )}
+            <p className="pageheader-intro">
+              {description}
+            </p>
+          </Form>
+        </div>
+
+        {/* Actions slot - can contain one or multiple buttons */}
+        {actions && (
+          <div className="heading-buttons-actions">
+            {actions}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PageHeaderWithTitleChange;

--- a/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
+++ b/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
@@ -18,6 +18,7 @@
   
   .pageheader-title-container {
     display: flex;
+    align-items: baseline;
     gap: var(--brand-space2);
     
     @include device(md) {
@@ -26,9 +27,20 @@
     
     // Mobile default (outside of any device mixin)
     flex-direction: column;
+    gap: 0;
+
+    @include device(md) {
+      gap: var(--brand-space2);
+    }
     
     .pageheader-title {
       margin-bottom: 0;
+    }
+
+    .link {
+      font-size: var(--fs-small);
+      color: var(--gray-600);
+      font-weight:300;
     }
   }
   
@@ -50,7 +62,7 @@
 }
 
 // Form styles
-.react-aria-Form {
+.pageheader-title-form{
   // Make the form a flex container
   display: flex;
   flex-wrap: wrap;

--- a/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
+++ b/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
@@ -1,0 +1,112 @@
+@import '@/styles/responsive.scss';
+
+.template-editor-header {
+  // This is to match the left padding for content container
+  padding: 0 var(--brand-space2);
+}
+
+.pageheader-container {
+  padding: 0;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+  
+  @include device(lg) {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+  
+  .pageheader-title-container {
+    display: flex;
+    gap: var(--brand-space2);
+    
+    @include device(md) {
+      flex-direction: row;
+    }
+    
+    // Mobile default (outside of any device mixin)
+    flex-direction: column;
+    
+    .pageheader-title {
+      margin-bottom: 0;
+    }
+  }
+  
+  .pageheader-title {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-weight: var(--fw-bold);
+  }
+  
+  .pageheader-intro {
+    font-size: 1rem;
+  }
+  
+  .heading-buttons-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+}
+
+// Form styles
+.react-aria-Form {
+  // Make the form a flex container
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  
+  // Mobile first approach - column layout by default
+  flex-direction: column;
+  
+  @include device(md) {
+    flex-direction: row;
+  }
+  
+  .react-aria-TextField {
+    margin-bottom: 0;
+  }
+  
+  // Field wrapper takes most of the space
+  [data-testid="field-wrapper"] {
+    flex: 1 1 300px; // Grow, shrink, and min width
+    height: auto; // Explicitly set height to auto
+    min-height: 0; // Reset any min-height
+    
+    // Mobile style
+    width: 100%;
+    flex-basis: auto; // Remove any flex-basis influence
+    
+    @include device(md) {
+      width: auto;
+      flex-basis: 300px;
+    }
+  }
+  
+  // Button container for the two buttons
+  .button-container {
+    display: flex;
+    gap: 8px; // Space between buttons
+    align-items: flex-start;
+    
+    // Mobile styles
+    margin-top: 8px;
+    align-self: flex-end; // Right-align on mobile
+    
+    @include device(md) {
+      margin-top: 24px; // Align with the input field's bottom
+      margin-left: var(--brand-space2);
+    }
+  }
+  
+  // Make the intro paragraph take full width
+  .pageheader-intro {
+    flex-basis: 100%;
+    margin-top: 16px;
+  }
+}
+
+// Custom input class
+.titleChange-input {
+  margin-bottom: 0;
+}

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -391,11 +391,11 @@ export type AffiliationSearch = {
   displayName: Scalars['String']['output'];
   /** Whether or not this affiliation is a funder */
   funder: Scalars['Boolean']['output'];
-  /** The unique identifer for the affiliation (typically the ROR id) */
+  /** The unique identifer for the affiliation */
   id: Scalars['Int']['output'];
   /** The categories the Affiliation belongs to */
   types?: Maybe<Array<AffiliationType>>;
-  /** The URI of the affiliation */
+  /** The URI of the affiliation (typically the ROR id) */
   uri: Scalars['String']['output'];
 };
 
@@ -556,6 +556,19 @@ export type ExternalProject = {
   startDate?: Maybe<Scalars['String']['output']>;
   /** The project title */
   title?: Maybe<Scalars['String']['output']>;
+};
+
+/** A result of the most popular funders */
+export type FunderPopularityResult = {
+  __typename?: 'FunderPopularityResult';
+  /** The official display name */
+  displayName: Scalars['String']['output'];
+  /** The unique identifer for the affiliation */
+  id: Scalars['Int']['output'];
+  /** The number of plans associated with this funder in the past year */
+  nbrPlans: Scalars['Int']['output'];
+  /** The URI of the affiliation (typically the ROR id) */
+  uri: Scalars['String']['output'];
 };
 
 /** Output type for the initializePlanVersion mutation */
@@ -1280,7 +1293,7 @@ export type MutationUpdateTagArgs = {
 
 
 export type MutationUpdateTemplateArgs = {
-  bestPractice?: InputMaybe<Scalars['Boolean']['input']>;
+  bestPractice: Scalars['Boolean']['input'];
   name: Scalars['String']['input'];
   templateId: Scalars['Int']['input'];
   visibility: TemplateVisibility;
@@ -2040,6 +2053,8 @@ export type Query = {
   planOutputs?: Maybe<Array<Maybe<ProjectOutput>>>;
   /** Get all plans for the research project */
   plans?: Maybe<Array<PlanSearchResult>>;
+  /** Returns a list of the top 20 funders ranked by popularity (nbr of plans) for the past year */
+  popularFunders?: Maybe<Array<Maybe<FunderPopularityResult>>>;
   /** Get a specific project */
   project?: Maybe<Project>;
   /** Get all of the Users that are collaborators for the Project */
@@ -3574,13 +3589,6 @@ export type RemoveProjectContributorMutationVariables = Exact<{
 
 export type RemoveProjectContributorMutation = { __typename?: 'Mutation', removeProjectContributor?: { __typename?: 'ProjectContributor', errors?: { __typename?: 'ProjectContributorErrors', general?: string | null, email?: string | null, affiliationId?: string | null, givenName?: string | null, orcid?: string | null, surName?: string | null, contributorRoleIds?: string | null } | null } | null };
 
-export type AddProjectContributorMutationVariables = Exact<{
-  input: AddProjectContributorInput;
-}>;
-
-
-export type AddProjectContributorMutation = { __typename?: 'Mutation', addProjectContributor?: { __typename?: 'ProjectContributor', email?: string | null, errors?: { __typename?: 'ProjectContributorErrors', general?: string | null } | null } | null };
-
 export type UpdateProjectFunderMutationVariables = Exact<{
   input: UpdateProjectFunderInput;
 }>;
@@ -3671,6 +3679,16 @@ export type AddTemplateMutationVariables = Exact<{
 
 
 export type AddTemplateMutation = { __typename?: 'Mutation', addTemplate?: { __typename?: 'Template', id?: number | null, description?: string | null, name: string, errors?: { __typename?: 'TemplateErrors', general?: string | null, name?: string | null, ownerId?: string | null } | null } | null };
+
+export type UpdateTemplateMutationVariables = Exact<{
+  templateId: Scalars['Int']['input'];
+  name: Scalars['String']['input'];
+  visibility: TemplateVisibility;
+  bestPractice: Scalars['Boolean']['input'];
+}>;
+
+
+export type UpdateTemplateMutation = { __typename?: 'Mutation', updateTemplate?: { __typename?: 'Template', id?: number | null, bestPractice: boolean, name: string, visibility: TemplateVisibility } | null };
 
 export type UpdateUserProfileMutationVariables = Exact<{
   input: UpdateUserProfileInput;
@@ -3849,7 +3867,7 @@ export type TemplateQueryVariables = Exact<{
 }>;
 
 
-export type TemplateQuery = { __typename?: 'Query', template?: { __typename?: 'Template', id?: number | null, name: string, description?: string | null, latestPublishVersion?: string | null, latestPublishDate?: string | null, created?: string | null, errors?: { __typename?: 'TemplateErrors', general?: string | null, name?: string | null, ownerId?: string | null } | null, sections?: Array<{ __typename?: 'Section', id?: number | null, name: string, bestPractice?: boolean | null, displayOrder?: number | null, isDirty: boolean, questions?: Array<{ __typename?: 'Question', displayOrder?: number | null, guidanceText?: string | null, id?: number | null, questionText?: string | null, sectionId: number, templateId: number, errors?: { __typename?: 'QuestionErrors', general?: string | null, templateId?: string | null, sectionId?: string | null, questionText?: string | null, displayOrder?: string | null } | null }> | null } | null> | null, owner?: { __typename?: 'Affiliation', displayName: string, id?: number | null } | null } | null };
+export type TemplateQuery = { __typename?: 'Query', template?: { __typename?: 'Template', id?: number | null, name: string, description?: string | null, latestPublishVersion?: string | null, latestPublishDate?: string | null, created?: string | null, visibility: TemplateVisibility, bestPractice: boolean, errors?: { __typename?: 'TemplateErrors', general?: string | null, name?: string | null, ownerId?: string | null } | null, sections?: Array<{ __typename?: 'Section', id?: number | null, name: string, bestPractice?: boolean | null, displayOrder?: number | null, isDirty: boolean, questions?: Array<{ __typename?: 'Question', displayOrder?: number | null, guidanceText?: string | null, id?: number | null, questionText?: string | null, sectionId: number, templateId: number, errors?: { __typename?: 'QuestionErrors', general?: string | null, templateId?: string | null, sectionId?: string | null, questionText?: string | null, displayOrder?: string | null } | null }> | null } | null> | null, owner?: { __typename?: 'Affiliation', displayName: string, id?: number | null } | null } | null };
 
 export type TemplateCollaboratorsQueryVariables = Exact<{
   templateId: Scalars['Int']['input'];
@@ -4243,42 +4261,6 @@ export function useRemoveProjectContributorMutation(baseOptions?: Apollo.Mutatio
 export type RemoveProjectContributorMutationHookResult = ReturnType<typeof useRemoveProjectContributorMutation>;
 export type RemoveProjectContributorMutationResult = Apollo.MutationResult<RemoveProjectContributorMutation>;
 export type RemoveProjectContributorMutationOptions = Apollo.BaseMutationOptions<RemoveProjectContributorMutation, RemoveProjectContributorMutationVariables>;
-export const AddProjectContributorDocument = gql`
-    mutation AddProjectContributor($input: AddProjectContributorInput!) {
-  addProjectContributor(input: $input) {
-    email
-    errors {
-      general
-    }
-  }
-}
-    `;
-export type AddProjectContributorMutationFn = Apollo.MutationFunction<AddProjectContributorMutation, AddProjectContributorMutationVariables>;
-
-/**
- * __useAddProjectContributorMutation__
- *
- * To run a mutation, you first call `useAddProjectContributorMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useAddProjectContributorMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [addProjectContributorMutation, { data, loading, error }] = useAddProjectContributorMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useAddProjectContributorMutation(baseOptions?: Apollo.MutationHookOptions<AddProjectContributorMutation, AddProjectContributorMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<AddProjectContributorMutation, AddProjectContributorMutationVariables>(AddProjectContributorDocument, options);
-      }
-export type AddProjectContributorMutationHookResult = ReturnType<typeof useAddProjectContributorMutation>;
-export type AddProjectContributorMutationResult = Apollo.MutationResult<AddProjectContributorMutation>;
-export type AddProjectContributorMutationOptions = Apollo.BaseMutationOptions<AddProjectContributorMutation, AddProjectContributorMutationVariables>;
 export const UpdateProjectFunderDocument = gql`
     mutation UpdateProjectFunder($input: UpdateProjectFunderInput!) {
   updateProjectFunder(input: $input) {
@@ -4814,6 +4796,50 @@ export function useAddTemplateMutation(baseOptions?: Apollo.MutationHookOptions<
 export type AddTemplateMutationHookResult = ReturnType<typeof useAddTemplateMutation>;
 export type AddTemplateMutationResult = Apollo.MutationResult<AddTemplateMutation>;
 export type AddTemplateMutationOptions = Apollo.BaseMutationOptions<AddTemplateMutation, AddTemplateMutationVariables>;
+export const UpdateTemplateDocument = gql`
+    mutation UpdateTemplate($templateId: Int!, $name: String!, $visibility: TemplateVisibility!, $bestPractice: Boolean!) {
+  updateTemplate(
+    templateId: $templateId
+    name: $name
+    visibility: $visibility
+    bestPractice: $bestPractice
+  ) {
+    id
+    bestPractice
+    name
+    visibility
+  }
+}
+    `;
+export type UpdateTemplateMutationFn = Apollo.MutationFunction<UpdateTemplateMutation, UpdateTemplateMutationVariables>;
+
+/**
+ * __useUpdateTemplateMutation__
+ *
+ * To run a mutation, you first call `useUpdateTemplateMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateTemplateMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateTemplateMutation, { data, loading, error }] = useUpdateTemplateMutation({
+ *   variables: {
+ *      templateId: // value for 'templateId'
+ *      name: // value for 'name'
+ *      visibility: // value for 'visibility'
+ *      bestPractice: // value for 'bestPractice'
+ *   },
+ * });
+ */
+export function useUpdateTemplateMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTemplateMutation, UpdateTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateTemplateMutation, UpdateTemplateMutationVariables>(UpdateTemplateDocument, options);
+      }
+export type UpdateTemplateMutationHookResult = ReturnType<typeof useUpdateTemplateMutation>;
+export type UpdateTemplateMutationResult = Apollo.MutationResult<UpdateTemplateMutation>;
+export type UpdateTemplateMutationOptions = Apollo.BaseMutationOptions<UpdateTemplateMutation, UpdateTemplateMutationVariables>;
 export const UpdateUserProfileDocument = gql`
     mutation UpdateUserProfile($input: UpdateUserProfileInput!) {
   updateUserProfile(input: $input) {
@@ -6214,6 +6240,8 @@ export const TemplateDocument = gql`
       displayName
       id
     }
+    visibility
+    bestPractice
   }
 }
     `;

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -1293,7 +1293,7 @@ export type MutationUpdateTagArgs = {
 
 
 export type MutationUpdateTemplateArgs = {
-  bestPractice: Scalars['Boolean']['input'];
+  bestPractice?: InputMaybe<Scalars['Boolean']['input']>;
   name: Scalars['String']['input'];
   templateId: Scalars['Int']['input'];
   visibility: TemplateVisibility;
@@ -3684,11 +3684,10 @@ export type UpdateTemplateMutationVariables = Exact<{
   templateId: Scalars['Int']['input'];
   name: Scalars['String']['input'];
   visibility: TemplateVisibility;
-  bestPractice: Scalars['Boolean']['input'];
 }>;
 
 
-export type UpdateTemplateMutation = { __typename?: 'Mutation', updateTemplate?: { __typename?: 'Template', id?: number | null, bestPractice: boolean, name: string, visibility: TemplateVisibility } | null };
+export type UpdateTemplateMutation = { __typename?: 'Mutation', updateTemplate?: { __typename?: 'Template', id?: number | null, name: string, visibility: TemplateVisibility } | null };
 
 export type UpdateUserProfileMutationVariables = Exact<{
   input: UpdateUserProfileInput;
@@ -4797,15 +4796,9 @@ export type AddTemplateMutationHookResult = ReturnType<typeof useAddTemplateMuta
 export type AddTemplateMutationResult = Apollo.MutationResult<AddTemplateMutation>;
 export type AddTemplateMutationOptions = Apollo.BaseMutationOptions<AddTemplateMutation, AddTemplateMutationVariables>;
 export const UpdateTemplateDocument = gql`
-    mutation UpdateTemplate($templateId: Int!, $name: String!, $visibility: TemplateVisibility!, $bestPractice: Boolean!) {
-  updateTemplate(
-    templateId: $templateId
-    name: $name
-    visibility: $visibility
-    bestPractice: $bestPractice
-  ) {
+    mutation UpdateTemplate($templateId: Int!, $name: String!, $visibility: TemplateVisibility!) {
+  updateTemplate(templateId: $templateId, name: $name, visibility: $visibility) {
     id
-    bestPractice
     name
     visibility
   }
@@ -4829,7 +4822,6 @@ export type UpdateTemplateMutationFn = Apollo.MutationFunction<UpdateTemplateMut
  *      templateId: // value for 'templateId'
  *      name: // value for 'name'
  *      visibility: // value for 'visibility'
- *      bestPractice: // value for 'bestPractice'
  *   },
  * });
  */

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -3866,7 +3866,7 @@ export type TemplateQueryVariables = Exact<{
 }>;
 
 
-export type TemplateQuery = { __typename?: 'Query', template?: { __typename?: 'Template', id?: number | null, name: string, description?: string | null, latestPublishVersion?: string | null, latestPublishDate?: string | null, created?: string | null, visibility: TemplateVisibility, bestPractice: boolean, errors?: { __typename?: 'TemplateErrors', general?: string | null, name?: string | null, ownerId?: string | null } | null, sections?: Array<{ __typename?: 'Section', id?: number | null, name: string, bestPractice?: boolean | null, displayOrder?: number | null, isDirty: boolean, questions?: Array<{ __typename?: 'Question', displayOrder?: number | null, guidanceText?: string | null, id?: number | null, questionText?: string | null, sectionId: number, templateId: number, errors?: { __typename?: 'QuestionErrors', general?: string | null, templateId?: string | null, sectionId?: string | null, questionText?: string | null, displayOrder?: string | null } | null }> | null } | null> | null, owner?: { __typename?: 'Affiliation', displayName: string, id?: number | null } | null } | null };
+export type TemplateQuery = { __typename?: 'Query', template?: { __typename?: 'Template', id?: number | null, name: string, description?: string | null, latestPublishVersion?: string | null, latestPublishDate?: string | null, created?: string | null, visibility: TemplateVisibility, bestPractice: boolean, isDirty: boolean, errors?: { __typename?: 'TemplateErrors', general?: string | null, name?: string | null, ownerId?: string | null } | null, sections?: Array<{ __typename?: 'Section', id?: number | null, name: string, bestPractice?: boolean | null, displayOrder?: number | null, isDirty: boolean, questions?: Array<{ __typename?: 'Question', displayOrder?: number | null, guidanceText?: string | null, id?: number | null, questionText?: string | null, sectionId: number, templateId: number, errors?: { __typename?: 'QuestionErrors', general?: string | null, templateId?: string | null, sectionId?: string | null, questionText?: string | null, displayOrder?: string | null } | null }> | null } | null> | null, owner?: { __typename?: 'Affiliation', displayName: string, id?: number | null } | null } | null };
 
 export type TemplateCollaboratorsQueryVariables = Exact<{
   templateId: Scalars['Int']['input'];
@@ -6234,6 +6234,7 @@ export const TemplateDocument = gql`
     }
     visibility
     bestPractice
+    isDirty
   }
 }
     `;

--- a/graphql/mutations/templates.mutation.graphql
+++ b/graphql/mutations/templates.mutation.graphql
@@ -34,10 +34,9 @@ mutation AddTemplate($name: String!, $copyFromTemplateId: Int) {
   }
 }
 
-mutation UpdateTemplate($templateId: Int!, $name: String!, $visibility: TemplateVisibility!, $bestPractice: Boolean!) {
-  updateTemplate(templateId: $templateId, name: $name, visibility: $visibility, bestPractice: $bestPractice) {
+mutation UpdateTemplate($templateId: Int!, $name: String!, $visibility: TemplateVisibility!) {
+  updateTemplate(templateId: $templateId, name: $name, visibility: $visibility) {
     id
-    bestPractice
     name
     visibility
   }

--- a/graphql/mutations/templates.mutation.graphql
+++ b/graphql/mutations/templates.mutation.graphql
@@ -33,3 +33,12 @@ mutation AddTemplate($name: String!, $copyFromTemplateId: Int) {
     name
   }
 }
+
+mutation UpdateTemplate($templateId: Int!, $name: String!, $visibility: TemplateVisibility!, $bestPractice: Boolean!) {
+  updateTemplate(templateId: $templateId, name: $name, visibility: $visibility, bestPractice: $bestPractice) {
+    id
+    bestPractice
+    name
+    visibility
+  }
+}

--- a/graphql/queries/templates.query.graphql
+++ b/graphql/queries/templates.query.graphql
@@ -53,7 +53,9 @@ query Template($templateId: Int!) {
     owner {
       displayName
       id
-    }
+    },
+    visibility,
+    bestPractice
   }
 }
 

--- a/graphql/queries/templates.query.graphql
+++ b/graphql/queries/templates.query.graphql
@@ -55,7 +55,8 @@ query Template($templateId: Int!) {
       id
     },
     visibility,
-    bestPractice
+    bestPractice,
+    isDirty
   }
 }
 

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -21,6 +21,7 @@
     "titleStatus": "Status",
     "draft": "Draft",
     "notPublished": "Not Published",
+    "published": "Published",
     "allowAccess": "Allow people to access, edit or comment on this plan",
     "description": {
       "archiveTemplate": "This template will no longer be visible to plan creators. Pre-existing plans that use this template will be unaffected. This is not reversible."

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -21,6 +21,7 @@
     "titleStatus": "Status",
     "draft": "Rascunho",
     "notPublished": "Não publicado",
+    "published": "Publicado",
     "allowAccess": "Permitir que as pessoas acessem, editem ou comentem este plano",
     "description": {
       "archiveTemplate": "Este modelo não será mais visível para os criadores de planos. Os planos pré-existentes que usam este modelo não serão afetados. Isto não é reversível."

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -112,7 +112,6 @@ html, body {
 
 
 :root {
-  --scale-mobile: 0.875; // Reduces font size by 12.5% on mobile
   --font-family: var(--font-sans-serif, sans-serif);
   --font-family-monospace: 'Fira Code', monospace;
   --font-family-heading: var(--font-sans-serif), sans-serif;

--- a/utils/graphqlServerActionHandler.ts
+++ b/utils/graphqlServerActionHandler.ts
@@ -40,7 +40,6 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
 }): Promise<GraphQLActionResponse<T>> {
 
   const mutationString = typeof document === "string" ? document : print(document);
-  console.log("***Mutation String***", mutationString);
   try {
     if (!mutationString) {
       throw new Error("No mutation string provided");


### PR DESCRIPTION
## Description

Per this wireframe, https://www.figma.com/proto/RRtoRLyr5Spf0KiyRfEclt/DMP-Tool-Wireframes?node-id=6-333&t=N2jvNbe3g9eOxDc7-0&scaling=scale-down-width&page-id=6%3A66&starting-point-node-id=69%3A345&content-scaling=fixed&show-proto-sidebar=1, we need to provide a link that allows users to edit a template title on the Template Overview page (i.e., `/template/[templateid]`).

- Created another version of our shared `PageHeader`, called `PageheaderWithTitleChange` to be used with pages that need to have this `edit title` functionality alongside the `page title`. Since we needed to add a good amount of new code for this new functionality, it made sense to create this second `page header` component so that the rest of the pages aren't weighed down with code that they don't use.

Fixes # ([#265](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/265))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually tested the change on `/template/[templateId]` by updating the title and seeing that it had changed.
Added unit test for the new `PageheaderWithTitleChange` component


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ *] Any dependent changes have been merged and published in downstream modules
* Note: This must be tested with the backend bug fixes branch, `bug/JS-fixes-for-updating-template`, which is in PR review https://github.com/CDLUC3/dmsp_backend_prototype/pull/272. 

## Screenshots:
- desktop view with `Edit template` link:
<img width="845" alt="image" src="https://github.com/user-attachments/assets/cc1d132b-74c7-426f-a7b5-4dec655ef0af" />

- View after clicking the `Edit template` link:
<img width="856" alt="image" src="https://github.com/user-attachments/assets/a42ef331-f335-4ce5-8377-9e9ed0c18731" />

- Display on mobile device:
<img width="364" alt="image" src="https://github.com/user-attachments/assets/ce19d1f8-0cc1-44a4-ac5e-efa919467a20" />

<img width="366" alt="image" src="https://github.com/user-attachments/assets/864cbd3a-f65e-44d6-b20f-562025353628" />
