### PR TITLE
Converted sample text field to Rich Text Editor in Question forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - Removed unused component `EditQuestionPage` to avoid confusion with other components. This is a legacy component. [#379]
 
 ### Fixed
+- Added Rich Text Editor for Sample Text in the Question forms [#456]
 - Fixed bugs related to the template builder flow
   - Fixed Preview page to not display HTML at top for Requirements [#449]
   - Added redirect back to Edit Template page when user creates a new Section [#452]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 
 ### Fixed
 - Added Rich Text Editor for Sample Text in the Question forms [#456]
+  - Adjusted widths of Edit template title to accomodate for very long titles [#456]
 - Fixed bugs related to the template builder flow
   - Fixed Preview page to not display HTML at top for Requirements [#449]
   - Added redirect back to Edit Template page when user creates a new Section [#452]

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -341,6 +341,7 @@ const QuestionEdit = () => {
                   <FormTextArea
                     name="sample_text"
                     isRequired={false}
+                    richText={true}
                     description={QuestionEdit('descriptions.sampleText')}
                     textAreaClasses={styles.questionFormField}
                     label={QuestionEdit('labels.sampleText')}

--- a/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
+++ b/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
@@ -35,6 +35,7 @@
     
     .pageheader-title {
       margin-bottom: 0;
+      max-width: 70%;
     }
 
     .link {
@@ -77,6 +78,13 @@
   
   .react-aria-TextField {
     margin-bottom: 0;
+    max-width: 70%;
+  }
+
+  // Custom input class
+  .titleChange-input {
+    margin-bottom: 0;
+    max-width: 100%;
   }
   
   // Field wrapper takes most of the space
@@ -116,9 +124,4 @@
     flex-basis: 100%;
     margin-top: 16px;
   }
-}
-
-// Custom input class
-.titleChange-input {
-  margin-bottom: 0;
 }

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -281,6 +281,7 @@ const QuestionAdd = ({
                 <FormTextArea
                   name="question_guidance"
                   isRequired={false}
+                  richText={true}
                   textAreaClasses={styles.questionFormField}
                   label={QuestionAdd('labels.guidanceText')}
                   value={question?.guidanceText ? question?.guidanceText : ''}
@@ -294,6 +295,7 @@ const QuestionAdd = ({
                   <FormTextArea
                     name="sample_text"
                     isRequired={false}
+                    richText={true}
                     description={QuestionAdd('descriptions.sampleText')}
                     textAreaClasses={styles.questionFormField}
                     label={QuestionAdd('labels.sampleText')}


### PR DESCRIPTION
## Description

Converted Sample Text field to Rich Text Editor type on Question Forms
Fixes # ([455](https://github.com/CDLUC3/dmsp_frontend_prototype/pull/455))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Tested manually


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots
![image](https://github.com/user-attachments/assets/c9b705dd-9910-4271-b020-33384550357c)

![image](https://github.com/user-attachments/assets/3a489f6e-5e72-4993-83af-8dba8a97ee45)

![image](https://github.com/user-attachments/assets/3760a0db-4616-4758-9232-7d1eb1d25a7b)
