### PR TITLE
AE - Plan Funder data integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Added
 - Added delete section functionality to template builder with confirmation modal, including translations, and tests
 - Implemented a "Delete Question" feature on the question editing page with extra dialog and with tests
+- Hook up the Plan Funder page with actual data so that the user can manage funders on their plan. [#363]
 
 ### Updated
 - Clean up connections page and buttons [#516]

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
@@ -209,7 +209,7 @@ describe('PlanOverviewPage', () => {
       expect(screen.getByRole('heading', { level: 2, name: 'publishModal.publish.visibilityOptionsTitle' })).toBeInTheDocument();
       expect(screen.getByRole('radio', { name: /private/i })).toBeInTheDocument();
       expect(screen.getByRole('radio', { name: /public/i })).toBeInTheDocument();
-      expect(screen.getByRole('radio', { name: /organizational/i })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /organization/i })).toBeInTheDocument();
       expect(screen.getByText('publishModal.publish.visibilityOptions.public.label')).toBeInTheDocument();
       expect(screen.getByText('publishModal.publish.visibilityOptions.public.description')).toBeInTheDocument();
       expect(screen.getByText('publishModal.publish.visibilityOptions.organization.label')).toBeInTheDocument();
@@ -234,7 +234,7 @@ describe('PlanOverviewPage', () => {
     await waitFor(() => {
       const privateRadio = screen.getByRole('radio', { name: /private/i });
       const publicRadio = screen.getByRole('radio', { name: /public/i });
-      const organizationalRadio = screen.getByRole('radio', { name: /organizational/i });
+      const organizationalRadio = screen.getByRole('radio', { name: /organization/i });
 
       // Check initial state (none selected by default)
       expect(privateRadio).not.toBeChecked();

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/feedback/invite/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/feedback/invite/__tests__/page.spec.tsx
@@ -100,12 +100,12 @@ describe('ProjectsProjectPlanFeedbackInvite', () => {
     expect(within(addCollaboratorForm).getByRole('textbox', { name: 'formLabels.email' })).toBeInTheDocument();
     expect(within(addCollaboratorForm).getByText('radioButtons.access.label')).toBeInTheDocument();
     const radioButton1 = screen.getByRole('radio', {
-      name: 'edit',
+      name: 'radioButtons.access.edit',
       checked: true,
     });
     expect(radioButton1).toBeInTheDocument();
     const radioButton2 = screen.getByRole('radio', {
-      name: 'comment',
+      name: 'radioButtons.access.comment',
       checked: false
     });
     expect(radioButton2).toBeInTheDocument();
@@ -191,7 +191,7 @@ describe('ProjectsProjectPlanFeedbackInvite', () => {
     expect(emailField).toHaveValue('testing@example.com');
 
     // Select the "Comment only" radio option
-    const commentOnlyRadio = screen.getByRole('radio', { name: 'comment' });
+    const commentOnlyRadio = screen.getByRole('radio', { name: 'radioButtons.access.comment' });
     fireEvent.click(commentOnlyRadio);
 
     // Click "Grant Access" button
@@ -232,7 +232,7 @@ describe('ProjectsProjectPlanFeedbackInvite', () => {
     expect(emailField).toHaveValue('testing@example.com');
 
     // Select the "Comment only" radio option
-    const commentOnlyRadio = screen.getByRole('radio', { name: 'comment' });
+    const commentOnlyRadio = screen.getByRole('radio', { name: 'radioButtons.access.comment' });
     fireEvent.click(commentOnlyRadio);
 
     // Click "Grant Access" button

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/__tests__/page.spec.tsx
@@ -299,8 +299,9 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
       </MockedProvider>
     );
 
-    expect(screen.getByText('Add a new funding source')).toBeInTheDocument();
-    expect(screen.getByText('Add a new funding source').closest('a')).toHaveAttribute('href', '/projects/proj_2425/fundings/');
+    const addFundingLink = screen.getByText("Add a new funding source");
+    expect(addFundingLink).toBeInTheDocument();
+    expect(addFundingLink).toHaveAttribute('href', '/en-US/projects/123/fundings/search');
   });
 
   it('should pass accessibility tests', async () => {

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/__tests__/page.spec.tsx
@@ -12,6 +12,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { MockedProvider } from '@apollo/client/testing';
 import {
   ProjectFundingsDocument,
+  PlanFundingsDocument,
   AddPlanFundingDocument,
 } from '@/generated/graphql';
 
@@ -28,6 +29,29 @@ expect.extend(toHaveNoViolations);
 
 // GraphQL Mocks
 const MOCKS = [
+  // Fetch the existing project funding selection
+  {
+    request: {
+      query: PlanFundingsDocument,
+      variables: {
+        planId: 456,
+      },
+    },
+
+    result: {
+      data: {
+        planFundings: [
+          {
+            id: 101,
+            projectFunding: {
+              id: 222
+            }
+          },
+        ],
+      },
+    },
+  },
+
   // Fetch Project Funders: Success
   {
     request: {
@@ -218,6 +242,24 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
     );
 
     expect(screen.getByRole('button', { name: 'buttons.save' })).toBeInTheDocument();
+  });
+
+  it('should have the current funding choice selected', async () => {
+    render(
+      <MockedProvider mocks={MOCKS} addTypename={false}>
+        <ProjectsProjectPlanAdjustFunding />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      const optionA = screen.getByRole('radio', { name: 'Project Funder A' });
+      expect(optionA).toBeInTheDocument();
+      expect(optionA).not.toBeChecked();
+
+      const optionB = screen.getByRole('radio', { name: 'Project Funder B' });
+      expect(optionB).toBeInTheDocument();
+      expect(optionB).toBeChecked();
+    });
   });
 
   it('should handle form submission', async () => {

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/__tests__/page.spec.tsx
@@ -22,6 +22,7 @@ import { stripHtml, scrollToTop } from '@/utils/general';
 import logECS from '@/utils/clientLogger';
 
 import ProjectsProjectPlanAdjustFunding from '../page';
+import { useToast } from '@/context/ToastContext';
 
 
 expect.extend(toHaveNoViolations);
@@ -180,6 +181,10 @@ jest.mock('@/components/PageHeader', () => ({
   default: () => <div data-testid="mock-page-header" />
 }));
 
+const mockToast = {
+  add: jest.fn(),
+};
+
 
 // Keep these separate and lean, so that we can customize based on
 // test requirements
@@ -202,6 +207,9 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
       projectId: '123',
       dmpid: '456',
     });
+
+    // Mock Toast
+    (useToast as jest.Mock).mockReturnValue(mockToast);
   });
 
   afterEach(() => {
@@ -279,6 +287,7 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
     fireEvent.click(saveButton);
 
     await waitFor(() => {
+      expect(mockToast.add).toHaveBeenCalledWith('successfullyUpdated', { type: 'success' });
       expect(mockUseRouter().push).toHaveBeenCalledWith('/en-US/projects/123/dmp/456');
     });
   });

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/__tests__/page.spec.tsx
@@ -191,7 +191,7 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
       </MockedProvider>
     );
 
-    expect(screen.getByText('Select funding sources for this plan')).toBeInTheDocument();
+    expect(screen.getByText('fundingLabel')).toBeInTheDocument();
 
     // Wait for the graphQL query to finish and check if the results are in
     await waitFor(() => {
@@ -207,7 +207,7 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
       </MockedProvider>
     );
 
-    expect(screen.getByText(/Note: Changing the funding sources may require a template change./)).toBeInTheDocument();
+    expect(screen.getByText('changeWarning')).toBeInTheDocument();
   });
 
   it('should render the save button', () => {
@@ -217,7 +217,7 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
       </MockedProvider>
     );
 
-    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.save' })).toBeInTheDocument();
   });
 
   it('should handle form submission', async () => {
@@ -233,7 +233,7 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
       fireEvent.click(option);
     });
 
-    const saveButton = screen.getByRole('button', { name: 'Save' });
+    const saveButton = screen.getByRole('button', { name: 'buttons.save' });
     fireEvent.click(saveButton);
 
     await waitFor(() => {
@@ -254,7 +254,7 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
       fireEvent.click(option);
     });
 
-    const saveButton = screen.getByRole('button', { name: 'Save' });
+    const saveButton = screen.getByRole('button', { name: 'buttons.save' });
     fireEvent.click(saveButton);
 
     await waitFor(() => {
@@ -277,7 +277,7 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
       fireEvent.click(option);
     });
 
-    const saveButton = screen.getByRole('button', { name: 'Save' });
+    const saveButton = screen.getByRole('button', { name: 'buttons.save' });
     fireEvent.click(saveButton);
 
     await waitFor(() => {
@@ -299,7 +299,7 @@ describe('ProjectsProjectPlanAdjustFunding', () => {
       </MockedProvider>
     );
 
-    const addFundingLink = screen.getByText("Add a new funding source");
+    const addFundingLink = screen.getByText("addSourceLink");
     expect(addFundingLink).toBeInTheDocument();
     expect(addFundingLink).toHaveAttribute('href', '/en-US/projects/123/fundings/search');
   });

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
@@ -1,7 +1,17 @@
 'use client';
 
-import React from 'react';
-import { useRouter } from 'next/navigation';
+import React, { useState, useRef } from 'react';
+import { useRouter, useParams, usePathname } from 'next/navigation';
+
+import {
+  useProjectFundingsQuery,
+  useAddPlanFundingMutation,
+  PlanFundingErrors,
+} from '@/generated/graphql';
+
+import { routePath } from '@/utils/routes';
+import logECS from '@/utils/clientLogger';
+
 import {
   Breadcrumb,
   Breadcrumbs,
@@ -15,18 +25,93 @@ import {
 } from "react-aria-components";
 
 import PageHeader from "@/components/PageHeader";
+import ErrorMessages from "@/components/ErrorMessages";
 import {
   ContentContainer,
   LayoutContainer,
 } from "@/components/Container";
-import { routePath } from '@/utils/routes';
+
 
 const ProjectsProjectPlanAdjustFunding = () => {
+  const [errors, setErrors] = useState<string[]>([]);
+  const errorRef = useRef<HTMLDivElement>(null);
+  const [addPlanFunding] = useAddPlanFundingMutation({});
+
+  const path = usePathname();
   const router = useRouter();
-  const handleSubmit = (e: React.FormEvent) => {
+  const params = useParams();
+
+  // NOTE:
+  // The dmpid here comes with a lowercase I (dmpid instead of dmpId).
+  // This is because the folder is named lowercased.
+  // We might create a ticket to rename the folder to sentence-cased in future,
+  // But a discussion is required as well.
+  const { projectId, dmpid: dmpId } = params;
+
+  const {data: funders} = useProjectFundingsQuery({
+    variables: {
+      projectId: Number(projectId),
+    }
+  });
+
+  /**
+   * Handle specific errors that we care about in this component.
+   * @param {ProjectFunderErrors} errs - The errors from the graphql response
+   */
+  function checkErrors(errs: PlanFundingErrors): string[] {
+    const typedKeys: (keyof PlanFundingErrors)[] = [
+      // TODO::
+      // Ask in developer meeting regarding the casing for this?
+      // Everything else starts with lowercase, but the first key here
+      // start with Uppercase
+      // I cannot change this to start with lowercase, since I have to do
+      // it in the mutation, and apollo will fail to generate cause it wants
+      // it this way.
+      "ProjectFundingId",
+      "general",
+      "projectId",
+    ];
+    const newErrors: string[] = [];
+
+    for (const k of typedKeys) {
+      const errVal = errs[k];
+      if (errVal) {
+        newErrors.push(errVal);
+      }
+    }
+
+    return newErrors
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    // Redirect or show success message
-    router.push(routePath('projects.dmp.show', { projectId: 'proj_2425', dmpId: 'xxx' }))
+
+    const NEXT_URL = routePath('projects.dmp.show', {
+      projectId: projectId as string,
+      dmpId: dmpId as string,
+    });
+
+    const formData = new FormData(e.currentTarget);
+    const projectFundingId = formData.get("funding");
+
+    addPlanFunding({
+      variables: {
+        planId: Number(dmpId),
+        projectFundingId: Number(projectFundingId),
+      },
+    }).then((result) => {
+        const errs = checkErrors(result?.data?.addPlanFunding?.errors as PlanFundingErrors);
+        if (errs.length > 0) {
+          setErrors(errs);
+        } else {
+          router.push(NEXT_URL);
+        }
+    }).catch(err => {
+      logECS('error', 'addPlanFunding', {
+        error: err.message,
+        url: { path }
+      });
+    });
   }
 
 
@@ -50,20 +135,25 @@ const ProjectsProjectPlanAdjustFunding = () => {
       />
       <LayoutContainer>
         <ContentContainer>
+          <ErrorMessages errors={errors} ref={errorRef} />
           <Form onSubmit={handleSubmit}>
-            <RadioGroup>
+            <RadioGroup name="funding">
               <Label>
                 Select funding sources for this plan
               </Label>
               <Text slot="description" className="help">
                 This funding list comes from the funding list attached to the project.
               </Text>
-              <Radio value="2525252525">
-                National Science Foundation (NSF)
-              </Radio>
-              <Radio value="new">
-                National Science Foundation - AAA (NSF-AA)
-              </Radio>
+
+              {funders?.projectFundings && funders.projectFundings.map((funder, index) => (
+                <Radio
+                  key={index}
+                  value={String(funder?.id)}
+                >
+                  {funder?.affiliation?.displayName}
+                </Radio>
+              ))}
+
             </RadioGroup>
 
             <p>
@@ -93,7 +183,6 @@ const ProjectsProjectPlanAdjustFunding = () => {
           <a href={"/projects/proj_2425/fundings/"} >
             Add a new funding source
           </a>
-
 
         </ContentContainer>
       </LayoutContainer>

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
@@ -27,6 +27,7 @@ import {
 
 import { RadioButtonInterface } from '@/app/types';
 import { RadioGroupComponent } from '@/components/Form';
+import { useToast } from '@/context/ToastContext';
 
 import PageHeader from "@/components/PageHeader";
 import ErrorMessages from "@/components/ErrorMessages";
@@ -37,8 +38,9 @@ import {
 
 
 const ProjectsProjectPlanAdjustFunding = () => {
-  const global = useTranslations('Global');
+  const Global = useTranslations('Global');
   const t = useTranslations('PlanFunding');
+  const Messaging = useTranslations('Messaging');
 
   const [radioData, setRadioData] = useState<RadioButtonInterface[]>([])
   const [fundingChoice, setFundingChoice] = useState<string>("");
@@ -48,6 +50,7 @@ const ProjectsProjectPlanAdjustFunding = () => {
   const errorRef = useRef<HTMLDivElement>(null);
   const [addPlanFunding] = useAddPlanFundingMutation({});
 
+  const toastState = useToast();
   const path = usePathname();
   const router = useRouter();
   const params = useParams();
@@ -147,6 +150,8 @@ const ProjectsProjectPlanAdjustFunding = () => {
         if (errs.length > 0) {
           setErrors(errs);
         } else {
+          const msg = Messaging('successfullyUpdated');
+          toastState.add(msg, { type: 'success' });
           router.push(NEXT_URL);
         }
     }).catch(err => {
@@ -165,13 +170,13 @@ const ProjectsProjectPlanAdjustFunding = () => {
         showBackButton={true}
         breadcrumbs={
           <Breadcrumbs>
-            <Breadcrumb><Link href="/">{global('breadcrumbs.home')}</Link></Breadcrumb>
-            <Breadcrumb><Link href={routePath('projects.index')}>{global('breadcrumbs.projects')}</Link></Breadcrumb>
+            <Breadcrumb><Link href="/">{Global('breadcrumbs.home')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.index')}>{Global('breadcrumbs.projects')}</Link></Breadcrumb>
             {projectId && dmpId && (
               <>
                 <Breadcrumb>
                   <Link href={routePath('projects.show', {projectId: String(projectId)})}>
-                    {global('breadcrumbs.project')}
+                    {Global('breadcrumbs.project')}
                   </Link>
                 </Breadcrumb>
                 <Breadcrumb>
@@ -179,13 +184,13 @@ const ProjectsProjectPlanAdjustFunding = () => {
                     projectId: String(projectId),
                     dmpId: String(dmpId)
                   })}>
-                    {global('breadcrumbs.planOverview')}
+                    {Global('breadcrumbs.planOverview')}
                   </Link>
                 </Breadcrumb>
               </>
             )}
             <Breadcrumb>
-              {global('breadcrumbs.planFunding')}
+              {Global('breadcrumbs.planFunding')}
             </Breadcrumb>
           </Breadcrumbs>
         }
@@ -212,7 +217,7 @@ const ProjectsProjectPlanAdjustFunding = () => {
               <strong>{t('changeWarning')}</strong>
             </p>
 
-            <Button type="submit">{global('buttons.save')}</Button>
+            <Button type="submit">{Global('buttons.save')}</Button>
           </Form>
 
           <h2 className="heading-3 mt-8">{t('addSourceTitle')}</h2>

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
@@ -114,7 +114,6 @@ const ProjectsProjectPlanAdjustFunding = () => {
     });
   }
 
-
   return (
     <>
       <PageHeader
@@ -180,10 +179,9 @@ const ProjectsProjectPlanAdjustFunding = () => {
             plan can only have a single source of funding as we match it to the required
             template.
           </p>
-          <a href={"/projects/proj_2425/fundings/"} >
+          <Link href={routePath('projects.fundings.search', {projectId})}>
             Add a new funding source
-          </a>
-
+          </Link>
         </ContentContainer>
       </LayoutContainer>
     </>

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
@@ -19,10 +19,7 @@ import {
   Breadcrumbs,
   Button,
   Form,
-  Label,
   Link,
-  Radio,
-  Text,
 } from "react-aria-components";
 
 import { RadioButtonInterface } from '@/app/types';

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef } from 'react';
 import { useRouter, useParams, usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 
 import {
   useProjectFundingsQuery,
@@ -33,6 +34,9 @@ import {
 
 
 const ProjectsProjectPlanAdjustFunding = () => {
+  const globalTrans = useTranslations('Global');
+  const trans = useTranslations('PlanFunding');
+
   const [errors, setErrors] = useState<string[]>([]);
   const errorRef = useRef<HTMLDivElement>(null);
   const [addPlanFunding] = useAddPlanFundingMutation({});
@@ -60,13 +64,6 @@ const ProjectsProjectPlanAdjustFunding = () => {
    */
   function checkErrors(errs: PlanFundingErrors): string[] {
     const typedKeys: (keyof PlanFundingErrors)[] = [
-      // TODO::
-      // Ask in developer meeting regarding the casing for this?
-      // Everything else starts with lowercase, but the first key here
-      // start with Uppercase
-      // I cannot change this to start with lowercase, since I have to do
-      // it in the mutation, and apollo will fail to generate cause it wants
-      // it this way.
       "ProjectFundingId",
       "general",
       "projectId",
@@ -122,8 +119,8 @@ const ProjectsProjectPlanAdjustFunding = () => {
         showBackButton={true}
         breadcrumbs={
           <Breadcrumbs>
-            <Breadcrumb><Link href="/">Home</Link></Breadcrumb>
-            <Breadcrumb><Link href="/projects">Projects</Link></Breadcrumb>
+            <Breadcrumb><Link href="/">{globalTrans('breadcrumbs.home')}</Link></Breadcrumb>
+            <Breadcrumb><Link href="/projects">{globalTrans('breadcrumbs.projects')}</Link></Breadcrumb>
           </Breadcrumbs>
         }
         actions={
@@ -137,11 +134,9 @@ const ProjectsProjectPlanAdjustFunding = () => {
           <ErrorMessages errors={errors} ref={errorRef} />
           <Form onSubmit={handleSubmit}>
             <RadioGroup name="funding">
-              <Label>
-                Select funding sources for this plan
-              </Label>
+              <Label>{trans('fundingLabel')}</Label>
               <Text slot="description" className="help">
-                This funding list comes from the funding list attached to the project.
+                {trans('fundingDescription')}
               </Text>
 
               {funders?.projectFundings && funders.projectFundings.map((funder, index) => (
@@ -156,31 +151,16 @@ const ProjectsProjectPlanAdjustFunding = () => {
             </RadioGroup>
 
             <p>
-              <strong>
-                Note: Changing the funding sources may require a template change. Only
-                change if you are sure.
-              </strong>
+              <strong>{trans('changeWarning')}</strong>
             </p>
 
-            <Button
-              type="submit"
-            >
-              Save
-            </Button>
+            <Button type="submit">{globalTrans('buttons.save')}</Button>
           </Form>
 
-
-          <h2 className="heading-3 mt-8">
-            Adding a funding source?
-          </h2>
-          <p>
-            If you want to add new funding information, you can add funding at the
-            project level. This project can have multiple funding sources, whereas each
-            plan can only have a single source of funding as we match it to the required
-            template.
-          </p>
-          <Link href={routePath('projects.fundings.search', {projectId})}>
-            Add a new funding source
+          <h2 className="heading-3 mt-8">{trans('addSourceTitle')}</h2>
+          <p>{trans('addSourceNote')}</p>
+          <Link href={routePath('projects.fundings.search', {projectId: String(projectId)})}>
+            {trans('addSourceLink')}
           </Link>
         </ContentContainer>
       </LayoutContainer>

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
@@ -34,8 +34,8 @@ import {
 
 
 const ProjectsProjectPlanAdjustFunding = () => {
-  const globalTrans = useTranslations('Global');
-  const trans = useTranslations('PlanFunding');
+  const global = useTranslations('Global');
+  const t = useTranslations('PlanFunding');
 
   const [errors, setErrors] = useState<string[]>([]);
   const errorRef = useRef<HTMLDivElement>(null);
@@ -114,13 +114,33 @@ const ProjectsProjectPlanAdjustFunding = () => {
   return (
     <>
       <PageHeader
-        title="Project Funding"
-        description="Manage funding sources for your project"
+        title={t('headerTitle')}
+        description={t('headerDescription')}
         showBackButton={true}
         breadcrumbs={
           <Breadcrumbs>
-            <Breadcrumb><Link href="/">{globalTrans('breadcrumbs.home')}</Link></Breadcrumb>
-            <Breadcrumb><Link href="/projects">{globalTrans('breadcrumbs.projects')}</Link></Breadcrumb>
+            <Breadcrumb><Link href="/">{global('breadcrumbs.home')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.index')}>{global('breadcrumbs.projects')}</Link></Breadcrumb>
+            {projectId && dmpId && (
+              <>
+                <Breadcrumb>
+                  <Link href={routePath('projects.show', {projectId: String(projectId)})}>
+                    {global('breadcrumbs.project')}
+                  </Link>
+                </Breadcrumb>
+                <Breadcrumb>
+                  <Link href={routePath('projects.dmp.show', {
+                    projectId: String(projectId),
+                    dmpId: String(dmpId)
+                  })}>
+                    {global('breadcrumbs.planOverview')}
+                  </Link>
+                </Breadcrumb>
+              </>
+            )}
+            <Breadcrumb>
+              {global('breadcrumbs.planFunding')}
+            </Breadcrumb>
           </Breadcrumbs>
         }
         actions={
@@ -134,9 +154,9 @@ const ProjectsProjectPlanAdjustFunding = () => {
           <ErrorMessages errors={errors} ref={errorRef} />
           <Form onSubmit={handleSubmit}>
             <RadioGroup name="funding">
-              <Label>{trans('fundingLabel')}</Label>
+              <Label>{t('fundingLabel')}</Label>
               <Text slot="description" className="help">
-                {trans('fundingDescription')}
+                {t('fundingDescription')}
               </Text>
 
               {funders?.projectFundings && funders.projectFundings.map((funder, index) => (
@@ -151,16 +171,16 @@ const ProjectsProjectPlanAdjustFunding = () => {
             </RadioGroup>
 
             <p>
-              <strong>{trans('changeWarning')}</strong>
+              <strong>{t('changeWarning')}</strong>
             </p>
 
-            <Button type="submit">{globalTrans('buttons.save')}</Button>
+            <Button type="submit">{global('buttons.save')}</Button>
           </Form>
 
-          <h2 className="heading-3 mt-8">{trans('addSourceTitle')}</h2>
-          <p>{trans('addSourceNote')}</p>
+          <h2 className="heading-3 mt-8">{t('addSourceTitle')}</h2>
+          <p>{t('addSourceNote')}</p>
           <Link href={routePath('projects.fundings.search', {projectId: String(projectId)})}>
-            {trans('addSourceLink')}
+            {t('addSourceLink')}
           </Link>
         </ContentContainer>
       </LayoutContainer>

--- a/app/[locale]/projects/create-project/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/create-project/__tests__/page.spec.tsx
@@ -113,7 +113,7 @@ describe('ProjectsCreateProject', () => {
     });
 
     fireEvent.change(screen.getByLabelText(/form.projectTitle/i), { target: { value: 'Test Project' } });
-    fireEvent.click(screen.getByLabelText('new'));
+    fireEvent.click(screen.getByLabelText('form.radioNewLabel'));
     fireEvent.click(screen.getByLabelText(/form.checkboxLabel/i));
     fireEvent.click(screen.getByRole('button', { name: /buttons.continue/i }));
 
@@ -165,7 +165,7 @@ describe('ProjectsCreateProject', () => {
 
 
     fireEvent.change(screen.getByLabelText(/form.projectTitle/i), { target: { value: 'Test Project' } });
-    fireEvent.click(screen.getByLabelText('new'));
+    fireEvent.click(screen.getByLabelText('form.radioExistingLabel'));
     fireEvent.click(screen.getByLabelText(/form.checkboxLabel/i));
     fireEvent.click(screen.getByRole('button', { name: /buttons.continue/i }));
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -269,7 +269,7 @@ export interface Affiliation {
   url?: string | null;
 }
 
-interface RadioButtonInterface {
+export interface RadioButtonInterface {
   value: string;
   label: string;
   description?: string | ReactNode;

--- a/components/Form/QuestionComponents/RadioButtonsQuestionComponent/__tests__/index.spec.tsx
+++ b/components/Form/QuestionComponents/RadioButtonsQuestionComponent/__tests__/index.spec.tsx
@@ -51,8 +51,9 @@ describe('RadioButtonsQuestionComponent', () => {
     expect(getByLabelText('Option 1')).toBeInTheDocument();
     expect(getByLabelText('Option 2')).toBeInTheDocument();
     expect(screen.getByText('My Radio Button Question')).toBeInTheDocument();
+
     // Find the radio input by its accessible name (from aria-label)
-    const radio = screen.getByRole('radio', { name: '2' });
+    const radio = screen.getByRole('radio', { name: 'Option 2' });
 
     // Assert the name attribute
     expect(radio).toHaveAttribute('name', 'radio-options');
@@ -95,7 +96,6 @@ describe('RadioButtonsQuestionComponent', () => {
   });
 
   it('should handle single option with no selected attribute', () => {
-
     const singleOptionParsedQuestion: RadioButtonsQuestionType = {
       meta: {
         schemaVersion: "1.0",
@@ -110,8 +110,18 @@ describe('RadioButtonsQuestionComponent', () => {
             selected: false,
           },
         },
+
+        {
+          type: "option",
+          attributes: {
+            label: "Option 2",
+            value: "option2",
+            selected: false,
+          },
+        },
       ],
     };
+
     const { getByLabelText } = render(
       <RadioButtonsQuestionComponent
         parsedQuestion={singleOptionParsedQuestion}
@@ -119,8 +129,11 @@ describe('RadioButtonsQuestionComponent', () => {
         handleRadioChange={mockHandleRadioChange}
       />
     );
-    expect(getByLabelText('option1')).not.toBeChecked();
-    fireEvent.click(getByLabelText('option1'));
+
+    expect(getByLabelText('Option 1')).not.toBeChecked();
+    expect(getByLabelText('Option 2')).not.toBeChecked();
+
+    fireEvent.click(getByLabelText('Option 1'));
     expect(mockHandleRadioChange).toHaveBeenCalledWith('option1');
   });
 

--- a/components/Form/RadioGroup/index.tsx
+++ b/components/Form/RadioGroup/index.tsx
@@ -43,7 +43,7 @@ const RadioGroupComponent: React.FC<RadioButtonProps> = ({
         </Text>
         {radioButtonData.map((radioButton, index) => (
           <div key={index}>
-            <Radio value={radioButton.value} aria-label={radioButton.value}>{radioButton.label}</Radio>
+            <Radio value={radioButton.value}>{radioButton.label}</Radio>
             {radioButton.description && (
               <Text
                 slot="description"

--- a/components/QuestionView/__tests__/index.spec.tsx
+++ b/components/QuestionView/__tests__/index.spec.tsx
@@ -680,7 +680,7 @@ describe("QuestionView", () => {
     );
     expect(screen.getByTestId('card-body').textContent).toContain('Yes');
     expect(screen.getByTestId('card-body').textContent).toContain('No');
-    expect(screen.getByRole('radio', { name: 'no' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'No' })).toBeChecked();
 
     const radioButtons = screen.getByTestId('card-body').querySelectorAll('input[type="radio"]');
     act(() => {

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -3784,6 +3784,14 @@ export type UpdatePlanStatusMutationVariables = Exact<{
 
 export type UpdatePlanStatusMutation = { __typename?: 'Mutation', updatePlanStatus?: { __typename?: 'Plan', id?: number | null, status?: PlanStatus | null, visibility?: PlanVisibility | null, errors?: { __typename?: 'PlanErrors', general?: string | null, status?: string | null } | null } | null };
 
+export type AddPlanFundingMutationVariables = Exact<{
+  planId: Scalars['Int']['input'];
+  projectFundingId: Scalars['Int']['input'];
+}>;
+
+
+export type AddPlanFundingMutation = { __typename?: 'Mutation', addPlanFunding?: { __typename?: 'PlanFunding', errors?: { __typename?: 'PlanFundingErrors', ProjectFundingId?: string | null, general?: string | null, projectId?: string | null } | null, projectFunding?: { __typename?: 'ProjectFunding', id?: number | null } | null } | null };
+
 export type AddProjectCollaboratorMutationVariables = Exact<{
   projectId: Scalars['Int']['input'];
   email: Scalars['String']['input'];
@@ -4379,6 +4387,47 @@ export function useUpdatePlanStatusMutation(baseOptions?: Apollo.MutationHookOpt
 export type UpdatePlanStatusMutationHookResult = ReturnType<typeof useUpdatePlanStatusMutation>;
 export type UpdatePlanStatusMutationResult = Apollo.MutationResult<UpdatePlanStatusMutation>;
 export type UpdatePlanStatusMutationOptions = Apollo.BaseMutationOptions<UpdatePlanStatusMutation, UpdatePlanStatusMutationVariables>;
+export const AddPlanFundingDocument = gql`
+    mutation AddPlanFunding($planId: Int!, $projectFundingId: Int!) {
+  addPlanFunding(planId: $planId, projectFundingId: $projectFundingId) {
+    errors {
+      ProjectFundingId
+      general
+      projectId
+    }
+    projectFunding {
+      id
+    }
+  }
+}
+    `;
+export type AddPlanFundingMutationFn = Apollo.MutationFunction<AddPlanFundingMutation, AddPlanFundingMutationVariables>;
+
+/**
+ * __useAddPlanFundingMutation__
+ *
+ * To run a mutation, you first call `useAddPlanFundingMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddPlanFundingMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addPlanFundingMutation, { data, loading, error }] = useAddPlanFundingMutation({
+ *   variables: {
+ *      planId: // value for 'planId'
+ *      projectFundingId: // value for 'projectFundingId'
+ *   },
+ * });
+ */
+export function useAddPlanFundingMutation(baseOptions?: Apollo.MutationHookOptions<AddPlanFundingMutation, AddPlanFundingMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddPlanFundingMutation, AddPlanFundingMutationVariables>(AddPlanFundingDocument, options);
+      }
+export type AddPlanFundingMutationHookResult = ReturnType<typeof useAddPlanFundingMutation>;
+export type AddPlanFundingMutationResult = Apollo.MutationResult<AddPlanFundingMutation>;
+export type AddPlanFundingMutationOptions = Apollo.BaseMutationOptions<AddPlanFundingMutation, AddPlanFundingMutationVariables>;
 export const AddProjectCollaboratorDocument = gql`
     mutation addProjectCollaborator($projectId: Int!, $email: String!, $accessLevel: ProjectCollaboratorAccessLevel) {
   addProjectCollaborator(

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -3988,6 +3988,13 @@ export type ProjectFundingsQueryVariables = Exact<{
 
 export type ProjectFundingsQuery = { __typename?: 'Query', projectFundings?: Array<{ __typename?: 'ProjectFunding', id?: number | null, affiliation?: { __typename?: 'Affiliation', displayName: string, uri: string } | null } | null> | null };
 
+export type PlanFundingsQueryVariables = Exact<{
+  planId: Scalars['Int']['input'];
+}>;
+
+
+export type PlanFundingsQuery = { __typename?: 'Query', planFundings?: Array<{ __typename?: 'PlanFunding', id?: number | null, projectFunding?: { __typename?: 'ProjectFunding', id?: number | null } | null } | null> | null };
+
 export type LanguagesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -5545,6 +5552,49 @@ export type ProjectFundingsQueryHookResult = ReturnType<typeof useProjectFunding
 export type ProjectFundingsLazyQueryHookResult = ReturnType<typeof useProjectFundingsLazyQuery>;
 export type ProjectFundingsSuspenseQueryHookResult = ReturnType<typeof useProjectFundingsSuspenseQuery>;
 export type ProjectFundingsQueryResult = Apollo.QueryResult<ProjectFundingsQuery, ProjectFundingsQueryVariables>;
+export const PlanFundingsDocument = gql`
+    query PlanFundings($planId: Int!) {
+  planFundings(planId: $planId) {
+    id
+    projectFunding {
+      id
+    }
+  }
+}
+    `;
+
+/**
+ * __usePlanFundingsQuery__
+ *
+ * To run a query within a React component, call `usePlanFundingsQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePlanFundingsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePlanFundingsQuery({
+ *   variables: {
+ *      planId: // value for 'planId'
+ *   },
+ * });
+ */
+export function usePlanFundingsQuery(baseOptions: Apollo.QueryHookOptions<PlanFundingsQuery, PlanFundingsQueryVariables> & ({ variables: PlanFundingsQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PlanFundingsQuery, PlanFundingsQueryVariables>(PlanFundingsDocument, options);
+      }
+export function usePlanFundingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PlanFundingsQuery, PlanFundingsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PlanFundingsQuery, PlanFundingsQueryVariables>(PlanFundingsDocument, options);
+        }
+export function usePlanFundingsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PlanFundingsQuery, PlanFundingsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<PlanFundingsQuery, PlanFundingsQueryVariables>(PlanFundingsDocument, options);
+        }
+export type PlanFundingsQueryHookResult = ReturnType<typeof usePlanFundingsQuery>;
+export type PlanFundingsLazyQueryHookResult = ReturnType<typeof usePlanFundingsLazyQuery>;
+export type PlanFundingsSuspenseQueryHookResult = ReturnType<typeof usePlanFundingsSuspenseQuery>;
+export type PlanFundingsQueryResult = Apollo.QueryResult<PlanFundingsQuery, PlanFundingsQueryVariables>;
 export const LanguagesDocument = gql`
     query Languages {
   languages {

--- a/graphql/mutations/plans.mutations.graphql
+++ b/graphql/mutations/plans.mutations.graphql
@@ -74,3 +74,17 @@ mutation UpdatePlanStatus($planId: Int!, $status: PlanStatus!) {
     visibility
   }
 }
+
+
+mutation AddPlanFunding($planId: Int!, $projectFundingId: Int!) {
+  addPlanFunding(planId: $planId, projectFundingId: $projectFundingId) {
+    errors {
+      ProjectFundingId
+      general
+      projectId
+    }
+    projectFunding {
+      id
+    }
+  }
+}

--- a/graphql/queries/fundings.query.graphql
+++ b/graphql/queries/fundings.query.graphql
@@ -7,3 +7,12 @@ query ProjectFundings($projectId: Int!) {
     }
   }
 }
+
+query PlanFundings($planId: Int!) {
+  planFundings(planId: $planId) {
+    id
+    projectFunding {
+      id
+    }
+  }
+}

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -125,6 +125,8 @@
     "addManuallyLabel": "Add funder manually"
   },
   "PlanFunding": {
+    "headerTitle": "Plan Funding",
+    "headerDescription": "Manage funding sources for this Plan",
     "fundingLabel": "Select funding sources for this plan",
     "fundingDescription": "This funding list comes from the funding list attached to the project.",
     "changeWarning": "Note: Changing the funding sources may require a template change. Only change if you are sure.",
@@ -170,6 +172,7 @@
       "projectOverview": "Project overview",
       "projectFunding": "Project funding",
       "planOverview": "Plan overview",
+      "planFunding": "Plan funding",
       "feedback": "Feedback"
     },
     "form": {

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -124,6 +124,14 @@
     "addManuallyText": "If your project isn’t shown, you can add the details manually.",
     "addManuallyLabel": "Add funder manually"
   },
+  "PlanFunding": {
+    "fundingLabel": "Select funding sources for this plan",
+    "fundingDescription": "This funding list comes from the funding list attached to the project.",
+    "changeWarning": "Note: Changing the funding sources may require a template change. Only change if you are sure.",
+    "addSourceTitle": "Adding a funding source?",
+    "addSourceNote": "If you want to add new funding information, you can add funding at the project level. This project can have multiple funding sources, whereas each plan can only have a single source of funding as we match it to the required template.",
+    "addSourceLink": "Add a new funding source"
+  },
   "TemplateHistory": {
     "title": "Template history",
     "subHeading": "History",


### PR DESCRIPTION
## Description

Hooked up the Plan funders page so that the user can select the funder for their
plan.

Fixes #363

## Type of change
Please delete options that are not relevant

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Tested by running the `npm run build` command manually, and checking for errors related to my code
- Also ran `npm run type-check` to make sure I didn't introduce any type errors
- I tested by manually checking that I can pick a funder for a dmp by creating a new Plan in an existing project, clicking on the link for funding, and then selecting the funder from there.
- Created automated unit tests; Checked that they pass, didn't introduce new errors, and also that the coverage is 100%


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
