### PR TITLE
Chore/js improve unit testing to capture extraneous errors even with passing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-### Updated
-- Clean up connections page and buttons [#516]
+### Added
+- Added a test in `jest.setup.ts` to catch extraneous errors that are not tested or in a unit test.
 
 ### Updated
+- Clean up connections page and buttons [#516]
 - Added spacing on the `Account Profile` for the demo [#509]
 - Updated `Account Profile` to use routePath() instead of hardcoded paths
 - fix translation string to use the correct tags for the `Account Profile` [#515]

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -37,3 +37,51 @@ jest.mock('next/navigation', () => ({
   useRouter: jest.fn()
 }))
 
+
+// Make sure to catch extraneous errors that occur even when unit tests pass
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+
+let caughtConsoleErrors: string[] = [];
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  caughtConsoleErrors = [];
+
+  console.error = (...args) => {
+    const message = args.join(' ');
+    if (message.startsWith('Error:')) {
+      caughtConsoleErrors.push(message);
+    }
+    originalConsoleError(...args); // Still log it for debugging
+  };
+
+  console.warn = originalConsoleWarn;
+
+  process.on('unhandledRejection', (reason: unknown) => {
+    if (reason instanceof Error && reason.message.startsWith('Error:')) {
+      caughtConsoleErrors.push(`Unhandled rejection: ${reason.message}`);
+    }
+  });
+
+  process.on('uncaughtException', (err: unknown) => {
+    if (err instanceof Error && err.message.startsWith('Error:')) {
+      caughtConsoleErrors.push(`Uncaught exception: ${err.message}`);
+    }
+  });
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+  console.warn = originalConsoleWarn;
+
+  process.removeAllListeners('unhandledRejection');
+  process.removeAllListeners('uncaughtException');
+
+  if (caughtConsoleErrors.length > 0) {
+    const combined = caughtConsoleErrors.join('\n');
+    throw new Error(
+      `Test had unexpected console.error logs starting with "Error:":\n\n${combined}`
+    );
+  }
+});

--- a/lib/graphql/__tests__/graphqlHelpers.spec.ts
+++ b/lib/graphql/__tests__/graphqlHelpers.spec.ts
@@ -5,12 +5,17 @@ import {
   Observable,
   Operation
 } from "@apollo/client";
-import { redirect } from "next/navigation";
 import { GraphQLError, Kind } from "graphql";
 import { errorLink } from "@/lib/graphql/graphqlHelper";
 import logECS from "@/utils/clientLogger";
 import { refreshAuthTokens, fetchCsrfToken } from "@/utils/authHelper";
+import * as navigationUtils from '@/utils/navigation';
 
+
+// Mock the navigation utility
+jest.mock('@/utils/navigation', () => ({
+  navigateTo: jest.fn(),
+}));
 
 // Mock the entire module
 jest.mock("@/utils/clientLogger", () => ({
@@ -27,6 +32,9 @@ jest.mock("next/navigation", () => ({
   redirect: jest.fn()
 }))
 
+
+const mockNavigateTo = navigationUtils.navigateTo as jest.MockedFunction<typeof navigationUtils.navigateTo>;
+
 describe("GraphQL Errors", () => {
   let operation: Operation;
   let forward: NextLink;
@@ -34,8 +42,7 @@ describe("GraphQL Errors", () => {
   beforeEach(() => {
     // Reset all mocks
     jest.clearAllMocks();
-
-    window.location.href = '';
+    mockNavigateTo.mockClear();
 
     // Setup operation mock with proper typing
     operation = {
@@ -171,7 +178,7 @@ describe("GraphQL Errors", () => {
           expect.stringContaining('Internal Server Error'),
           expect.objectContaining({ errorCode: 'INTERNAL_SERVER_ERROR' })
         );
-        expect(redirect).toHaveBeenCalledWith("/500-error");
+        expect(mockNavigateTo).toHaveBeenCalledWith('/500-error');
       },
     });
   });

--- a/lib/graphql/graphqlHelper.ts
+++ b/lib/graphql/graphqlHelper.ts
@@ -3,6 +3,7 @@ import { Observable } from "@apollo/client";
 import logECS from "@/utils/clientLogger";
 import { RetryLink } from "@apollo/client/link/retry";
 import { createAuthLink } from "@/utils/authLink";
+import { navigateTo } from "@/utils/navigation";
 import { fetchCsrfToken, refreshAuthTokens } from "@/utils/authHelper";
 
 interface CustomError extends Error {
@@ -31,11 +32,11 @@ export const errorLink = onError(({ graphQLErrors, networkError, operation, forw
                   return;
                 } else {
                   logECS('error', 'Token refresh failed with no result', { errorCode: 'UNAUTHENTICATED' });
-                  window.location.href = '/login';
+                  navigateTo('/login');
                 }
               } catch (error) {
                 logECS('error', 'Token refresh failed', { error });
-                window.location.href = '/login';
+                navigateTo('/login');
               }
               break;
 
@@ -53,11 +54,11 @@ export const errorLink = onError(({ graphQLErrors, networkError, operation, forw
                   return;
                 } else {
                   logECS('error', 'Token refresh failed with no result', { errorCode: 'FORBIDDEN' });
-                  window.location.href = '/login';
+                  navigateTo('/login');
                 }
               } catch (error) {
                 logECS('error', 'Fetching csrf token failed', { error });
-                window.location.href = '/login';
+                navigateTo('/login');
               }
               break;
 
@@ -67,7 +68,7 @@ export const errorLink = onError(({ graphQLErrors, networkError, operation, forw
               logECS('error', `[GraphQL Error]: INTERNAL_SERVER_ERROR - ${message}`, {
                 errorCode: 'INTERNAL_SERVER_ERROR'
               });
-              window.location.href = '/500-error';
+              navigateTo('/500-error');
               break;
 
             default:

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -1,0 +1,3 @@
+export const navigateTo = (url: string) => {
+  window.location.href = url;
+};


### PR DESCRIPTION
## Description

Currently, we may get passing unit tests in NextJS, but we sometimes get exceptions that are not captured because we are not testing for them in the unit test, and jest/react-testing-library just lets those errors go through. These unhandled errors could disrupt unit test results by giving false positives. These errors also contribute to a lot of noise in the logs when we run our tests.

Therefore, I added another test in `jest.setup.ts` that will hopefully capture those errors. I found that if I filter the exceptions on `Error:`, it seems to just catch real errors, rather than catching all `console.error` that includes ones we log intentionally in our unit tests.

This new test already caught one of those issues with the unit test in graphqlHelper.ts. I added `navigateion.ts` util so that we can adequately test the redirects for INTERNAL_SERVER_ERROR, and address the navigation error.

Fixes # ([548](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/548))

## Type of change

- [X] Chore

## How Has This Been Tested?
Ran unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules