### PR TITLE
 Add Delete Section Functionality to Template Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Added
+- Added delete section functionality to template builder with confirmation modal, including translations, and tests
+
 ### Updated
 - Clean up connections page and buttons [#516]
 

--- a/app/[locale]/template/[templateId]/section/[section_slug]/sectionUpdate.module.scss
+++ b/app/[locale]/template/[templateId]/section/[section_slug]/sectionUpdate.module.scss
@@ -1,0 +1,16 @@
+.deleteSectionContainer {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.dangerZoneDescription {
+  margin-bottom: 1rem;
+}
+
+.deleteConfirmButtons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 1rem;
+}

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -3864,6 +3864,13 @@ export type UpdateSectionMutationVariables = Exact<{
 
 export type UpdateSectionMutation = { __typename?: 'Mutation', updateSection: { __typename?: 'Section', id?: number | null, name: string, introduction?: string | null, requirements?: string | null, guidance?: string | null, displayOrder?: number | null, bestPractice?: boolean | null, errors?: { __typename?: 'SectionErrors', general?: string | null, name?: string | null, introduction?: string | null, requirements?: string | null, guidance?: string | null } | null, tags?: Array<{ __typename?: 'Tag', id?: number | null, description?: string | null, name: string } | null> | null } };
 
+export type RemoveSectionMutationVariables = Exact<{
+  sectionId: Scalars['Int']['input'];
+}>;
+
+
+export type RemoveSectionMutation = { __typename?: 'Mutation', removeSection: { __typename?: 'Section', id?: number | null, name: string } };
+
 export type AddTemplateCollaboratorMutationVariables = Exact<{
   templateId: Scalars['Int']['input'];
   email: Scalars['String']['input'];
@@ -4863,6 +4870,40 @@ export function useUpdateSectionMutation(baseOptions?: Apollo.MutationHookOption
 export type UpdateSectionMutationHookResult = ReturnType<typeof useUpdateSectionMutation>;
 export type UpdateSectionMutationResult = Apollo.MutationResult<UpdateSectionMutation>;
 export type UpdateSectionMutationOptions = Apollo.BaseMutationOptions<UpdateSectionMutation, UpdateSectionMutationVariables>;
+export const RemoveSectionDocument = gql`
+    mutation RemoveSection($sectionId: Int!) {
+  removeSection(sectionId: $sectionId) {
+    id
+    name
+  }
+}
+    `;
+export type RemoveSectionMutationFn = Apollo.MutationFunction<RemoveSectionMutation, RemoveSectionMutationVariables>;
+
+/**
+ * __useRemoveSectionMutation__
+ *
+ * To run a mutation, you first call `useRemoveSectionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveSectionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeSectionMutation, { data, loading, error }] = useRemoveSectionMutation({
+ *   variables: {
+ *      sectionId: // value for 'sectionId'
+ *   },
+ * });
+ */
+export function useRemoveSectionMutation(baseOptions?: Apollo.MutationHookOptions<RemoveSectionMutation, RemoveSectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RemoveSectionMutation, RemoveSectionMutationVariables>(RemoveSectionDocument, options);
+      }
+export type RemoveSectionMutationHookResult = ReturnType<typeof useRemoveSectionMutation>;
+export type RemoveSectionMutationResult = Apollo.MutationResult<RemoveSectionMutation>;
+export type RemoveSectionMutationOptions = Apollo.BaseMutationOptions<RemoveSectionMutation, RemoveSectionMutationVariables>;
 export const AddTemplateCollaboratorDocument = gql`
     mutation AddTemplateCollaborator($templateId: Int!, $email: String!) {
   addTemplateCollaborator(templateId: $templateId, email: $email) {

--- a/graphql/mutations/sections.mutation.graphql
+++ b/graphql/mutations/sections.mutation.graphql
@@ -51,3 +51,10 @@ mutation UpdateSection($input: UpdateSectionInput!) {
     }
   }
 }
+
+mutation RemoveSection($sectionId: Int!) {
+  removeSection(sectionId: $sectionId) {
+    id
+    name
+  }
+}

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -163,10 +163,25 @@
   },
   "SectionUpdatePage": {
     "title": "Update section",
+    "buttons": {
+      "deleteSection": "Delete section"
+    },
     "messages": {
       "fieldLengthValidation": "Name must be at least 2 characters.",
       "errorUpdatingSection": "Error when updating section.",
-      "success": "Section updated successfully."
+      "success": "Section updated successfully.",
+      "errorDeletingSection": "Error when deleting section.",
+      "successDeletingSection": "Section deleted successfully."
+    },
+    "deleteModal": {
+      "title": "Delete section",
+      "content": "Deleting this section will also permanently remove all associated questions. Deletion is not reversible.",
+      "cancelButton": "Cancel",
+      "deleteButton": "Delete section"
+    },
+    "deleteSection": {
+      "heading": "Delete this section",
+      "description": "Deleting this section will also permanently remove all associated questions. Deletion is not reversible."
     }
   },
   "QuestionTypeSelectPage": {

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -163,10 +163,25 @@
   },
   "SectionUpdatePage": {
     "title": "Seção de atualização",
+    "buttons": {
+      "deleteSection": "Excluir seção"
+    },
     "messages": {
       "fieldLengthValidation": "O nome precisa ter pelo menos 3 caracteres",
       "errorUpdatingSection": "Erro ao criar a seção.",
-      "success": "Seção criada com sucesso."
+      "success": "Seção criada com sucesso.",
+      "errorDeletingSection": "Erro ao excluir a seção.",
+      "successDeletingSection": "Seção excluída com sucesso."
+    },
+    "deleteModal": {
+      "title": "Excluir seção",
+      "content": "Excluir esta seção também removerá permanentemente todas as perguntas associadas. A exclusão não é reversível.",
+      "cancelButton": "Cancelar",
+      "deleteButton": "Excluir seção"
+    },
+    "deleteSection": {
+      "heading": "Excluir esta seção",
+      "description": "Excluir esta seção também removerá permanentemente todas as perguntas associadas. A exclusão não é reversível."
     }
   },
   "QuestionTypeSelectPage": {
@@ -191,14 +206,16 @@
     "clearFilter": "filtros transparentes",
     "buttons": {
       "loadMore": "Carregue mais {name}",
-      "load3More": "Carregue mais 3"
+      "load3More": "Carregue mais 3",
+      "startNew": "Iniciar"
     },
     "headings": {
       "previouslyCreatedTemplates": "Use uma de suas seções criadas anteriormente",
-      "publicTemplates": "Use um dos modelos públicos"
+      "publicTemplates": "Use um dos modelos públicos",
+      "createNew": "Criar novo modelo"
     },
     "messages": {
-      "noItemsFound": "Nenhum “item” encontrado",
+      "noItemsFound": "Nenhum items encontrado",
       "missingTemplateName": "Nome do modelo não pode ser vazio.",
       "loadingError": "Erro ao carregar modelos. Tente novamente mais tarde."
     }


### PR DESCRIPTION
## Description

Added delete functionality for sections in the template builder, similar to the question delete feature. This includes a delete button, confirmation and translations.

Fixes #457

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Mix of automated and manual testing 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have completed manual or automated accessibility testing for my changes
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
