### PR TITLE
Fixed ProjectsProjectMembers breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Hook up the Plan Funder page with actual data so that the user can manage funders on their plan. [#363]
 
 ### Updated
+- Updated `routePath` with route `projects.share.index` and updated unit test for `ProjectsProjectMembers` [#589]
 - Updated `graphqlHelper.ts` file to be more robust and correctly refresh tokens and refresh content when there is an `UNAUTHENTICATED` error [#320]
 - Clean up connections page and buttons [#516]
 - Added spacing on the `Account Profile` for the demo [#509]
@@ -15,6 +16,7 @@
 - fix translation string to use the correct tags for the `Account Profile` [#515]
 
 ### Fixed
+- Updated `projects/[projectId]/members` page to have consistent breadcrumbs as the `Project overview` page [#589]
 - Removed the `Sample text` field from the Question Add/Edit forms for all question types except for `textArea` [#564]
 
 

--- a/app/[locale]/projects/[projectId]/members/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/members/__tests__/page.spec.tsx
@@ -99,6 +99,11 @@ describe('ProjectsProjectMembers', () => {
 
     render(<ProjectsProjectMembers />);
 
+    // Expect certain breadcrumbs 
+    expect(screen.getByText('breadcrumbs.home')).toBeInTheDocument();
+    expect(screen.getByText('breadcrumbs.projects')).toBeInTheDocument();
+    expect(screen.getByText('breadcrumbs.projectOverview')).toBeInTheDocument();
+
     expect(screen.getByText('Jacques Cousteau')).toBeInTheDocument();
     expect(screen.getByText('Captain Nemo')).toBeInTheDocument();
     const affiliation = screen.getAllByText('University of California, Davis (ucdavis.edu)');
@@ -122,7 +127,18 @@ describe('ProjectsProjectMembers', () => {
 
     fireEvent.click(screen.getByText('buttons.addMembers'));
 
-    expect(mockRouter.push).toHaveBeenCalledWith('/projects/1/members/search');
+    expect(mockRouter.push).toHaveBeenCalledWith('/en-US/projects/1/members/search');
+  });
+
+  it('should handle edit member button click', () => {
+    mockUseProjectMembersQuery.mockReturnValue({ data: mockProjectMembersData });
+
+    render(<ProjectsProjectMembers />);
+
+    const editButtons = screen.queryAllByText('buttons.edit');
+    fireEvent.click(editButtons[0]);
+
+    expect(mockRouter.push).toHaveBeenCalledWith('/en-US/projects/1/members/1/edit');
   });
 
   it('should handle share button click', () => {
@@ -132,7 +148,7 @@ describe('ProjectsProjectMembers', () => {
 
     fireEvent.click(screen.getByText('buttons.shareWithPeople'));
 
-    expect(mockRouter.push).toHaveBeenCalledWith('/projects/1/share');
+    expect(mockRouter.push).toHaveBeenCalledWith('/en-US/projects/1/share');
   });
 
   it('should pass axe accessibility test', async () => {

--- a/app/[locale]/projects/[projectId]/members/page.tsx
+++ b/app/[locale]/projects/[projectId]/members/page.tsx
@@ -13,6 +13,7 @@ import { ContentContainer, LayoutContainer, } from "@/components/Container";
 import { OrcidIcon } from '@/components/Icons/orcid/';
 import ErrorMessages from '@/components/ErrorMessages';
 
+import { routePath } from '@/utils/routes';
 import styles from './ProjectsProjectMembers.module.scss';
 
 interface ProjectMemberInterface {
@@ -29,7 +30,7 @@ const ProjectsProjectMembers = () => {
   const errorRef = useRef<HTMLDivElement | null>(null);
   // Get projectId param
   const params = useParams();
-  const { projectId } = params; // From route /projects/:projectId
+  const projectId = String(params.projectId);  // From route /projects/:projectId
 
   // Localization keys
   const ProjectMembers = useTranslations('ProjectsProjectMembers');
@@ -48,18 +49,18 @@ const ProjectsProjectMembers = () => {
 
   const handleAddMember = (): void => {
     // Handle adding new member
-    router.push(`/projects/${projectId}/members/search`);
+    router.push(routePath('projects.members.search', {projectId}));
   };
 
   const handleEdit = (memberId: number | null): void => {
 
     // Handle editing member
-    router.push(`/projects/${projectId}/members/${memberId?.toString()}/edit`);
+    router.push(routePath('projects.members.edit', {projectId, memberId: String(memberId)}));
   };
 
   const handleShare = (): void => {
     // Handle share
-    router.push(`/projects/${projectId}/share`);
+    router.push(routePath('projects.share.index', {projectId}));
   };
 
   useEffect(() => {
@@ -96,9 +97,9 @@ const ProjectsProjectMembers = () => {
         showBackButton={false}
         breadcrumbs={
           <Breadcrumbs>
-            <Breadcrumb><Link href="/">{Global('breadcrumbs.home')}</Link></Breadcrumb>
-            <Breadcrumb><Link href="/projects">{Global('breadcrumbs.projects')}</Link></Breadcrumb>
-            <Breadcrumb><Link href={`/projects/${projectId}`}>{Global('breadcrumbs.projects')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('app.home')}>{Global('breadcrumbs.home')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.index')}>{Global('breadcrumbs.projects')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.show', {projectId})}>{Global('breadcrumbs.projectOverview')}</Link></Breadcrumb>
             <Breadcrumb>{ProjectMembers('title')}</Breadcrumb>
           </Breadcrumbs>
         }

--- a/utils/routes.ts
+++ b/utils/routes.ts
@@ -35,6 +35,7 @@ const routes = {
   'projects.members.search': '/projects/:projectId/members/search',
   'projects.outputs.index': '/projects/:projectId/research-outputs',
   'projects.outputs.edit': '/projects/:projectId/research-outputs/edit',
+  'projects.share.index': '/projects/:projectId/share',
 
   // DMP (Data Management Plan) routes
   'projects.dmp.index': '/projects/:projectId/dmp',


### PR DESCRIPTION

## Description

- Updated `projects/[projectId]/members` page to have consistent breadcrumbs as the `Project overview` page
- Updated `routePath` with route `projects.share.index` and updated unit test for `ProjectsProjectMembers`

Fixes # ([589](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/589))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually and with unit test

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Testing

1. Go to a project that has project members (e.g., http://localhost:3000/en-US/projects/1)
2. Click on `Edit project members` link to go to the `Project members` page
3. On the `Project members` page, you should see the `Project overview` link in the breadcrumb in the same order as was on the `Project Overview` page.
