### PR TITLE
Ae 483 publish modal typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@
 - Fixed bug where `/template` page was continuosly refreshed when no data was returned [#351]
 - Fixed that didn't show the current title when editing a template name [#475]
 - Added the missing button to create a new template from scratch [#474]
+- Fixed typo and ensure that correct visibility text displays when changing the
+  Private/Public status in the Template Publish Modal [#483]
 
 ### Chore
 - Updated a number of packages, such as next, react-aria-components, eslint, next-intl, etc [#529]

--- a/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
@@ -215,6 +215,53 @@ describe("TemplateEditPage", () => {
     });
   })
 
+  it('should update the visibility text when publish visibility changes', async () => {
+    (useTemplateQuery as jest.Mock).mockReturnValue({
+      data: { template: mockTemplateData },
+      loading: false,
+      error: null,
+    });
+    (useCreateTemplateVersionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }), // Correct way to mock a resolved promise
+      { loading: false, error: undefined },
+    ]);
+
+    await act(async () => {
+      render(
+        <TemplateEditPage />
+      );
+    });
+
+    // Simulate the user triggering the publishTemplate button
+    const publishTemplateButton = screen.getByRole('button', { name: /button.publishtemplate/i });
+    fireEvent.click(publishTemplateButton);
+    await waitFor(() => {
+      expect(screen.getByTestId('visPublic')).toBeInTheDocument();
+    });
+
+    const publicOption = screen.getByTestId('visPublic');
+    const privateOption = screen.getByTestId('visPrivate');
+
+    expect(publicOption).toBeInTheDocument();
+    expect(privateOption).toBeInTheDocument();
+
+    // Test the public option
+    fireEvent.click(publicOption);
+    await waitFor(() => {
+      const visBullet = screen.getByTestId('visText');
+      expect(visBullet).toBeInTheDocument();
+      expect(visBullet).toHaveTextContent('bullet.publishingTemplate3');
+    });
+
+    // Test the Private Option
+    fireEvent.click(privateOption);
+    await waitFor(() => {
+      const visBullet = screen.getByTestId('visText');
+      expect(visBullet).toBeInTheDocument();
+      expect(visBullet).toHaveTextContent('bullet.publishingTemplate3Private');
+    });
+  });
+
   it('should set correct error when useCreate returns error', async () => {
     (useTemplateQuery as jest.Mock).mockReturnValue({
       data: { template: mockTemplateData },

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -69,6 +69,10 @@ const TemplateEditPage: React.FC = () => {
   const Messaging = useTranslations('Messaging');
   const Global = useTranslations('Global');
 
+  // Used to set the translated visibility text, based on the
+  // public/private choice.
+  const [visibilityText, setVisibilityText] = useState<string>("");
+
   // Get templateId param
   const params = useParams();
   const router = useRouter();
@@ -245,6 +249,14 @@ const TemplateEditPage: React.FC = () => {
       }
       //Need to refetch plan data to refresh the info that was changed
       await refetch();
+    }
+  }
+
+  function handleVisibilityChange(value: string) {
+    if (value == "public") {
+      setVisibilityText(PublishTemplate('bullet.publishingTemplate3'));
+    } else if (value == "private") {
+      setVisibilityText(PublishTemplate('bullet.publishingTemplate3Private'));
     }
   }
 
@@ -453,18 +465,29 @@ const TemplateEditPage: React.FC = () => {
               <ErrorMessages errors={errorMessages} ref={errorRef} />
               <Heading slot="title">{PublishTemplate('heading.publish')}</Heading>
 
-              <RadioGroup name="visibility">
+              <RadioGroup
+                name="visibility"
+                onChange={handleVisibilityChange}
+              >
                 <Label>{PublishTemplate('heading.visibilitySettings')}</Label>
                 <Text slot="description" className="help">
                   {PublishTemplate('descPublishedTemplate')}
                 </Text>
-                <Radio value="public" className={`${styles.radioBtn} react-aria-Radio`}>
+                <Radio
+                  data-testid="visPublic"
+                  value="public"
+                  className={`${styles.radioBtn} react-aria-Radio`}
+                >
                   <div>
                     <span>{PublishTemplate('radioBtn.public')}</span>
-                    <p className="text-gray-600 text-sm">{PublishTemplate('radioBtn.publicHelpText')}.</p>
+                    <p className="text-gray-600 text-sm">{PublishTemplate('radioBtn.publicHelpText')}</p>
                   </div>
                 </Radio>
-                <Radio value="private" className={`${styles.radioBtn} react-aria-Radio`}>
+                <Radio
+                  data-testid="visPrivate"
+                  value="private"
+                  className={`${styles.radioBtn} react-aria-Radio`}
+                >
                   <div>
                     <span>{PublishTemplate('radioBtn.organizationOnly')}</span>
                     <p className="text-gray-600 text-sm">{PublishTemplate('radioBtn.orgOnlyHelpText')}</p>
@@ -485,9 +508,11 @@ const TemplateEditPage: React.FC = () => {
                 <li>
                   {PublishTemplate('bullet.publishingTemplate2')}
                 </li>
-                <li>
-                  {PublishTemplate('bullet.publishingTemplate3')}
-                </li>
+                {visibilityText && (
+                  <li data-testid="visText">
+                    {visibilityText}
+                  </li>
+                )}
               </ul>
               <div className="">
 

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -71,7 +71,8 @@
     "bullet": {
       "publishingTemplate": "After publication, all new plans will use this version.",
       "publishingTemplate2": "In-progress or existing plans will not be updated.",
-      "publishingTemplate3": "You have configured Visibility as Public in Template options. All DMP Tool users will be able to see and use this template."
+      "publishingTemplate3": "You have configured Visibility as Public in Template options. All DMP Tool users will be able to see and use this template.",
+      "publishingTemplate3Private": "You have configured Visibility as Private in Template options. Only DMP Tool users within your organization will be able to see and use this template."
     },
     "descChangeLog": "Enter a short description of what has been changed. This will only be visible to people in your organization.",
     "button": {


### PR DESCRIPTION
## Description

- Fixed typo and ensure that correct visibility text displays when changing the
  Private/Public status in the Template Publish Modal [#483]

Fixes #483 

## Type of change
Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual testing by navigating to the Template create page, Creating a template, and then clicking the publish modal. I then verified that the text updates when I change visibility a number of times.
- Also created a new unit test to verify that the text is updated correctly
- I ran `npm run lint` and `npm run type-check` against my new code to ensure that there are no typing and linting issues.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes