### PR TITLE
[Bug fix] - Corrected the redirects from the Search for Funders page to take users to the correct page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fix translation string to use the correct tags for the `Account Profile` [#515]
 
 ### Fixed
+- Updated `Select` buttons on the `projects/projectId/funding-search` page to go to the correct `Search for your project` page [#596]
 - Improved color contrast on date picker [#597]
 - Updated `projects/[projectId]/members` page to have consistent breadcrumbs as the `Project overview` page [#589]
 - Prevent the project date from displaying if either `startDate` or `endDate` are not available [#588]

--- a/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
@@ -390,7 +390,7 @@ describe("CreateProjectSearchFunder", () => {
     fireEvent.click(selectBtn);
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith(expect.stringMatching(/\/projects\/123/));
+      expect(mockPush).toHaveBeenCalledWith(expect.stringMatching(/\/projects\/create-project\/projects-search/));
     });
   });
 

--- a/app/[locale]/projects/[projectId]/funding-search/page.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/page.tsx
@@ -74,9 +74,7 @@ const CreateProjectSearchFunder = () => {
   }
 
   async function handleSelectFunder(funder: AffiliationSearch) {
-    const NEXT_URL = routePath('projects.create.projects.search', {
-      projectId: projectId as string,
-    });
+    const NEXT_URL = routePath('projects.create.project.search');
     const input = {
       projectId: Number(projectId),
       affiliationId: funder.uri

--- a/utils/routes.ts
+++ b/utils/routes.ts
@@ -21,6 +21,7 @@ const routes = {
   'projects.index': '/projects',
   'projects.show': '/projects/:projectId',
   'projects.create': '/projects/create',
+  'projects.create.project.search': '/projects/create-project/projects-search',
   'projects.search': '/projects/search',
   'projects.create.funding.search': '/projects/:projectId/funding-search',
   'projects.create.projects.search': '/projects/:projectId/project',


### PR DESCRIPTION

## Description

-Updated the `Funder search` page to take users to the correct `Search for Projects` page when they click `Select` in a funder card.

Fixes # ([596](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/596))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested and ran unit tests.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screen recording

### Incorrect flow:


https://github.com/user-attachments/assets/1e1ccd41-6ab8-4e78-8265-21bdc6b12bda

### Correct flow:

https://github.com/user-attachments/assets/14a3570d-17ff-4db7-87a3-eab2c5c3bca4

