### PR TITLE
Removed the Sample Text field for most question types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Updated
 - Clean up connections page and buttons [#516]
-
-### Updated
 - Added spacing on the `Account Profile` for the demo [#509]
 - Updated `Account Profile` to use routePath() instead of hardcoded paths
 - fix translation string to use the correct tags for the `Account Profile` [#515]
+
+### Fixed
+- Removed the `Sample text` field from the Question Add/Edit forms for all question types except for `textArea` [#564]
+
 
 ## v0.0.1
 - Plan Manage Access [#299]

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -60,11 +60,11 @@ import {
   QuestionTypesInterface
 } from '@/app/types';
 import {
-  TEXT_QUESTION_TYPE,
   RANGE_QUESTION_TYPE,
   TYPEAHEAD_QUESTION_TYPE,
   DATE_RANGE_QUESTION_TYPE,
-  NUMBER_RANGE_QUESTION_TYPE
+  NUMBER_RANGE_QUESTION_TYPE,
+  TEXT_AREA_QUESTION_TYPE
 } from '@/lib/constants';
 import {
   isOptionsType,
@@ -628,7 +628,7 @@ const QuestionEdit = () => {
 
                 />
 
-                {!hasOptions && (
+                {questionType === TEXT_AREA_QUESTION_TYPE && (
                   <FormTextArea
                     name="sample_text"
                     isRequired={false}
@@ -644,7 +644,7 @@ const QuestionEdit = () => {
                   />
                 )}
 
-                {questionType && TEXT_QUESTION_TYPE.includes(questionType) && (
+                {questionType === TEXT_AREA_QUESTION_TYPE && (
                   <Checkbox
                     onChange={() => setQuestion({
                       ...question,

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -49,9 +49,9 @@ import { routePath } from '@/utils/routes';
 import { Question, QuestionOptions } from '@/app/types';
 import {
   OPTIONS_QUESTION_TYPES,
-  TEXT_QUESTION_TYPE,
   RANGE_QUESTION_TYPE,
-  TYPEAHEAD_QUESTION_TYPE
+  TYPEAHEAD_QUESTION_TYPE,
+  TEXT_AREA_QUESTION_TYPE
 } from '@/lib/constants';
 import {
   isOptionsType,
@@ -136,7 +136,7 @@ const QuestionAdd = ({
     }
 
     // Filter out null/undefined questions and handle missing displayOrder
-    const validDisplayOrders = (questionDisplayOrders.questions ?? [])
+    const validDisplayOrders = questionDisplayOrders.questions
       .map(q => q?.displayOrder)
       .filter((order): order is number => typeof order === 'number');
 
@@ -486,7 +486,7 @@ const QuestionAdd = ({
                   onChange={(newValue) => handleInputChange('guidanceText', newValue)}
                 />
 
-                {!hasOptions && (
+                {questionType === TEXT_AREA_QUESTION_TYPE && (
                   <FormTextArea
                     name="sample_text"
                     isRequired={false}
@@ -501,7 +501,7 @@ const QuestionAdd = ({
                 )}
 
 
-                {questionType && TEXT_QUESTION_TYPE.includes(questionType) && (
+                {questionType === TEXT_AREA_QUESTION_TYPE && (
                   <Checkbox
                     onChange={() => handleInputChange('useSampleTextAsDefault', !question?.useSampleTextAsDefault)}
                     isSelected={question?.useSampleTextAsDefault || false}


### PR DESCRIPTION

## Description

Removed `Sample text` field from the "Add Question" and "Edit Question" forms for all question types except for `textArea`.

Fixes # ([564](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/564))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules