### PR TITLE
Fixed issue with template not refreshing after user clicks 'publish'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ NEXT_PUBLIC_BASE_URL="http://localhost:3000"
 NEXT_PUBLIC_SERVER_ENDPOINT="http://localhost:4000"
 NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT="http://localhost:4000/graphql"
 
+SERVER_ENDPOINT="http://localhost:4000"
+
 NEXT_PUBLIC_GRAPHQL_ENDPOINT="http://localhost:4000"
 NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT="http://localhost:4000/graphql"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - Removed unused component `EditQuestionPage` to avoid confusion with other components. This is a legacy component. [#379]
 
 ### Fixed
+- Fixed issue with Template not refreshing after published [#456]
 - Added Rich Text Editor for Sample Text in the Question forms [#456]
   - Adjusted widths of Edit template title to accomodate for very long titles [#456]
 - Fixed bugs related to the template builder flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 
 ### Fixed
 - Fixed issue with Template not refreshing after published [#455]
+  - Added a server endpoint env variable for graphqlServerActionHandler.ts since env variables prefixed with NEXT_PUBLIC do not work on the server side [#455]
 - Added Rich Text Editor for Sample Text in the Question forms [#456]
   - Adjusted widths of Edit template title to accomodate for very long titles [#456]
 - Fixed bugs related to the template builder flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
 - Removed unused component `EditQuestionPage` to avoid confusion with other components. This is a legacy component. [#379]
 
 ### Fixed
-- Fixed issue with Template not refreshing after published [#456]
+- Fixed issue with Template not refreshing after published [#455]
 - Added Rich Text Editor for Sample Text in the Question forms [#456]
   - Adjusted widths of Edit template title to accomodate for very long titles [#456]
 - Fixed bugs related to the template builder flow

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -156,6 +156,7 @@ const TemplateEditPage: React.FC = () => {
         } else {
           setPublishModalOpen(false);
           showSuccessToast();
+          await refetch();
         }
       }
     } catch (err) {

--- a/utils/server/graphqlServerActionHandler.ts
+++ b/utils/server/graphqlServerActionHandler.ts
@@ -57,7 +57,7 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
     };
 
     // Make the GraphQL request
-    const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/graphql`, {
+    const response = await fetch(`${process.env.SERVER_ENDPOINT}/graphql`, {
       method: "POST",
       headers,
       credentials: "include",
@@ -121,7 +121,7 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
               };
 
               // Retry GraphQL request after getting the new auth token
-              const retryResponse = await fetch(`${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}/graphql`, {
+              const retryResponse = await fetch(`${process.env.SERVER_ENDPOINT}/graphql`, {
                 method: "POST",
                 headers,
                 credentials: "include",


### PR DESCRIPTION
## Description

Currently, when a user publishes a template on the Template Overview page (`template/[templateId]`), the template does not refresh.

Added a call to `refetch()` the data.

Also, added a new env variable, `SERVER_ENDPOINT` to be used in server-side components for `/graphql` endpoints since the env variables prefixed with `NEXT_PUBLIC` are only for client-side components.

Fixes # ([455](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/455))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules