### PR TITLE
[Bug] - Fixed issue with success toast message when changing language on Profile page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - QuestionPreview component [#224]
 
 ### Updated
+- Added the `Account Profile` link on the home page for the demo and fixed the success message when updating profile [#508] [#512]
 - Updated the "add new section" page to properly split our the affiliation's sections from best practice sections [#451]
 - Changed all instances of TemplateVisibility.PRIVATE to TemplateVisibility.ORGANIZATION to accomodate backend changes and also made update to `template/[templateId]` so that the `Version` and `Last updated` titles don't show in `description` when values are undefined [#466]
 - Updated `affiliations`, `myTemplates`, `publishedTemplates`, `myProjects` queries to handle the new pagination format. Updated the corresponding pages and components only enough to keep them working as-is [#180](https://github.com/CDLUC3/dmsp_backend_prototype/issues/180)

--- a/app/[locale]/account/profile/__tests__/page.spec.tsx
+++ b/app/[locale]/account/profile/__tests__/page.spec.tsx
@@ -13,7 +13,10 @@ import {mockScrollIntoView, mockScrollTo} from '@/__mocks__/common';
 expect.extend(toHaveNoViolations);
 
 jest.mock('next/navigation', () => ({
-  useRouter: jest.fn()
+  useRouter: jest.fn(),
+  useSearchParams: () => ({
+    get: jest.fn(),
+  })
 }));
 
 jest.mock('@/utils/clientLogger', () => ({

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -11,6 +11,7 @@ const Home = () => {
         <ul>
           <li><Link href="/template">Create Template</Link>(Must be Admin to access)</li>
           <li><Link href="/projects">Create Project</Link></li>
+          <li><Link href="/account/profile">Account Profile</Link></li>
         </ul>
 
       </ContentContainer>


### PR DESCRIPTION

## Description

- The success toast was flashing and disappearing when a user changed their language on the Profile page. In order to fix that, I added a query a param when the url updates with the new locale, and I check for the query param in my useEffect, and call ShowSuccessToast from there.
- I also added a link to the `Account profile` page on the home page, so it will be easier for users to find it in the interim.

Fixes # ([512](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/512), [508](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/508)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested and ran unit tests


## Checklist:
- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [x] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules