### PR TITLE
Fixed bugs related to the template builder flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@
 - Removed unused component `EditQuestionPage` to avoid confusion with other components. This is a legacy component. [#379]
 
 ### Fixed
+- Fixed bugs related to the template builder flow
+  - Fixed Preview page to not display HTML at top for Requirements [#449]
+  - Added redirect back to Edit Template page when user creates a new Section [#452]
+  - On `/template` page, fixed the `published` and `unpublished` labels on the list items because they were reversed [#453]
+  - Replaced hard-coded org names with the actual org names in text on `Manage access` page, and fixed archive modal title to `Confirm removal` [#454]
+  - Changed `Published` to `Last updated` on `/template/[templateId]` page and fixed missing translation for `Load 3 more`. Also when adding a new `Question`, the button should say `Save and add` and when editing an existing question, the form button should say `Save and update`. [#455]
+  - Added missing space after `Guidance by` and `These are requirements by` in the Preview page [#455]
 - Fix logger path issue in auth.ts [#441]
 - Added handling of scenario where no jwt payload is returned when getting languageId in middleware [#441]
 - Fixed ordering issue for Sections on the Edit Templates page [#436]

--- a/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
@@ -1,25 +1,26 @@
 import React from "react";
-import {act, fireEvent, render, screen, waitFor} from '@/utils/test-utils';
+import { act, fireEvent, render, screen, waitFor } from '@/utils/test-utils';
 import {
   useArchiveTemplateMutation,
   useCreateTemplateVersionMutation,
   useTemplateQuery
 } from '@/generated/graphql';
 
-import {useParams} from 'next/navigation';
+import { useParams } from 'next/navigation';
 import TemplateEditPage from '../page';
-import {mockScrollIntoView, mockScrollTo} from "@/__mocks__/common";
+import { mockScrollIntoView, mockScrollTo } from "@/__mocks__/common";
 
 // Mock the useTemplateQuery hook
 jest.mock("@/generated/graphql", () => ({
   useTemplateQuery: jest.fn(),
   useArchiveTemplateMutation: jest.fn(),
   useCreateTemplateVersionMutation: jest.fn(),
-  TemplateVersionType: {Draft: 'DRAFT', Published: 'PUBLISHED'}
+  TemplateVersionType: { Draft: 'DRAFT', Published: 'PUBLISHED' }
 }));
 
 jest.mock('next/navigation', () => ({
   useParams: jest.fn(),
+  useRouter: jest.fn(),
 }))
 
 // Mock useFormatter and useTranslations from next-intl
@@ -70,11 +71,11 @@ describe("TemplateEditPage", () => {
     const mockUseParams = useParams as jest.Mock;
 
     // Mock the return value of useParams
-    mockUseParams.mockReturnValue({templateId: `${mockTemplateId}`});
+    mockUseParams.mockReturnValue({ templateId: `${mockTemplateId}` });
 
     (useArchiveTemplateMutation as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce({data: {key: 'value'}}),
-      {loading: false, error: undefined},
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
     ]);
   });
 
@@ -87,13 +88,13 @@ describe("TemplateEditPage", () => {
     });
 
     (useCreateTemplateVersionMutation as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce({data: {key: 'value'}}),
-      {loading: false, error: undefined},
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
     ]);
 
     await act(async () => {
       render(
-        <TemplateEditPage/>
+        <TemplateEditPage />
       );
     });
 
@@ -103,16 +104,16 @@ describe("TemplateEditPage", () => {
   it("should render data returned from template query correctly", async () => {
     // Mock the hook for data state
     (useTemplateQuery as jest.Mock).mockReturnValue({
-      data: {template: mockTemplateData},
+      data: { template: mockTemplateData },
       loading: false,
       error: null,
     });
 
     await act(async () => {
-      render(<TemplateEditPage/>);
+      render(<TemplateEditPage />);
     });
 
-    const heading = screen.getByRole('heading', {level: 1});
+    const heading = screen.getByRole('heading', { level: 1 });
     expect(heading).toHaveTextContent('DMP Template from Dataverse');
 
     const versionText = screen.getByText(/Version: v1/i);
@@ -137,32 +138,32 @@ describe("TemplateEditPage", () => {
 
   it('should close dialog when \'Publish template\' form submitted', async () => {
     (useTemplateQuery as jest.Mock).mockReturnValue({
-      data: {template: mockTemplateData},
+      data: { template: mockTemplateData },
       loading: false,
       error: null,
     });
     (useCreateTemplateVersionMutation as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce({data: {key: 'value'}}), // Correct way to mock a resolved promise
-      {loading: false, error: undefined},
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }), // Correct way to mock a resolved promise
+      { loading: false, error: undefined },
     ]);
 
     await act(async () => {
       render(
-        <TemplateEditPage/>
+        <TemplateEditPage />
       );
     });
 
     // Simulate the user triggering the publishTemplate button
-    const publishTemplateButton = screen.getByRole('button', {name: /button.publishtemplate/i});
+    const publishTemplateButton = screen.getByRole('button', { name: /button.publishtemplate/i });
     fireEvent.click(publishTemplateButton);
 
     // Locate the textarea using data-testid
     const textarea = screen.getByTestId('changeLog');
 
     // Simulate user typing into the textarea
-    fireEvent.change(textarea, {target: {value: 'This is a test comment.'}});
+    fireEvent.change(textarea, { target: { value: 'This is a test comment.' } });
 
-    const saveAndPublishButton = screen.getByRole('button', {name: /button.saveandpublish/i});
+    const saveAndPublishButton = screen.getByRole('button', { name: /button.saveandpublish/i });
     fireEvent.click(saveAndPublishButton);
 
     // Wait for mutation response
@@ -175,7 +176,7 @@ describe("TemplateEditPage", () => {
 
   it('should set correct error when useCreate returns error', async () => {
     (useTemplateQuery as jest.Mock).mockReturnValue({
-      data: {template: mockTemplateData},
+      data: { template: mockTemplateData },
       loading: false,
       error: null,
     });
@@ -185,21 +186,21 @@ describe("TemplateEditPage", () => {
 
     await act(async () => {
       render(
-        <TemplateEditPage/>
+        <TemplateEditPage />
       );
     });
 
     // Simulate the user triggering the publishTemplate button
-    const publishTemplateButton = screen.getByRole('button', {name: /button.publishtemplate/i});
+    const publishTemplateButton = screen.getByRole('button', { name: /button.publishtemplate/i });
     fireEvent.click(publishTemplateButton);
 
     // Locate the textarea using data-testid
     const textarea = screen.getByTestId('changeLog');
 
     // Simulate user typing into the textarea
-    fireEvent.change(textarea, {target: {value: 'This is a test comment.'}});
+    fireEvent.change(textarea, { target: { value: 'This is a test comment.' } });
 
-    const saveAndPublishButton = screen.getByRole('button', {name: /button.saveandpublish/i});
+    const saveAndPublishButton = screen.getByRole('button', { name: /button.saveandpublish/i });
     fireEvent.click(saveAndPublishButton);
 
     // Wait for the error to be added to the page
@@ -210,18 +211,18 @@ describe("TemplateEditPage", () => {
 
   it('should call useArchiveTemplateMutation when user clicks on the Archive Template button', async () => {
     (useTemplateQuery as jest.Mock).mockReturnValue({
-      data: {template: mockTemplateData},
+      data: { template: mockTemplateData },
       loading: false,
       error: null,
     });
     (useCreateTemplateVersionMutation as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce({data: {key: 'value'}}), // Correct way to mock a resolved promise
-      {loading: false, error: undefined},
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }), // Correct way to mock a resolved promise
+      { loading: false, error: undefined },
     ]);
 
     await act(async () => {
       render(
-        <TemplateEditPage/>
+        <TemplateEditPage />
       );
     });
 
@@ -238,13 +239,13 @@ describe("TemplateEditPage", () => {
 
   it('should display correct error when archving template fails', async () => {
     (useTemplateQuery as jest.Mock).mockReturnValue({
-      data: {template: mockTemplateData},
+      data: { template: mockTemplateData },
       loading: false,
       error: null,
     });
     (useCreateTemplateVersionMutation as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce({data: {key: 'value'}}), // Correct way to mock a resolved promise
-      {loading: false, error: undefined},
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }), // Correct way to mock a resolved promise
+      { loading: false, error: undefined },
     ]);
 
     (useArchiveTemplateMutation as jest.Mock).mockReturnValue([
@@ -253,7 +254,7 @@ describe("TemplateEditPage", () => {
 
     await act(async () => {
       render(
-        <TemplateEditPage/>
+        <TemplateEditPage />
       );
     });
 

--- a/app/[locale]/template/[templateId]/access/page.tsx
+++ b/app/[locale]/template/[templateId]/access/page.tsx
@@ -208,6 +208,7 @@ const TemplateAccessPage: React.FC = () => {
               </div>
             </div>
             <ConfirmModal
+              title={AccessPage('headings.confirmRemoval')}
               email={person.email}
               onConfirm={handleRevokeAccess}
             />
@@ -266,7 +267,7 @@ const TemplateAccessPage: React.FC = () => {
             <div className="main-content">
               <ErrorMessages errors={errorMessages} ref={errorRef} />
               <p>
-                {AccessPage('intro')}
+                {AccessPage('intro', { orgName: organization?.name })}
               </p>
               <section className="sectionContainer"
                 aria-labelledby="org-access-heading">
@@ -286,7 +287,7 @@ const TemplateAccessPage: React.FC = () => {
                   <h3 id="external-access-heading">{AccessPage('headings.externalPeople')}</h3>
                 </div>
                 <div className="sectionContent">
-                  <p>{AccessPage('paragraphs.externalPara1')}</p>
+                  <p>{AccessPage('paragraphs.externalPara1', { orgName: organization?.name })}</p>
                   <div className={styles.externalPeopleList}>
                     {renderExternalPeople}
                   </div>

--- a/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import {act, fireEvent, render, screen, waitFor} from '@/utils/test-utils';
+import { act, fireEvent, render, screen, waitFor } from '@/utils/test-utils';
 import {
   useQuestionQuery,
   useQuestionTypesQuery,
   useUpdateQuestionMutation
 } from '@/generated/graphql';
 
-import {axe, toHaveNoViolations} from 'jest-axe';
-import {useParams, useRouter, useSearchParams} from 'next/navigation';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import QuestionEdit from '../page';
-import {mockScrollIntoView, mockScrollTo} from "@/__mocks__/common";
+import { mockScrollIntoView, mockScrollTo } from "@/__mocks__/common";
 
 expect.extend(toHaveNoViolations);
 
@@ -350,7 +350,7 @@ describe("QuestionEditPage", () => {
       );
     });
 
-    const saveButton = screen.getByText('buttons.saveAndAdd');
+    const saveButton = screen.getByText('buttons.saveAndUpdate');
     expect(saveButton).toBeInTheDocument();
 
     fireEvent.click(saveButton);

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -370,7 +370,7 @@ const QuestionEdit = () => {
                   </Checkbox>
                 )}
 
-                <Button type="submit" onPress={() => setFormSubmitted(true)}>{Global('buttons.saveAndAdd')}</Button>
+                <Button type="submit" onPress={() => setFormSubmitted(true)}>{Global('buttons.saveAndUpdate')}</Button>
 
               </Form>
 

--- a/app/[locale]/template/[templateId]/section/[section_slug]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/section/[section_slug]/__tests__/page.spec.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import {act, fireEvent, render, screen, waitFor} from '@/utils/test-utils';
+import { act, fireEvent, render, screen, waitFor } from '@/utils/test-utils';
 import {
   useSectionQuery,
   useTagsQuery,
   useUpdateSectionMutation
 } from '@/generated/graphql';
 
-import {axe, toHaveNoViolations} from 'jest-axe';
-import {useParams, useRouter} from 'next/navigation';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { useParams, useRouter } from 'next/navigation';
 import SectionUpdatePage from '../page';
-import {mockScrollIntoView, mockScrollTo} from "@/__mocks__/common";
+import { mockScrollIntoView, mockScrollTo } from "@/__mocks__/common";
 
 expect.extend(toHaveNoViolations);
 
@@ -123,7 +123,7 @@ describe("SectionUpdatePage", () => {
     const mockUseParams = useParams as jest.Mock;
 
     // Mock the return value of useParams
-    mockUseParams.mockReturnValue({templateId: `${mockTemplateId}`});
+    mockUseParams.mockReturnValue({ templateId: `${mockTemplateId}` });
     (useTagsQuery as jest.Mock).mockReturnValue({
       data: mockTagsData,
       loading: true,
@@ -136,37 +136,37 @@ describe("SectionUpdatePage", () => {
 
     (useSectionQuery as jest.Mock).mockReturnValue([
       jest.fn().mockResolvedValueOnce(mockSectionsData),
-      {loading: false, error: undefined},
+      { loading: false, error: undefined },
     ]);
   });
 
   it("should render correct fields", async () => {
     (useUpdateSectionMutation as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce({data: {key: 'value'}}),
-      {loading: false, error: undefined},
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
     ]);
 
     await act(async () => {
       render(
-        <SectionUpdatePage/>
+        <SectionUpdatePage />
       );
     });
 
-    const heading = screen.getByRole('heading', {level: 1});
+    const heading = screen.getByRole('heading', { level: 1 });
     expect(heading).toHaveTextContent('title');
-    const editQuestionTab = screen.getByRole('tab', {name: 'tabs.editSection'});
+    const editQuestionTab = screen.getByRole('tab', { name: 'tabs.editSection' });
     expect(editQuestionTab).toBeInTheDocument();
-    const editOptionsTab = screen.getByRole('tab', {name: 'tabs.options'});
+    const editOptionsTab = screen.getByRole('tab', { name: 'tabs.options' });
     expect(editOptionsTab).toBeInTheDocument();
-    const editLogicTab = screen.getByRole('tab', {name: 'tabs.logic'});
+    const editLogicTab = screen.getByRole('tab', { name: 'tabs.logic' });
     expect(editLogicTab).toBeInTheDocument();
-    const sectionNameEditor = screen.getByRole('textbox', {name: /sectionName/i});
+    const sectionNameEditor = screen.getByRole('textbox', { name: /sectionName/i });
     expect(sectionNameEditor).toBeInTheDocument();
-    const sectionIntroductionEditor = screen.getByRole('textbox', {name: /sectionIntroduction/i});
+    const sectionIntroductionEditor = screen.getByRole('textbox', { name: /sectionIntroduction/i });
     expect(sectionIntroductionEditor).toBeInTheDocument();
-    const sectionRequirementsEditor = screen.getByRole('textbox', {name: /sectionRequirements/i});
+    const sectionRequirementsEditor = screen.getByRole('textbox', { name: /sectionRequirements/i });
     expect(sectionRequirementsEditor).toBeInTheDocument();
-    const sectionGuidanceEditor = screen.getByRole('textbox', {name: /sectionGuidance/i});
+    const sectionGuidanceEditor = screen.getByRole('textbox', { name: /sectionGuidance/i });
     expect(sectionGuidanceEditor).toBeInTheDocument();
     const tagsHeader = screen.getByText('labels.bestPracticeTags');
     expect(tagsHeader).toBeInTheDocument();
@@ -181,18 +181,18 @@ describe("SectionUpdatePage", () => {
 
   it('should display error when no value is entered in section name field', async () => {
     (useUpdateSectionMutation as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce({data: {key: 'value'}}),
-      {loading: false, error: undefined},
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
     ]);
 
 
     await act(async () => {
       render(
-        <SectionUpdatePage/>
+        <SectionUpdatePage />
       );
     });
 
-    const saveAndAdd = screen.getByRole('button', {name: /buttons.saveAndAdd/i});
+    const saveAndAdd = screen.getByRole('button', { name: /buttons.saveAndUpdate/i });
     fireEvent.click(saveAndAdd);
 
     const errorMessage = screen.getByRole('alert');
@@ -202,21 +202,21 @@ describe("SectionUpdatePage", () => {
 
   it('should redirect to Edit Template page after submitting form', async () => {
     (useUpdateSectionMutation as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce({data: {key: 'value'}}),
-      {loading: false, error: undefined},
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
     ]);
 
     await act(async () => {
-      render(<SectionUpdatePage/>);
+      render(<SectionUpdatePage />);
     });
 
     // Simulate adding content to the sectionName field
     const sectionNameInput = screen.getByLabelText(/sectionName/i);
     await act(async () => {
-      fireEvent.change(sectionNameInput, {target: {value: 'Updated Section Name'}});
+      fireEvent.change(sectionNameInput, { target: { value: 'Updated Section Name' } });
     });
 
-    const saveAndAdd = screen.getByRole('button', {name: /buttons.saveAndAdd/i});
+    const saveAndAdd = screen.getByRole('button', { name: /buttons.saveAndUpdate/i });
     fireEvent.click(saveAndAdd);
 
     await waitFor(() => {
@@ -227,13 +227,13 @@ describe("SectionUpdatePage", () => {
 
   it('should pass axe accessibility test', async () => {
     (useUpdateSectionMutation as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce({data: {key: 'value'}}),
-      {loading: false, error: undefined},
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
     ]);
 
 
-    const {container} = render(
-      <SectionUpdatePage/>
+    const { container } = render(
+      <SectionUpdatePage />
     );
     await act(async () => {
       const results = await axe(container);

--- a/app/[locale]/template/[templateId]/section/[section_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/section/[section_slug]/page.tsx
@@ -404,7 +404,7 @@ const SectionUpdatePage: React.FC = () => {
                         })}
                       </div>
                     </CheckboxGroup>
-                    <Button type="submit">{Global('buttons.saveAndAdd')}</Button>
+                    <Button type="submit">{Global('buttons.saveAndUpdate')}</Button>
 
                   </Form>
                 </TabPanel>

--- a/app/[locale]/template/[templateId]/section/create/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/section/create/__tests__/page.spec.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import {act, fireEvent, render, screen} from '@/utils/test-utils';
+import { act, fireEvent, render, screen } from '@/utils/test-utils';
 import {
   useAddSectionMutation,
   useSectionsDisplayOrderQuery,
   useTagsQuery,
 } from '@/generated/graphql';
 
-import {axe, toHaveNoViolations} from 'jest-axe';
-import {useParams} from 'next/navigation';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { useParams } from 'next/navigation';
 import CreateSectionPage from '../page';
-import {mockScrollIntoView, mockScrollTo} from "@/__mocks__/common";
+import { mockScrollIntoView, mockScrollTo } from "@/__mocks__/common";
 
 expect.extend(toHaveNoViolations);
 
@@ -22,6 +22,7 @@ jest.mock("@/generated/graphql", () => ({
 }));
 
 jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
   useParams: jest.fn(),
 }))
 

--- a/app/[locale]/template/[templateId]/section/create/page.tsx
+++ b/app/[locale]/template/[templateId]/section/create/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { ApolloError } from '@apollo/client';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import {
   Breadcrumb,
@@ -53,6 +53,7 @@ const CreateSectionPage: React.FC = () => {
 
   // Get templateId param
   const params = useParams();
+  const router = useRouter();
   const { templateId } = params; // From route /template/:templateId/section/create
 
   //For scrolling to error in page
@@ -268,6 +269,8 @@ const CreateSectionPage: React.FC = () => {
       } else {
         // Show success message
         showSuccessToast();
+        // Redirect to the edit template page
+        router.push(`/template/${templateId}`)
       }
 
       scrollToTop(topRef);

--- a/app/[locale]/template/__tests__/page.spec.tsx
+++ b/app/[locale]/template/__tests__/page.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import {act, fireEvent, render, screen} from '@/utils/test-utils';
+import { act, fireEvent, render, screen } from '@/utils/test-utils';
 import TemplateListPage from '../page';
-import {axe, toHaveNoViolations} from 'jest-axe';
-import {useTemplatesQuery,} from '@/generated/graphql';
-import {mockScrollIntoView} from '@/__mocks__/common';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { useTemplatesQuery, } from '@/generated/graphql';
+import { mockScrollIntoView } from '@/__mocks__/common';
 
 expect.extend(toHaveNoViolations);
 
@@ -191,7 +191,7 @@ describe('TemplateListPage', () => {
 
     // Searching for translation keys since cannot run next-intl for unit tests
     const homeLink = screen.getByRole('link', { name: 'breadcrumbs.home' });
-    const templatesLink = screen.getByRole('link', { name: 'title' });
+    const templatesLink = screen.getByRole('link', { name: 'breadcrumbs.templates' });
 
     expect(homeLink).toHaveAttribute('href', '/en-US');
     expect(templatesLink).toHaveAttribute('href', '/en-US/template');

--- a/app/[locale]/template/page.tsx
+++ b/app/[locale]/template/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, {useEffect, useRef, useState} from 'react';
-import {ApolloError} from "@apollo/client";
+import React, { useEffect, useRef, useState } from 'react';
+import { ApolloError } from "@apollo/client";
 import {
   Breadcrumb,
   Breadcrumbs,
@@ -13,23 +13,23 @@ import {
   SearchField,
   Text
 } from 'react-aria-components';
-import {useFormatter, useTranslations} from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 
 //GraphQL
-import {useTemplatesQuery,} from '@/generated/graphql';
+import { useTemplatesQuery, } from '@/generated/graphql';
 
 // Components
 import PageHeader from '@/components/PageHeader';
 import TemplateListItem from '@/components/TemplateListItem';
-import {ContentContainer, LayoutContainer,} from '@/components/Container';
+import { ContentContainer, LayoutContainer, } from '@/components/Container';
 import ErrorMessages from '@/components/ErrorMessages';
 
 // Hooks
-import {useScrollToTop} from '@/hooks/scrollToTop';
+import { useScrollToTop } from '@/hooks/scrollToTop';
 
 import logECS from '@/utils/clientLogger';
-import {routePath} from '@/utils/routes';
-import {TemplateItemProps, TemplateSearchResultInterface,} from '@/app/types';
+import { routePath } from '@/utils/routes';
+import { TemplateItemProps, TemplateSearchResultInterface, } from '@/app/types';
 import styles from './orgTemplates.module.scss';
 
 const TemplateListPage: React.FC = () => {
@@ -169,7 +169,7 @@ const TemplateListPage: React.FC = () => {
               ) : null, // Set to null if no description or last modified data
               funder: template?.ownerDisplayName,
               lastUpdated: (template?.modified) ? formatDate(template?.modified) : null,
-              publishStatus: (template?.isDirty) ? 'Published' : 'Unpublished',
+              publishStatus: (template?.isDirty) ? 'Unpublished' : 'Published',
               defaultExpanded: false
             }
           }));
@@ -238,7 +238,7 @@ const TemplateListPage: React.FC = () => {
         breadcrumbs={
           <Breadcrumbs>
             <Breadcrumb><Link href={routePath('app.home')}>{Global('breadcrumbs.home')}</Link></Breadcrumb>
-            <Breadcrumb><Link href={routePath('template.index')}>{t('title')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('template.index')}>{Global('breadcrumbs.templates')}</Link></Breadcrumb>
             <Breadcrumb>{t('title')}</Breadcrumb>
           </Breadcrumbs>
         }

--- a/components/Modal/ConfirmModal.tsx
+++ b/components/Modal/ConfirmModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import {useState} from 'react';
-import {useTranslations} from 'next-intl';
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import {
   Button,
   Dialog,
@@ -11,7 +11,12 @@ import {
 } from 'react-aria-components';
 
 
-const ConfirmModal: React.FC<{ email: string, onConfirm: (email: string) => void }> = ({ email, onConfirm }) => {
+const ConfirmModal: React.FC<{
+  title: string,
+  email: string,
+  onConfirm: (email: string) => void
+}
+> = ({ title, email, onConfirm }) => {
   const [isOpen, setOpen] = useState(false);
   //Localization keys
   const Global = useTranslations('Global');
@@ -23,7 +28,7 @@ const ConfirmModal: React.FC<{ email: string, onConfirm: (email: string) => void
       <ModalOverlay>
         <Modal>
           <Dialog>
-            <h3>{AccessPage('headings.confirmCheckout')}</h3>
+            <h3>{title ?? AccessPage('headings.confirmCheckout')}</h3>
             <p>{AccessPage('paragraphs.modalPara1', { email: email })}</p>
             <div style={{ display: "flex", justifyContent: "flex-end", gap: "10px" }}>
               <Button onPress={() => setOpen(false)}>{Global('buttons.cancel')}</Button>

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import {act, fireEvent, render, screen, waitFor} from '@/utils/test-utils';
+import { act, fireEvent, render, screen, waitFor } from '@/utils/test-utils';
 import {
   useAddQuestionMutation,
   useQuestionsDisplayOrderQuery,
 } from '@/generated/graphql';
 
-import {axe, toHaveNoViolations} from 'jest-axe';
-import {useParams, useRouter} from 'next/navigation';
-import {useTranslations as OriginalUseTranslations} from 'next-intl';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslations as OriginalUseTranslations } from 'next-intl';
 import QuestionAdd from '@/components/QuestionAdd';
 
 expect.extend(toHaveNoViolations);
@@ -201,7 +201,7 @@ describe("QuestionAdd", () => {
       );
     });
 
-    const saveButton = screen.getByText('buttons.save');
+    const saveButton = screen.getByText('buttons.saveAndAdd');
     expect(saveButton).toBeInTheDocument();
 
     fireEvent.click(saveButton);

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -326,7 +326,7 @@ const QuestionAdd = ({
                 )}
 
                 {/**We need to set formSubmitted here, so that it is passed down to the child component QuestionOptionsComponent */}
-                <Button type="submit" onPress={e => setFormSubmitted(true)}>{Global('buttons.save')}</Button>
+                <Button type="submit" onPress={e => setFormSubmitted(true)}>{Global('buttons.saveAndAdd')}</Button>
               </Form>
 
             </TabPanel>

--- a/components/QuestionPreview/index.tsx
+++ b/components/QuestionPreview/index.tsx
@@ -116,7 +116,6 @@ const QuestionPreview: React.FC<QuestionPreviewProps> = ({
                   {t('closeButton')}
                 </Button>
               </div>
-
               {children}
             </Dialog>
           </Modal>

--- a/components/QuestionView/index.tsx
+++ b/components/QuestionView/index.tsx
@@ -86,13 +86,14 @@ const QuestionView: React.FC<QuestionViewProps> = ({
       <ContentContainer className={`${styles.QuestionView}__content-container`}>
         <h2>{question?.questionText}</h2>
 
-        <div className={styles.Requirements}>
-          <p className={styles.ByLine}>
-            {trans('requirements')}
-            {templateData?.template?.owner?.displayName}
-          </p>
-          <p>{question?.requirementText}</p>
-        </div>
+        {(question?.requirementText) && (
+          <div className={styles.Requirements}>
+            <p className={styles.ByLine}>
+              {trans('requirements', { orgName: templateData?.template?.owner?.displayName })}
+            </p>
+            <div dangerouslySetInnerHTML={{ __html: question.requirementText || '' }}></div>
+          </div>
+        )}
 
         <p>
           <a className={styles.JumpLink} href="#_guidance">
@@ -139,8 +140,7 @@ const QuestionView: React.FC<QuestionViewProps> = ({
         {(question?.guidanceText) && (
           <div className="guidance">
             <p className={styles.ByLine}>
-              {trans('guidanceBy')}
-              {templateData?.template?.owner?.displayName}
+              {trans('guidanceBy', { orgName: templateData?.template?.owner?.displayName })}
             </p>
             <div dangerouslySetInnerHTML={{ __html: question.guidanceText }}></div>
           </div>

--- a/components/SelectExistingTemplate/index.tsx
+++ b/components/SelectExistingTemplate/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, {useEffect, useRef, useState} from 'react';
-import {useRouter} from 'next/navigation';
-import {useTranslations} from 'next-intl';
+import React, { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import {
   Breadcrumb,
   Breadcrumbs,
@@ -17,8 +17,8 @@ import {
 
 //Components
 import PageHeader from "@/components/PageHeader";
-import {ContentContainer, LayoutContainer,} from '@/components/Container';
-import {filterTemplates} from '@/utils/filterTemplates';
+import { ContentContainer, LayoutContainer, } from '@/components/Container';
+import { filterTemplates } from '@/utils/filterTemplates';
 import TemplateList from '@/components/TemplateList';
 import ErrorMessages from '@/components/ErrorMessages';
 
@@ -30,12 +30,12 @@ import {
 } from '@/generated/graphql';
 
 // Hooks
-import {useScrollToTop} from '@/hooks/scrollToTop';
+import { useScrollToTop } from '@/hooks/scrollToTop';
 // Other
 import logECS from '@/utils/clientLogger';
-import {MyVersionedTemplatesInterface, TemplateItemProps} from '@/app/types';
-import {useFormatDate} from '@/hooks/useFormatDate';
-import {useToast} from '@/context/ToastContext';
+import { MyVersionedTemplatesInterface, TemplateItemProps } from '@/app/types';
+import { useFormatDate } from '@/hooks/useFormatDate';
+import { useToast } from '@/context/ToastContext';
 
 
 // Step 2 of the Create Template start pages

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -146,6 +146,7 @@
       "next": "Next",
       "save": "Save",
       "saveAndAdd": "Save and add",
+      "saveAndUpdate": "Save and update",
       "saveChanges": "Save changes",
       "remove": "Remove",
       "confirm": "Confirm",
@@ -188,6 +189,7 @@
     },
     "headings": {
       "preview": "Preview"
-    }
+    },
+    "version": "Version"
   }
 }

--- a/messages/en-US/questionView.json
+++ b/messages/en-US/questionView.json
@@ -1,9 +1,9 @@
 {
   "QuestionView": {
     "cardType": "Question",
-    "requirements": "These are requirements by",
+    "requirements": "These are requirements by {orgName}",
     "guidanceLink": "Jump to additional guidance",
-    "guidanceBy": "Guidance by",
+    "guidanceBy": "Guidance by {orgName}",
     "backToSection": "Back to Section",
     "saveButton": "Save",
     "lastSaved": "Last Saved",

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -48,6 +48,9 @@
       "archiveTemplateError": "Error when archiving template",
       "saveTemplateError": "Error when saving template",
       "getTemplatesError": "Error getting templates"
+    },
+    "messages": {
+      "successfullyArchived": "Successfully archived the template"
     }
   },
   "PublishTemplate": {
@@ -183,7 +186,8 @@
     "numDisplaying": "Showing {num} of {total}",
     "clearFilter": "clear filter",
     "buttons": {
-      "loadMore": "Load {name} more"
+      "loadMore": "Load {name} more",
+      "load3More": "Load 3 more"
     },
     "headings": {
       "previouslyCreatedTemplates": "Use one of your previously created templates",
@@ -311,17 +315,18 @@
   },
   "TemplateAccessPage": {
     "title": "Manage access",
-    "intro": "This template is accessible to everyone at NSF with full view and edit permissions. It can also be shared with people outside your organization.",
+    "intro": "This template is accessible to everyone at {orgName} with full view and edit permissions. It can also be shared with people outside your organization.",
     "headings": {
       "h3OrgAccess": "Within organization",
       "externalPeople": "External people",
       "share": "Share with someone outside your organization",
-      "confirmCheckout": "Confirm checkout?"
+      "confirmCheckout": "Confirm checkout?",
+      "confirmRemoval": "Confirm removal"
     },
     "paragraphs": {
       "orgAccessPara1": "Everyone at {name} can view and edit",
       "orgAccessPara2": "{count} administrator(s) can manage access",
-      "externalPara1": "Share this template with people outside NSF",
+      "externalPara1": "Share this template with people outside {orgName}",
       "sharePara1": "Enter their email address. If they do not already have a DMP Tool account they will be prompted to create one.",
       "modalPara1": "Please confirm that you want to remove {email}"
     },

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -122,7 +122,7 @@
       "section": "Seção",
       "addNewSection": "Adicionar uma nova seção",
       "updateSection": "Seção de atualização",
-      "editSection": "",
+      "editSection": "Editar seção",
       "createSection": "Criar seção",
       "editTemplate": "Editar Modelo",
       "question": "Pergunta",
@@ -146,6 +146,7 @@
       "next": "Seguinte",
       "save": "Salvar",
       "saveAndAdd": "Salvar e adicionar",
+      "saveAndUpdate": "Salvar e atualizar",
       "saveChanges": "Salvar as alterações",
       "remove": "Remover",
       "confirm": "Confirmação",
@@ -171,7 +172,7 @@
     "links": {
       "clearFilter": "limpar filtro",
       "request": "Solicitação",
-      "learnMore": "Learn more"
+      "learnMore": "Saiba mais"
     },
     "messaging": {
       "loading": "Baixar",
@@ -188,6 +189,7 @@
     },
     "headings": {
       "preview": "Pré-visualizar"
-    }
+    },
+    "version": "Versão"
   }
 }

--- a/messages/pt-BR/questionView.json
+++ b/messages/pt-BR/questionView.json
@@ -1,9 +1,9 @@
 {
   "QuestionView": {
     "cardType": "Pergunta",
-    "requirements": "Estes são requisitos por",
+    "requirements": "Estes são requisitos de {orgName}",
     "guidanceLink": "Pule para orientação adicional",
-    "guidanceBy": "Orientação por",
+    "guidanceBy": "Guia por {orgName}",
     "backToSection": "Voltar para a seção",
     "saveButton": "Salvar",
     "lastSaved": "Último salvamento",

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -183,7 +183,8 @@
     "numDisplaying": "Mostrando {num} de {total}",
     "clearFilter": "filtros transparentes",
     "buttons": {
-      "loadMore": "Carregue mais {name}"
+      "loadMore": "Carregue mais {name}",
+      "load3More": "Carregue mais 3"
     },
     "headings": {
       "previouslyCreatedTemplates": "Use uma de suas seções criadas anteriormente",

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -48,6 +48,9 @@
       "archiveTemplateError": "Erro ao arquivar template",
       "saveTemplateError": "Erro ao salvar modelo",
       "getTemplatesError": "Erro ao obter modelos"
+    },
+    "messages": {
+      "successfullyArchived": "Modelo arquivado com sucesso"
     }
   },
   "PublishTemplate": {
@@ -317,12 +320,13 @@
       "h3OrgAccess": "Dentro da organização",
       "externalPeople": "Pessoas externas",
       "share": "Compartilhe com alguém fora da sua organização",
-      "confirmCheckout": "Confirmar finalização do pedido?"
+      "confirmCheckout": "Confirmar finalização do pedido?",
+      "confirmRemoval": "Confirme a exclusão"
     },
     "paragraphs": {
       "orgAccessPara1": "Todos em {name} podem ver e editar",
       "orgAccessPara2": "Administradores {count} podem gerenciar o acesso",
-      "externalPara1": "Administradores {count} podem gerenciar o acesso",
+      "externalPara1": "Compartilhe este modelo com pessoas fora do {orgName}",
       "sharePara1": "Digite seu endereço de e-mail. Se eles já não tiverem uma conta de DMP Tool eles serão convidados a criar uma.",
       "modalPara1": "Por favor, confirme que você deseja remover {email}"
     },


### PR DESCRIPTION
## Description

- Fixed bugs related to the template builder flow
  - Fixed Preview page to not display HTML at top for Requirements [#449]
  - Added redirect back to Edit Template page when user creates a new Section [#452]
  - On `/template` page, fixed the `published` and `unpublished` labels on the list items because they were reversed [#453]
  - Replaced hard-coded org names with the actual org names in text on `Manage access` page, and fixed archive modal title to `Confirm removal` [#454]
  - Changed `Published` to `Last updated` on `/template/[templateId]` page and fixed missing translation for `Load 3 more`. Also when adding a new `Question`, the button should say `Save and add` and when editing an existing question, the form button should say `Save and update`. [#455]
  - Added missing space after `Guidance by` and `These are requirements by` in the Preview page [#455]
  
Fixes # ([449](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/449), [452](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/452), [453](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/453), [454](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/454), [455](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/455))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually and with updated unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules