### PR TITLE
Add popular funders to the funder search page when creating a new project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added delete section functionality to template builder with confirmation modal, including translations, and tests
 - Implemented a "Delete Question" feature on the question editing page with extra dialog and with tests
 - Hook up the Plan Funder page with actual data so that the user can manage funders on their plan. [#363]
+- Added popular funders to the funder search page when creating a new project. [#380]
 
 ### Updated
 - Updated `routePath` with route `projects.share.index` and updated unit test for `ProjectsProjectMembers` [#589]

--- a/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
@@ -298,18 +298,11 @@ describe("CreateProjectSearchFunder", () => {
   });
 
   it("Should show a short-list of Popular Funders", async () => {
-    // NOTE: Act and async here is an attempt to remove a warning I get
-    // from the testing framework. The tests still pass however. but wrapping
-    // the compoment doesn't remove the warning.
-    // I also tried to use this wrapper in every other test, but it still didn't
-    // resolve the error.
-    await act(async () => {
-      render(
-        <MockedProvider mocks={mocks} addTypename={false}>
-          <CreateProjectSearchFunder />
-        </MockedProvider>
-      );
-    });
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <CreateProjectSearchFunder />
+      </MockedProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByText('popularTitle')).toBeInTheDocument();

--- a/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
@@ -17,7 +17,7 @@ import {
   AddProjectFundingDocument,
 } from '@/generated/graphql';
 
-import { stripHtml, scrollToTop } from '@/utils/general';
+import { scrollToTop } from '@/utils/general';
 import logECS from "@/utils/clientLogger";
 
 import CreateProjectSearchFunder from '../page';
@@ -270,7 +270,6 @@ const mocks = [
 // Needed for the errormessages component
 jest.mock('@/utils/general', () => ({
   scrollToTop: jest.fn(),
-  stripHtml: jest.fn(),
 }));
 
 

--- a/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
@@ -114,7 +114,6 @@ const mocks = [
     },
   },
 
-
   // Paginated Mocks
   {
     request: {
@@ -265,6 +264,20 @@ const mocks = [
   },
 ];
 
+const emptyPopularMock = [
+  {
+    request: {
+      query: PopularFundersDocument,
+    },
+
+    result: {
+      data: {
+        popularFunders: [],
+      }
+    },
+  },
+];
+
 
 // Needed for the errormessages component
 jest.mock('@/utils/general', () => ({
@@ -309,6 +322,18 @@ describe("CreateProjectSearchFunder", () => {
     });
   });
 
+  it("Should neatly handle empty popular funder results", async () => {
+    render(
+      <MockedProvider mocks={emptyPopularMock} addTypename={false}>
+        <CreateProjectSearchFunder />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('popularTitle')).not.toBeInTheDocument();
+    });
+  });
+
   it("Should render the search results", async () => {
     render(
       <MockedProvider mocks={mocks} addTypename={false}>
@@ -340,6 +365,26 @@ describe("CreateProjectSearchFunder", () => {
         expect(funderTitle).toBeInTheDocument();
         expect(selectBtn).toHaveAttribute('data-funder-uri', funder[1]);
       });
+    });
+  });
+
+  it("Should cleanly handle empty results", async() => {
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <CreateProjectSearchFunder />
+      </MockedProvider>
+    );
+
+    // NOTE: search-field and search-input are testID's provided by elements
+    // inside the FunderSearch component.
+    const searchInput = screen.getByTestId('search-field').querySelector('input')!;
+    fireEvent.change(searchInput, { target: { value: "empty" } });
+
+    const searchBtn = screen.getByTestId('search-btn');
+    fireEvent.click(searchBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("noResults")).toBeInTheDocument();
     });
   });
 

--- a/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
@@ -608,6 +608,10 @@ describe("CreateProjectSearchFunder", () => {
       </MockedProvider>
     );
 
+    await waitFor(() => {
+      expect(screen.getByText("popularTitle")).toBeInTheDocument();
+    });
+
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
@@ -6,7 +6,6 @@ import {
   fireEvent,
   waitFor,
   within,
-  act,
 } from '@testing-library/react';
 
 import { useParams, useRouter } from 'next/navigation';

--- a/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
@@ -12,6 +12,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { MockedProvider } from '@apollo/client/testing';
 import {
   AffiliationFundersDocument,
+  PopularFundersDocument,
   AddProjectFundingDocument,
 } from '@/generated/graphql';
 
@@ -61,6 +62,26 @@ const mocks = [
     },
   },
 
+  // Popular Funders
+  {
+    request: {
+      query: PopularFundersDocument,
+    },
+
+    result: {
+      data: {
+        popularFunders: Array.from({length: 5}, (_, i) => {
+          const count = i + 1;
+          return {
+            id: count,
+            uri: `https://funder${count}`,
+            displayName: `Popular Funder ${count}`,
+            nbrPlans: 10,
+          };
+        }),
+      }
+    },
+  },
   // Empty results
   {
     request: {
@@ -257,6 +278,26 @@ describe("CreateProjectSearchFunder", () => {
 
     // NOTE: Search-field is the testid provided by the fundersearch component
     expect(screen.getByTestId('search-field')).toBeInTheDocument();
+  });
+
+  it("Should show a short-list of Popular Funders", async () => {
+    await render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <CreateProjectSearchFunder />
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('popularTitle')).toBeInTheDocument();
+
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Popular Funder 1')).toBeInTheDocument();
+      expect(screen.getByText('Popular Funder 2')).toBeInTheDocument();
+      expect(screen.getByText('Popular Funder 3')).toBeInTheDocument();
+      expect(screen.getByText('Popular Funder 4')).toBeInTheDocument();
+    });
   });
 
   it("Should render the search results", async () => {

--- a/app/[locale]/projects/[projectId]/funding-search/page.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/page.tsx
@@ -232,7 +232,7 @@ const CreateProjectSearchFunder = () => {
                     <Button
                       data-testid="load-more-btn"
                       onPress={() => setMoreCounter(moreCounter + 1)}
-                      aria-label="Load more funders"
+                      aria-label={globalTrans('buttons.loadMore')}
                     >
                       {globalTrans('buttons.loadMore')}
                     </Button>
@@ -262,7 +262,7 @@ const CreateProjectSearchFunder = () => {
               <Button
                 className="add-funder-button"
                 onPress={() => handleAddFunderManually()}
-                aria-label="{trans(addManuallyLabel)}"
+                aria-label={trans('addManuallyLabel')}
               >
                 {trans('addManuallyLabel')}
               </Button>

--- a/app/[locale]/projects/[projectId]/funding-search/page.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/page.tsx
@@ -5,8 +5,6 @@ import { useTranslations } from 'next-intl';
 import { useParams, useRouter } from 'next/navigation';
 import { routePath } from '@/utils/routes';
 
-import { LoggedError } from "@/utils/exceptions";
-
 import {
   AffiliationSearch,
   FunderPopularityResult,

--- a/app/[locale]/projects/[projectId]/funding-search/page.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/page.tsx
@@ -152,7 +152,7 @@ const CreateProjectSearchFunder = () => {
    */
   function hasMore() {
     if (!nextCursor) return false;
-    if (funders.length < totalCount) return true;
+    return (funders.length < totalCount);
   }
 
   return (

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -1250,6 +1250,7 @@ export type MutationUpdateMetadataStandardArgs = {
 
 
 export type MutationUpdatePasswordArgs = {
+  email: Scalars['String']['input'];
   newPassword: Scalars['String']['input'];
   oldPassword: Scalars['String']['input'];
 };
@@ -3317,16 +3318,16 @@ export type User = {
   /** The user who created the Object */
   createdById?: Maybe<Scalars['Int']['output']>;
   /** The user's primary email address */
-  email: Scalars['EmailAddress']['output'];
+  email?: Maybe<Scalars['String']['output']>;
   /** The user's email addresses */
   emails?: Maybe<Array<Maybe<UserEmail>>>;
   /** Errors associated with the Object */
   errors?: Maybe<UserErrors>;
   /** The number of failed login attempts */
-  failed_sign_in_attemps?: Maybe<Scalars['Int']['output']>;
+  failed_sign_in_attempts?: Maybe<Scalars['Int']['output']>;
   /** The user's first/given name */
   givenName?: Maybe<Scalars['String']['output']>;
-  /** The unique identifer for the Object */
+  /** The unique identifier for the Object */
   id?: Maybe<Scalars['Int']['output']>;
   /** The user's preferred language */
   languageId: Scalars['String']['output'];
@@ -3336,7 +3337,7 @@ export type User = {
   last_sign_in_via?: Maybe<Scalars['String']['output']>;
   /** Whether or not the account is locked from failed login attempts */
   locked?: Maybe<Scalars['Boolean']['output']>;
-  /** The timestamp when the Object was last modifed */
+  /** The timestamp when the Object was last modified */
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
@@ -3370,13 +3371,13 @@ export type UserEmail = {
   email: Scalars['String']['output'];
   /** Errors associated with the Object */
   errors?: Maybe<UserEmailErrors>;
-  /** The unique identifer for the Object */
+  /** The unique identifier for the Object */
   id?: Maybe<Scalars['Int']['output']>;
   /** Whether or not the email address has been confirmed */
   isConfirmed: Scalars['Boolean']['output'];
   /** Whether or not this is the primary email address */
   isPrimary: Scalars['Boolean']['output'];
-  /** The timestamp when the Object was last modifed */
+  /** The timestamp when the Object was last modified */
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
@@ -3984,7 +3985,7 @@ export type UpdateUserProfileMutationVariables = Exact<{
 }>;
 
 
-export type UpdateUserProfileMutation = { __typename?: 'Mutation', updateUserProfile?: { __typename?: 'User', id?: number | null, givenName?: string | null, surName?: string | null, languageId: string, email: any, errors?: { __typename?: 'UserErrors', general?: string | null, email?: string | null, password?: string | null, role?: string | null } | null, affiliation?: { __typename?: 'Affiliation', id?: number | null, name: string, searchName: string, uri: string } | null } | null };
+export type UpdateUserProfileMutation = { __typename?: 'Mutation', updateUserProfile?: { __typename?: 'User', id?: number | null, givenName?: string | null, surName?: string | null, languageId: string, email?: string | null, errors?: { __typename?: 'UserErrors', general?: string | null, email?: string | null, password?: string | null, role?: string | null } | null, affiliation?: { __typename?: 'Affiliation', id?: number | null, name: string, searchName: string, uri: string } | null } | null };
 
 export type AddUserEmailMutationVariables = Exact<{
   email: Scalars['String']['input'];
@@ -4216,7 +4217,7 @@ export type TemplateCollaboratorsQueryVariables = Exact<{
 }>;
 
 
-export type TemplateCollaboratorsQuery = { __typename?: 'Query', template?: { __typename?: 'Template', id?: number | null, name: string, collaborators?: Array<{ __typename?: 'TemplateCollaborator', email: string, id?: number | null, user?: { __typename?: 'User', id?: number | null, email: any, givenName?: string | null, surName?: string | null } | null }> | null, admins?: Array<{ __typename?: 'User', givenName?: string | null, surName?: string | null, email: any }> | null, owner?: { __typename?: 'Affiliation', name: string } | null } | null };
+export type TemplateCollaboratorsQuery = { __typename?: 'Query', template?: { __typename?: 'Template', id?: number | null, name: string, collaborators?: Array<{ __typename?: 'TemplateCollaborator', email: string, id?: number | null, user?: { __typename?: 'User', id?: number | null, email?: string | null, givenName?: string | null, surName?: string | null } | null }> | null, admins?: Array<{ __typename?: 'User', givenName?: string | null, surName?: string | null, email?: string | null }> | null, owner?: { __typename?: 'Affiliation', name: string } | null } | null };
 
 export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -4047,6 +4047,11 @@ export type PlanFundingsQueryVariables = Exact<{
 
 export type PlanFundingsQuery = { __typename?: 'Query', planFundings?: Array<{ __typename?: 'PlanFunding', id?: number | null, projectFunding?: { __typename?: 'ProjectFunding', id?: number | null } | null } | null> | null };
 
+export type PopularFundersQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type PopularFundersQuery = { __typename?: 'Query', popularFunders?: Array<{ __typename?: 'FunderPopularityResult', displayName: string, id: number, nbrPlans: number, uri: string } | null> | null };
+
 export type LanguagesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -5975,6 +5980,48 @@ export type PlanFundingsQueryHookResult = ReturnType<typeof usePlanFundingsQuery
 export type PlanFundingsLazyQueryHookResult = ReturnType<typeof usePlanFundingsLazyQuery>;
 export type PlanFundingsSuspenseQueryHookResult = ReturnType<typeof usePlanFundingsSuspenseQuery>;
 export type PlanFundingsQueryResult = Apollo.QueryResult<PlanFundingsQuery, PlanFundingsQueryVariables>;
+export const PopularFundersDocument = gql`
+    query PopularFunders {
+  popularFunders {
+    displayName
+    id
+    nbrPlans
+    uri
+  }
+}
+    `;
+
+/**
+ * __usePopularFundersQuery__
+ *
+ * To run a query within a React component, call `usePopularFundersQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePopularFundersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePopularFundersQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function usePopularFundersQuery(baseOptions?: Apollo.QueryHookOptions<PopularFundersQuery, PopularFundersQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PopularFundersQuery, PopularFundersQueryVariables>(PopularFundersDocument, options);
+      }
+export function usePopularFundersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PopularFundersQuery, PopularFundersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PopularFundersQuery, PopularFundersQueryVariables>(PopularFundersDocument, options);
+        }
+export function usePopularFundersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PopularFundersQuery, PopularFundersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<PopularFundersQuery, PopularFundersQueryVariables>(PopularFundersDocument, options);
+        }
+export type PopularFundersQueryHookResult = ReturnType<typeof usePopularFundersQuery>;
+export type PopularFundersLazyQueryHookResult = ReturnType<typeof usePopularFundersLazyQuery>;
+export type PopularFundersSuspenseQueryHookResult = ReturnType<typeof usePopularFundersSuspenseQuery>;
+export type PopularFundersQueryResult = Apollo.QueryResult<PopularFundersQuery, PopularFundersQueryVariables>;
 export const LanguagesDocument = gql`
     query Languages {
   languages {

--- a/graphql/queries/fundings.query.graphql
+++ b/graphql/queries/fundings.query.graphql
@@ -16,3 +16,12 @@ query PlanFundings($planId: Int!) {
     }
   }
 }
+
+query PopularFunders {
+  popularFunders {
+    displayName
+    id
+    nbrPlans
+    uri
+  }
+}

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -117,6 +117,7 @@
   "FunderSearch": {
     "headerTitle": "Search for Funders",
     "funder": "Funder",
+    "popularTitle": "Most popular funders",
     "found": "{count} funders found",
     "noResults": "No results found",
     "showCount": "Showing {count} of {total}",


### PR DESCRIPTION
## Description

Added the most popular funders to the funding search page _when creating a new project_.

Fixes #380

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Created new automated test and related mocks to check that the correct graphQL queries are called.
- Automated tests also check that selecting a popular funder will add the funder to the project just like searching for a funder would.
- Did manual testing where I clicked through to this page, verified that the popular funders are show, and that I can click to pick one of the popular funders.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
