### PR TITLE
Updated the plan overview page to use the text 'Start' on the section button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fix translation string to use the correct tags for the `Account Profile` [#515]
 
 ### Fixed
+- Updated `Update` link for each section on `projects/[projectId]/dmp/[dmpid]` to `Start` if no questions have been answered yet in that section [#594]
 - Improved color contrast on date picker [#597]
 - Updated `projects/[projectId]/members` page to have consistent breadcrumbs as the `Project overview` page [#589]
 - Prevent the project date from displaying if either `startDate` or `endDate` are not available [#588]

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
@@ -147,6 +147,22 @@ describe('PlanOverviewPage', () => {
     expect(within(sidebar).getByRole('link', { name: 'download' })).toBeInTheDocument();
   });
 
+  it('should use \'Start\' for section buttons if no questions in that section have been answered, otherwise it should use \'Update\'', async () => {
+    const {container} = render(<PlanOverviewPage />);
+
+    const sectionWithSomeAnswers = container.querySelector('section[aria-labelledby="section-title-8"]') as HTMLElement;
+    if(sectionWithSomeAnswers){
+      const button = within(sectionWithSomeAnswers).getByText('sections.update');
+      expect(button).toBeInTheDocument();
+    }
+
+    const sectionWithNoAnswers = container.querySelector('section[aria-labelledby="section-title-11"]') as HTMLElement;
+    if (sectionWithNoAnswers) {
+      const button = within(sectionWithNoAnswers).getByText('sections.start');
+      expect(button).toBeInTheDocument();
+    }
+  });
+
   it('should open and close modal', async () => {
     render(<PlanOverviewPage />);
     const publishButton = screen.getByText(/buttons.publish/i);

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
@@ -137,6 +137,7 @@ const PlanOverviewPage: React.FC = () => {
   const { data, loading, error: queryError, refetch } = usePlanQuery(
     {
       variables: { planId: Number(planId) },
+      skip: isNaN(planId), // prevents the query from running when id is not a number
       notifyOnNetworkStatusChange: true
     }
   );
@@ -591,7 +592,7 @@ const PlanOverviewPage: React.FC = () => {
                     })}
                     className={"react-aria-Button react-aria-Button--secondary"}
                   >
-                    {t('sections.update')}
+                    {(section.answeredQuestions === 0) ? t('sections.start') : t('sections.update')}
                   </Link>
                 </div>
               </section>


### PR DESCRIPTION

## Description

- Updated `Plan Overview` page so that we use the text `Start` on the section button if a user has not answered any questions yet in that section. If they have, then we continue to use the text `Update` on the button.

Fixes # ([594](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/594))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually test and added unit test.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshot
<img width="904" height="731" alt="image" src="https://github.com/user-attachments/assets/6a24e52b-a8e1-41dc-89dc-ea6c7e341632" />
