### PR TITLE
Fixed issue with TypeAheadWithOther dropdown displaying when user clicks into the "Edit" view of User Profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@
 - Removed unused component `EditQuestionPage` to avoid confusion with other components. This is a legacy component. [#379]
 
 ### Fixed
--
+- Fixed issue with TypeAheadWithOther dropdown menu displaying when user clicks the `Edit` button on `User profile` page [#511]
 - Fixed issue with Template not refreshing after published [#455]
   - Added a server endpoint env variable for graphqlServerActionHandler.ts since env variables prefixed with NEXT_PUBLIC do not work on the server side [#455]
 - Added Rich Text Editor for Sample Text in the Question forms [#456]

--- a/app/[locale]/account/profile/page.tsx
+++ b/app/[locale]/account/profile/page.tsx
@@ -369,7 +369,7 @@ const ProfilePage: React.FC = () => {
                 <div className={`sectionContent ${styles.section}`}>
                   <Form onSubmit={handleProfileSubmit}>
                     <ErrorMessages errors={errors} ref={errorRef} />
-                    <div className="form-row two-item-row">
+                    <div className={`${isEditing ? styles.formEditingRow : styles.formRow} ${`${isEditing ? styles.twoItemRowIsEditing : styles.twoItemRow}`}`}>
                       {isEditing ? (
                         <FormInput
                           name="givenName"
@@ -408,7 +408,7 @@ const ProfilePage: React.FC = () => {
 
                     </div>
 
-                    <div className="form-row one-item-row">
+                    <div className={`${styles.formRow} ${styles.oneItemRow}`}>
                       {isEditing ? (
                         <>
                           <TypeAheadWithOther
@@ -424,7 +424,7 @@ const ProfilePage: React.FC = () => {
                             value={formData.affiliationName}
                           />
                           {otherField && (
-                            <div className="form-row one-item-row">
+                            <div className={`${styles.formRow} ${styles.oneItemRow}`}>
                               <FormInput
                                 name="otherAffiliationName"
                                 type="text"
@@ -447,7 +447,7 @@ const ProfilePage: React.FC = () => {
                       )}
                     </div>
 
-                    <div className="form-row one-item-row">
+                    <div className={`${styles.formRow} ${styles.oneItemRow}`}>
                       {isEditing ? (
                         <FormSelect
                           label="Language"
@@ -473,16 +473,16 @@ const ProfilePage: React.FC = () => {
                         </Text>
                       )}
                     </div>
-                    {isEditing ? (
-                      <div className={styles.btnContainer}>
-                        <Button className="secondary" onPress={cancelEdit}>{t('btnCancel')}</Button>
-                        <Button type="submit" isDisabled={updateUserProfileLoading} className={styles.btn}>{updateUserProfileLoading ? t('btnUpdating') : t('btnUpdate')}</Button>
-                      </div>
-                    ) : (
-                      <div className={styles.btnContainer}>
-                        <Button type="submit" onPress={handleEdit} className={styles.btn}>{t('btnEdit')}</Button>
-                      </div>
-                    )}
+                      {isEditing ? (
+                        <div className={styles.btnContainer}>
+                          <Button className="secondary" onPress={() => cancelEdit()}>{t('btnCancel')}</Button>
+                          <Button type="submit" isDisabled={updateUserProfileLoading} className={styles.btn}>{updateUserProfileLoading ? t('btnUpdating') : t('btnUpdate')}</Button>
+                        </div>
+                      ) : (
+                        <div className={styles.btnContainer}>
+                          <Button onPress={() => handleEdit()} className={styles.btnEdit}>{t('btnEdit')}</Button>
+                        </div>
+                      )}
                   </Form>
                 </div>
               </div>

--- a/app/[locale]/account/profile/profile.module.scss
+++ b/app/[locale]/account/profile/profile.module.scss
@@ -50,3 +50,58 @@
 .btn {
   margin-left: auto;
 }
+
+.btnEdit {
+  @include device(sm) {
+    margin-left: auto;
+    margin-right: 0;
+  }
+  margin-right: auto;
+  margin-left: 0;
+}
+
+// Form spacing styles
+.formRow {
+  margin: 20px 0;
+  min-height: 85px;
+}
+
+.twoItemRow {
+  @include device(sm) {
+    flex-direction: row;
+  }
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  > div {
+    flex: 1; /* Make both fields take equal width */
+  }
+}
+
+.oneItemRow {
+  max-width: 100%;
+  input {
+    max-width: 100%;
+  }
+}
+
+.formEditingRow {
+  margin-top: 20px;
+  margin-bottom: 0;
+}
+
+.twoItemRowIsEditing {
+  @include device(sm) {
+    flex-direction: row;
+    gap: 20px;
+  }
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+
+  > div {
+    flex: 1; /* Make both fields take equal width */
+    margin-bottom: var(--space-4);
+  }
+}

--- a/components/Form/TypeAheadWithOther/index.tsx
+++ b/components/Form/TypeAheadWithOther/index.tsx
@@ -54,6 +54,7 @@ const TypeAheadWithOther = ({
     resultsKey,
     otherText = "Other",
 }: TypeAheadInputProps) => {
+    const [initialInputValue, setInitialInputValue] = useState<string>(''); // Needed to set initial input value without triggering search
     const [inputValue, setInputValue] = useState<string>('');
     const [errorMessage, setErrorMessage] = useState<string>('');
     const [suggestions, setSuggestions] = useState<SuggestionInterface[]>([]);
@@ -105,6 +106,7 @@ const TypeAheadWithOther = ({
         setOpen(true);
         setOtherField(false);
         setInputValue('');
+        setInitialInputValue('');
         updateFormData({});
     }
 
@@ -207,7 +209,7 @@ const TypeAheadWithOther = ({
 
     useEffect(() => {
         if (value) {
-            setInputValue(value);
+            setInitialInputValue(value);
         }
     }, [])
 
@@ -305,7 +307,7 @@ const TypeAheadWithOther = ({
                 <Input
                     name={fieldName}
                     type="text"
-                    value={inputValue}
+                    value={inputValue ? inputValue : initialInputValue}
                     role="textbox"
                     aria-controls="results"
                     aria-activedescendant={activeDescendentId}

--- a/components/Form/TypeAheadWithOther/typeaheadWithOther.module.scss
+++ b/components/Form/TypeAheadWithOther/typeaheadWithOther.module.scss
@@ -50,6 +50,7 @@
   .autocompleteContainer {
     position: relative;
     min-height: 85px;
+    margin-bottom: 2rem;
   }
 
   .autocompleteDropdownArrow {


### PR DESCRIPTION

## Description

- Solved issue with TypeAheadWithOther dropdown menu displaying on render by just setting a new state variable called `initialInputValue` which is passed into the component.
- adjusted some form field styles so that the fields look more evenly spaced

Fixes # ([511](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/511))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual testing and unit testing.

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules