### PR TITLE
[Bug fix] - Prevent the project date section from displaying if startDate or endDate are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fix translation string to use the correct tags for the `Account Profile` [#515]
 
 ### Fixed
+- Prevent the project date from displaying if either `startDate` or `endDate` are not available [#588]
 - Removed the `Sample text` field from the Question Add/Edit forms for all question types except for `textArea` [#564]
 
 

--- a/app/[locale]/projects/[projectId]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/__tests__/page.spec.tsx
@@ -125,6 +125,22 @@ describe('ProjectOverviewPage', () => {
     expect(screen.getByText('project')).toBeInTheDocument();
   });
 
+  it('should not display project start and end dates if one of them is null', () => {
+    const mockProjectDataWithoutStartDate = {
+      ...mockProjectData,
+      startDate: null
+    };
+
+    (useProjectQuery as jest.Mock).mockReturnValue({
+      data: { project: mockProjectDataWithoutStartDate },
+      loading: false,
+      error: null,
+    });
+    render(<ProjectOverviewPage />);
+    //Should not see end date
+    expect(screen.queryByText('2028-12-31')).not.toBeInTheDocument();
+  })
+
   it('should render the project fundings', () => {
     render(<ProjectOverviewPage />);
     expect(screen.getByText('fundings')).toBeInTheDocument();

--- a/app/[locale]/projects/[projectId]/page.tsx
+++ b/app/[locale]/projects/[projectId]/page.tsx
@@ -161,10 +161,11 @@ const ProjectOverviewPage: React.FC = () => {
                 </strong>
               </p>
               <p>
-                {ProjectOverview('dateRange', {
-                  startDate: (project.startDate ?? ''),
-                  endDate: (project.endDate ?? '')
-                })}
+                {project.startDate && project.endDate && (
+                  ProjectOverview('dateRange', {
+                    startDate: (project.startDate ?? ''),
+                    endDate: (project.endDate ?? '')
+                  }))}
               </p>
               <Link href={`/projects/${projectId}/project`} aria-label={ProjectOverview('editProject')}>
                 {ProjectOverview('edit')}


### PR DESCRIPTION

## Description
This bug was filed because `to` was displaying when project start and end dates were not available on the `Project Overview` page.

We decided that if `startDate` or `endDate` are missing, we will not display that line.

-Prevent the project date from displaying if either `startDate` or `endDate` are not available.

Fixes # ([588](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/588))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually and using unit test.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
