### PR TITLE
Added radio buttons to QuestionAdd and QuestionEdit to allow users to set question as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added the `Mark as required` radio buttons on the `QuestionAdd` and `QuestionEdit` pages and updated unit tests [#562]
 - Added three more `icons` for solid down, left and right arrows for the Date Picker [#597]
 - Added a new `ExpandableContentSection` component that allows use to `expand` and `collapse` content, especially for the `Best Practices` right sidebar, but can be used for any content [#578]
 - Added the `Question details` page that allows users to answer a question [#320]

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
@@ -731,7 +731,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(options[0]).toHaveAttribute('aria-selected', 'false');
     expect(options[1]).toHaveAttribute('aria-selected', 'true');
     expect(options[2]).toHaveAttribute('aria-selected', 'true');
-    expect(options[3]).toHaveAttribute('aria-selected', 'true');
+    expect(options[3]).toHaveAttribute('aria-selected', 'false');
   })
 
   it('should load correct question content for selectBox question', async () => {
@@ -1611,7 +1611,7 @@ describe('Call to updateAnswerAction', () => {
     await waitFor(() => {
       expect(updateAnswerAction).toHaveBeenCalledWith({
         answerId: 18,
-        json: "{\"answer\":[\"Banana\",\"Pear\",\"Orange\",\"Apple\"]}"
+        json: "{\"answer\":[\"Banana\",\"Pear\",\"Apple\"]}"
       });
     });
   })

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
@@ -824,7 +824,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
             <Form onSubmit={handleSubmit}>
               <Card data-testid='question-card'>
                 <span>Question</span>
-                <h2 id="question-title">
+                <h2 id="question-title" className="h3">
                   {question?.questionText}
                 </h2>
                 {question?.required && (

--- a/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
@@ -920,7 +920,7 @@ describe("QuestionEditPage", () => {
     await waitFor(() => {
       expect(logECS).toHaveBeenCalledWith(
         'error',
-        'GraphQL Query Error',
+        'Parsing error',
         expect.objectContaining({
           error: expect.anything(),
           url: { path: '/en-US/template/123/q/67' },

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -40,6 +40,7 @@ import QuestionOptionsComponent
 import QuestionPreview from '@/components/QuestionPreview';
 import {
   FormInput,
+  RadioGroupComponent,
   RangeComponent,
   TypeAheadSearch
 } from '@/components/Form';
@@ -112,7 +113,6 @@ const QuestionEdit = () => {
   const [typeaheadHelpText, setTypeAheadHelpText] = useState<string>('');
   const [typeaheadSearchLabel, setTypeaheadSearchLabel] = useState<string>('');
   const [parsedQuestionJSON, setParsedQuestionJSON] = useState<AnyParsedQuestion>();
-
   const [isConfirmOpen, setConfirmOpen] = useState(false);
 
   // Initialize update question mutation
@@ -144,6 +144,21 @@ const QuestionEdit = () => {
     data: questionTypesData,
     error: questionTypesError,
   }] = useQuestionTypesLazyQuery();
+
+
+  const radioData = {
+    radioGroupLabel: Global('labels.requiredField'),
+    radioButtonData: [
+      {
+        value: 'yes',
+        label: Global('form.yesLabel'),
+      },
+      {
+        value: 'no',
+        label: Global('form.noLabel')
+      }
+    ]
+  }
 
 
   // Update rows state and question.json when options change
@@ -219,6 +234,20 @@ const QuestionEdit = () => {
       }
     }
   };
+
+  // Handle changes from RadioGroup
+  const handleRadioChange = (value: string) => {
+
+    if (value) {
+      const isRequired = value === 'yes' ? true : false;
+      setQuestion(prev => ({
+        ...prev,
+        required: isRequired
+      }));
+    }
+
+  };
+
 
   // Prepare input for the questionTypeHandler. For options questions, we update the 
   // values with rows state. For non-options questions, we use the parsed JSON
@@ -661,6 +690,15 @@ const QuestionEdit = () => {
 
                   </Checkbox>
                 )}
+
+                <RadioGroupComponent
+                  name="radioGroup"
+                  value={question?.required ? 'yes' : 'no'}
+                  radioGroupLabel={radioData.radioGroupLabel}
+                  radioButtonData={radioData.radioButtonData}
+                  description={Global('descriptions.requiredFieldDescription')}
+                  onChange={handleRadioChange}
+                />
 
                 <Button type="submit" onPress={() => setFormSubmitted(true)}>{Global('buttons.saveAndUpdate')}</Button>
 

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -40,7 +40,6 @@ import QuestionOptionsComponent
 import QuestionPreview from '@/components/QuestionPreview';
 import {
   FormInput,
-  RadioGroupComponent,
   RangeComponent,
   TypeAheadSearch
 } from '@/components/Form';
@@ -146,21 +145,6 @@ const QuestionEdit = () => {
   }] = useQuestionTypesLazyQuery();
 
 
-  const radioData = {
-    radioGroupLabel: Global('labels.requiredField'),
-    radioButtonData: [
-      {
-        value: 'yes',
-        label: Global('form.yesLabel'),
-      },
-      {
-        value: 'no',
-        label: Global('form.noLabel')
-      }
-    ]
-  }
-
-
   // Update rows state and question.json when options change
   const updateRows = (newRows: QuestionOptions[]) => {
     setRows(newRows);
@@ -233,19 +217,6 @@ const QuestionEdit = () => {
         }));
       }
     }
-  };
-
-  // Handle changes from RadioGroup
-  const handleRadioChange = (value: string) => {
-
-    if (value) {
-      const isRequired = value === 'yes' ? true : false;
-      setQuestion(prev => ({
-        ...prev,
-        required: isRequired
-      }));
-    }
-
   };
 
 
@@ -690,15 +661,6 @@ const QuestionEdit = () => {
 
                   </Checkbox>
                 )}
-
-                <RadioGroupComponent
-                  name="radioGroup"
-                  value={question?.required ? 'yes' : 'no'}
-                  radioGroupLabel={radioData.radioGroupLabel}
-                  radioButtonData={radioData.radioButtonData}
-                  description={Global('descriptions.requiredFieldDescription')}
-                  onChange={handleRadioChange}
-                />
 
                 <Button type="submit" onPress={() => setFormSubmitted(true)}>{Global('buttons.saveAndUpdate')}</Button>
 

--- a/components/Form/QuestionComponents/MultiSelectQuestionComponent/index.tsx
+++ b/components/Form/QuestionComponents/MultiSelectQuestionComponent/index.tsx
@@ -30,7 +30,7 @@ const MultiSelectQuestionComponent: React.FC<SelectboxQuestionProps> = ({
   return (
     <MultiSelect
       options={items}
-      selectedKeys={selectedMultiSelectValues ? selectedMultiSelectValues : new Set(defaultSelected)}
+      selectedKeys={(selectedMultiSelectValues && selectedMultiSelectValues.size > 0) ? selectedMultiSelectValues : new Set(defaultSelected)}
       onSelectionChange={handleMultiSelectChange}
       label={selectBoxLabel}
       aria-label={selectBoxLabel}

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -193,7 +193,7 @@ describe("QuestionAdd", () => {
 
     await waitFor(() => {
       expect(mockRouter.push).toHaveBeenCalledTimes(1);
-      expect(mockRouter.push).toHaveBeenCalledWith('/template/123/q/new?section_id=1&step=1');
+      expect(mockRouter.push).toHaveBeenCalledWith('/en-US/template/123/q/new?section_id=1&step=1');
     });
   });
 
@@ -225,7 +225,7 @@ describe("QuestionAdd", () => {
     const changeTypeButton = screen.getByRole('button', { name: 'buttons.changeType' });
     fireEvent.click(changeTypeButton);
     await waitFor(() => {
-      expect(mockRouter.push).toHaveBeenCalledWith('/template/123/q/new?section_id=1&step=1');
+      expect(mockRouter.push).toHaveBeenCalledWith('/en-US/template/123/q/new?section_id=1&step=1');
     });
   });
 

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -7,11 +7,23 @@ import {
 
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { useParams, useRouter } from 'next/navigation';
+import { useToast } from '@/context/ToastContext';
 import QuestionAdd from '@/components/QuestionAdd';
+import * as getParsedJSONModule from '@/components/hooks/getParsedQuestionJSON';
+
 
 expect.extend(toHaveNoViolations);
 
-// Mock the useTemplateQuery hook
+jest.mock('@/components/hooks/getParsedQuestionJSON', () => {
+  const actual = jest.requireActual('@/components/hooks/getParsedQuestionJSON');
+  return {
+    __esModule: true,
+    ...actual,
+    getParsedQuestionJSON: jest.fn(actual.getParsedQuestionJSON),
+  };
+});
+
+// Mock the hooks
 jest.mock("@/generated/graphql", () => ({
   useQuestionsDisplayOrderQuery: jest.fn(),
   useAddQuestionMutation: jest.fn(),
@@ -34,6 +46,9 @@ if (typeof global.structuredClone !== 'function') {
 
 // Create a mock for scrollIntoView and focus
 const mockScrollIntoView = jest.fn();
+const mockToast = {
+  add: jest.fn(),
+};
 
 // Mock useTranslations from next-intl
 jest.mock('next-intl', () => ({
@@ -163,6 +178,9 @@ describe("QuestionAdd", () => {
     expect(bestPracticePara2).toBeInTheDocument();
     const bestPracticePara3 = screen.getByText('descriptions.bestPracticePara3', { selector: 'p' });
     expect(bestPracticePara3).toBeInTheDocument();
+    // Setting question as required
+    expect(screen.getByText('form.yesLabel')).toBeInTheDocument();
+    expect(screen.getByText('form.noLabel')).toBeInTheDocument();
   });
 
   it("should return user to the template edit page if questionType is missing", async () => {
@@ -229,49 +247,6 @@ describe("QuestionAdd", () => {
     });
   });
 
-  it('should display error when no value is entered in question Text field', async () => {
-    (useAddQuestionMutation as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
-      { loading: false, error: undefined },
-    ]);
-
-    const json = JSON.stringify({
-      meta: {
-        schemaVersion: "1.0"
-      },
-      type: "radioButtons",
-      options: [
-        {
-          attributes: {
-            label: null,
-            value: null,
-            selected: false
-          }
-        }
-      ]
-    })
-    await act(async () => {
-      render(
-        <QuestionAdd
-          questionType="radioButtons"
-          questionName="Radio buttons"
-          questionJSON={json}
-          sectionId="1"
-        />);
-    });
-
-    // Get the input
-    const input = screen.getByLabelText('labels.questionText');
-
-    // Set value to empty
-    fireEvent.change(input, { target: { value: '' } });
-
-    const saveButton = screen.getByRole('button', { name: /buttons.save/i });
-    fireEvent.click(saveButton);
-
-    const errorMessage = screen.getByText('messages.errors.questionTextRequired');
-    expect(errorMessage).toBeInTheDocument();
-  })
 
   it('should call addQuestionMutation when Save button is clicked after entering data', async () => {
     const mockAddQuestionMutation = jest.fn().mockResolvedValueOnce({
@@ -321,6 +296,13 @@ describe("QuestionAdd", () => {
       fireEvent.change(radioInput, { target: { value: 'Yes' } });
     })
 
+    // Select that the question should be required
+    const isRequiredRadio = screen.getByLabelText('form.yesLabel');
+
+    await act(async () => {
+      fireEvent.click(isRequiredRadio);
+    })
+
     const saveButton = screen.getByRole('button', { name: /buttons.saveAndAdd/i });
 
     await act(async () => {
@@ -342,66 +324,11 @@ describe("QuestionAdd", () => {
             guidanceText: '',
             sampleText: '',
             useSampleTextAsDefault: false,
-            required: false,
+            required: true,
           },
         },
       });
     });
-  })
-
-  it('should display error when addQuestionMutation returns an error', async () => {
-    const mockAddQuestionMutation = jest.fn().mockRejectedValueOnce(new Error("Error"));
-
-    (useAddQuestionMutation as jest.Mock).mockReturnValue([
-      mockAddQuestionMutation,
-      { loading: false, error: undefined },
-    ]);
-
-    const json = JSON.stringify({
-      meta: {
-        schemaVersion: "1.0"
-      },
-      type: "radioButtons",
-      options: [
-        {
-          attributes: {
-            label: 'Yes',
-            value: 'yes',
-            selected: false
-          }
-        }
-      ]
-    })
-    await act(async () => {
-      render(
-        <QuestionAdd
-          questionType="radioButtons"
-          questionName="Radio buttons"
-          questionJSON={json}
-          sectionId="1"
-        />);
-    });
-
-    // Get the input
-    const input = screen.getByLabelText('labels.questionText');
-
-    // Set value to 'New Question'
-    fireEvent.change(input, { target: { value: 'New Question' } });
-
-    // Add a new radio row
-    const radioInput = screen.getByPlaceholderText('placeholder.text');
-
-    await act(async () => {
-      fireEvent.change(radioInput, { target: { value: 'Yes' } });
-    })
-
-    const saveButton = screen.getByRole('button', { name: /buttons.saveAndAdd/i });
-
-    await act(async () => {
-      fireEvent.click(saveButton);
-    })
-
-    expect(screen.getByText('messages.errors.questionAddingError')).toBeInTheDocument();
   })
 
   it('should call addQuestionMutation with correct data for \'text\' question type ', async () => {
@@ -954,6 +881,150 @@ describe("QuestionAdd", () => {
     expect(rangeStartInput).toHaveValue('New Range Label');
   });
 
+  it('should call handleRangeLabelChange for numberRange changes', () => {
+    (useAddQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+    const mockDateRangeJSON = JSON.stringify({
+      meta: {
+        schemaVersion: "1.0"
+      },
+      type: "numberRange",
+      columns: {
+        end: {
+          meta: {
+            schemaVersion: "1.0"
+          },
+          type: "number",
+          attributes: {
+            max: null,
+            min: 0,
+            step: 1,
+            label: "To"
+          }
+        },
+        start: {
+          meta: {
+            schemaVersion: "1.0"
+          },
+          type: "number",
+          attributes: {
+            max: null,
+            min: 0,
+            step: 1,
+            label: "From"
+          }
+        }
+      }
+    });
+    render(
+      <QuestionAdd
+        questionType="numberRange"
+        questionName="Number Range Label"
+        questionJSON={mockDateRangeJSON}
+        sectionId="1"
+      />);
+
+    // Find the input rendered by RangeComponent
+    const rangeStartInput = screen.getByLabelText('range start');
+
+    // Simulate user typing
+    fireEvent.change(rangeStartInput, { target: { value: 'New Range Label' } });
+
+    expect(rangeStartInput).toHaveValue('New Range Label');
+  });
+
+  it('should set displayOrder to 1 for the new question, if there are no existing questions', async () => {
+
+    (useQuestionsDisplayOrderQuery as jest.Mock).mockReturnValue({
+      data: null,
+      loading: false,
+      error: undefined,
+    });
+
+    const mockAddQuestionMutation = jest.fn().mockResolvedValueOnce({
+      data: { addQuestion: { id: 1 } },
+    });
+
+    (useAddQuestionMutation as jest.Mock).mockReturnValue([
+      mockAddQuestionMutation,
+      { loading: false, error: undefined },
+    ]);
+
+    const json = JSON.stringify({
+      meta: {
+        schemaVersion: "1.0"
+      },
+      type: "radioButtons",
+      options: [
+        {
+          attributes: {
+            label: null,
+            value: null,
+            selected: false
+          }
+        }
+      ]
+    })
+    await act(async () => {
+      render(
+        <QuestionAdd
+          questionType="radioButtons"
+          questionName="Radio buttons"
+          questionJSON={json}
+          sectionId="1"
+        />);
+    });
+
+    // Get the question text input
+    const input = screen.getByLabelText('labels.questionText');
+
+    // add text to question text field
+    fireEvent.change(input, { target: { value: 'New Question' } });
+
+    // Add a new radio row
+    const radioInput = screen.getByPlaceholderText('placeholder.text');
+
+    await act(async () => {
+      fireEvent.change(radioInput, { target: { value: 'Yes' } });
+    })
+
+    // Select that the question should be required
+    const isRequiredRadio = screen.getByLabelText('form.yesLabel');
+
+    await act(async () => {
+      fireEvent.click(isRequiredRadio);
+    })
+
+    const saveButton = screen.getByRole('button', { name: /buttons.saveAndAdd/i });
+
+    await act(async () => {
+      fireEvent.click(saveButton);
+    })
+
+    // Check if the addQuestionMutation was called
+    await waitFor(() => {
+      expect(mockAddQuestionMutation).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            templateId: 123,
+            sectionId: 1,
+            displayOrder: 1,
+            isDirty: true,
+            questionText: 'New Question',
+            json: "{\"type\":\"radioButtons\",\"meta\":{\"schemaVersion\":\"1.0\"},\"options\":[{\"type\":\"option\",\"attributes\":{\"label\":\"Yes\",\"value\":\"Yes\",\"selected\":false}}]}",
+            requirementText: '',
+            guidanceText: '',
+            sampleText: '',
+            useSampleTextAsDefault: false,
+            required: true,
+          },
+        },
+      });
+    });
+  })
+
   it('should call handleTypeAheadSearchLabelChange when typeaheadSearch label value changes', () => {
     (useAddQuestionMutation as jest.Mock).mockReturnValue([
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
@@ -1090,5 +1161,270 @@ describe("QuestionAdd", () => {
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
+  });
+});
+
+describe("Error handling", () => {
+  let mockRouter;
+  beforeEach(() => {
+    HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
+    window.scrollTo = jest.fn(); // Called by the wrapping PageHeader
+    const mockTemplateId = 123;
+    const mockUseParams = useParams as jest.Mock;
+
+    // Mock window.tinymce
+    window.tinymce = {
+      init: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    // Mock the return value of useParams
+    mockUseParams.mockReturnValue({ templateId: `${mockTemplateId}` });
+
+    // Mock the router
+    mockRouter = { push: jest.fn() };
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+
+    // Mock Toast
+    (useToast as jest.Mock).mockReturnValue(mockToast);
+
+    (useQuestionsDisplayOrderQuery as jest.Mock).mockReturnValue({
+      data: mockQuestionDisplayData,
+      loading: false,
+      error: undefined,
+    });
+  });
+
+  it('should display error when no value is entered in question Text field', async () => {
+    (useAddQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+    const json = JSON.stringify({
+      meta: {
+        schemaVersion: "1.0"
+      },
+      type: "radioButtons",
+      options: [
+        {
+          attributes: {
+            label: null,
+            value: null,
+            selected: false
+          }
+        }
+      ]
+    })
+    await act(async () => {
+      render(
+        <QuestionAdd
+          questionType="radioButtons"
+          questionName="Radio buttons"
+          questionJSON={json}
+          sectionId="1"
+        />);
+    });
+
+    // Get the input
+    const input = screen.getByLabelText('labels.questionText');
+
+    // Set value to empty
+    fireEvent.change(input, { target: { value: '' } });
+
+    const saveButton = screen.getByRole('button', { name: /buttons.save/i });
+    fireEvent.click(saveButton);
+
+    const errorMessage = screen.getByText('messages.errors.questionTextRequired');
+    expect(errorMessage).toBeInTheDocument();
+  })
+
+  it('should display error when addQuestionMutation returns an error', async () => {
+    const mockAddQuestionMutation = jest.fn().mockRejectedValueOnce(new Error("Error"));
+
+    (useAddQuestionMutation as jest.Mock).mockReturnValue([
+      mockAddQuestionMutation,
+      { loading: false, error: undefined },
+    ]);
+
+    const json = JSON.stringify({
+      meta: {
+        schemaVersion: "1.0"
+      },
+      type: "radioButtons",
+      options: [
+        {
+          attributes: {
+            label: 'Yes',
+            value: 'yes',
+            selected: false
+          }
+        }
+      ]
+    })
+    await act(async () => {
+      render(
+        <QuestionAdd
+          questionType="radioButtons"
+          questionName="Radio buttons"
+          questionJSON={json}
+          sectionId="1"
+        />);
+    });
+
+    // Get the input
+    const input = screen.getByLabelText('labels.questionText');
+
+    // Set value to 'New Question'
+    fireEvent.change(input, { target: { value: 'New Question' } });
+
+    // Add a new radio row
+    const radioInput = screen.getByPlaceholderText('placeholder.text');
+
+    await act(async () => {
+      fireEvent.change(radioInput, { target: { value: 'Yes' } });
+    })
+
+    const saveButton = screen.getByRole('button', { name: /buttons.saveAndAdd/i });
+
+    await act(async () => {
+      fireEvent.click(saveButton);
+    })
+
+    expect(screen.getByText('messages.errors.questionAddingError')).toBeInTheDocument();
+  })
+
+  it('should display toast error and call router.push when no sectionId', async () => {
+    (useAddQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+    const json = JSON.stringify({
+      meta: {
+        schemaVersion: "1.0"
+      },
+      type: "radioButtons",
+      options: [
+        {
+          attributes: {
+            label: 'Yes',
+            value: 'yes',
+            selected: false
+          }
+        }
+      ]
+    })
+    await act(async () => {
+      render(
+        <QuestionAdd
+          questionType="radioButtons"
+          questionName="Radio buttons"
+          questionJSON={json}
+        />);
+    });
+
+    expect(mockToast.add).toHaveBeenCalledWith('messaging.somethingWentWrong', { type: 'error' });
+    expect(mockRouter.push).toHaveBeenCalledWith('/en-US/template/123');
+  })
+
+  it('should display error when getParsedQuestionJSON returns null for parsed', async () => {
+    const mockGetParsed = getParsedJSONModule.getParsedQuestionJSON as jest.Mock;
+
+    // temporarily override return value
+    mockGetParsed.mockReturnValueOnce({
+      parsed: null,
+      error: 'Mocked parse error',
+    });
+
+    (useAddQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+
+    act(() => {
+      render(
+        <QuestionAdd
+          questionType="radioButtons"
+          questionName="Radio buttons"
+          questionJSON=""
+          sectionId="1"
+        />
+      );
+    });
+
+    const saveButton = screen.getByRole('button', { name: /buttons.saveAndAdd/i });
+    act(() => {
+      fireEvent.click(saveButton);
+    });
+
+    expect(screen.getByText('Mocked parse error')).toBeInTheDocument();
+
+  });
+
+  it('should trigger an error when trying to add the question due to getParsedQuestionJSON returning null for parsed', async () => {
+    const mockGetParsed = getParsedJSONModule.getParsedQuestionJSON as jest.Mock;
+
+    // 1. First render sets parsedQuestionJSON
+    mockGetParsed.mockReturnValueOnce({
+      parsed: { type: 'radioButtons' },
+      error: null,
+    });
+
+    // 2. On second invocation (triggered by form submit), it fails
+    mockGetParsed.mockReturnValueOnce({
+      parsed: null,
+      error: 'Failed to parse during submit',
+    });
+
+    (useAddQuestionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+
+    const json = JSON.stringify({
+      meta: {
+        asRichText: true,
+        schemaVersion: "1.0"
+      },
+      type: "textArea",
+      attributes: {
+        cols: 20,
+        rows: 4,
+        maxLength: null,
+        minLength: 0
+      }
+    })
+
+    await act(async () => {
+      render(
+        <QuestionAdd
+          questionType="text"
+          questionName="Text"
+          questionJSON={json}
+          sectionId="1"
+        />);
+    });
+
+    //Wait for component to mount and parsedQuestionJSON to be set
+    await waitFor(() => {
+      expect(screen.queryByText('Failed to parse during submit')).not.toBeInTheDocument();
+    });
+
+    // Get the input
+    const input = screen.getByLabelText('labels.questionText');
+
+    // Set value to empty
+    fireEvent.change(input, { target: { value: 'Test' } });
+
+    const saveButton = screen.getByRole('button', { name: /buttons.saveAndAdd/i });
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
+
+    expect(screen.getByText('Failed to parse during submit')).toBeInTheDocument();
+
   });
 });

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -169,7 +169,7 @@ const QuestionAdd = ({
     setRows(newRows);
 
     if (hasOptions && questionType && question?.json) {
-      const updatedJSON = buildUpdatedJSON(question, newRows);
+      const updatedJSON = buildUpdatedJSON(newRows);
 
       if (updatedJSON) {
         setQuestion((prev) => ({
@@ -257,7 +257,7 @@ const QuestionAdd = ({
 
   // Prepare input for the questionTypeHandler. For options questions, we update the 
   // values with rows state. For non-options questions, we use the parsed JSON
-  const getFormState = (question: Question, rowsOverride?: QuestionOptions[]) => {
+  const getFormState = (rowsOverride?: QuestionOptions[]) => {
 
     if (hasOptions) {
       const useRows = rowsOverride ?? rows;
@@ -284,8 +284,8 @@ const QuestionAdd = ({
   };
 
   // Pass the merged userInput to questionTypeHandlers to generate json and do type and schema validation
-  const buildUpdatedJSON = (question: Question, rowsOverride?: QuestionOptions[]) => {
-    const userInput = getFormState(question, rowsOverride);
+  const buildUpdatedJSON = (rowsOverride?: QuestionOptions[]) => {
+    const userInput = getFormState(rowsOverride);
 
     if (parsedQuestionJSON && userInput) {
       return questionTypeHandlers[questionType as keyof typeof questionTypeHandlers](
@@ -302,7 +302,7 @@ const QuestionAdd = ({
     e.preventDefault();
 
     const displayOrder = getDisplayOrder();
-    const updatedJSON = buildUpdatedJSON(question);
+    const updatedJSON = buildUpdatedJSON();
 
     if (updatedJSON) {
       // Strip all tags from questionText before sending to backend

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -464,7 +464,7 @@ const QuestionAdd = ({
                 />
 
                 {/**Options question types*/}
-                {questionType && OPTIONS_QUESTION_TYPES.includes(questionType) && (
+                {questionType && OPTIONS_QUESTION_TYPES.includes(questionType) && parsedQuestionJSON && (
                   <>
                     <p className={styles.optionsDescription}>
                       {QuestionAdd('helpText.questionOptions', { questionName: questionName ?? '' })}

--- a/components/TinyMCEEditor/tinyMCEEditor.module.scss
+++ b/components/TinyMCEEditor/tinyMCEEditor.module.scss
@@ -1,7 +1,6 @@
 @use '@/styles/responsive';
 
 .tinyMCE-editor-container {
-  margin-bottom: 2rem;
   max-width: 600px;
 
 

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -211,11 +211,15 @@
       "searchByKeyword": "Search by keyword",
       "startDate": "Start date",
       "endDate": "End date",
-      "funderSearch": "Search by funder name"
+      "funderSearch": "Search by funder name",
+      "requiredField": "Required field?"
     },
     "helpText": {
       "searchHelpText": "Search by research organization, field station or lab, template description, etc.",
       "funderSearch": "Search by research organization, funder name, or related keywords."
+    },
+    "descriptions": {
+      "requiredFieldDescription": "Should this question include a warning to the plan builder that an answer is required as a condition of accepting the DMP?(Users will be able to submit the DMP even if they don't answer)"
     },
     "placeholders": {
       "funderSearch": "Enter funder name..."

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -212,7 +212,7 @@
       "startDate": "Start date",
       "endDate": "End date",
       "funderSearch": "Search by funder name",
-      "requiredField": "Marks as required?"
+      "requiredField": "Mark as required?"
     },
     "helpText": {
       "searchHelpText": "Search by research organization, field station or lab, template description, etc.",

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -212,7 +212,7 @@
       "startDate": "Start date",
       "endDate": "End date",
       "funderSearch": "Search by funder name",
-      "requiredField": "Required field?"
+      "requiredField": "Marks as required?"
     },
     "helpText": {
       "searchHelpText": "Search by research organization, field station or lab, template description, etc.",

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -200,11 +200,15 @@
       "searchByKeyword": "Pesquisar por palavra-chave",
       "startDate": "Data de início",
       "endDate": "Data final",
-      "funderSearch": "Pesquisar por nome do financiador"
+      "funderSearch": "Pesquisar por nome do financiador",
+      "requiredField": "Marcar como necessário?"
     },
     "helpText": {
       "searchHelpText": "Pesquisar por organização de pesquisa, estação de campo ou laboratório, descrição de modelo, etc.",
       "funderSearch": "Pesquisar por organização de pesquisa, nome do financiador ou palavras-chave relacionadas."
+    },
+    "descriptions": {
+      "requiredFieldDescription": "Esta questão deve incluir um aviso ao criador do plano de que uma resposta é necessária como condição para aceitar o PGD? (Os usuários poderão enviar o PGD mesmo que não respondam)"
     },
     "placeholders": {
       "funderSearch": "Insira o nome da pasta"

--- a/utils/routes.ts
+++ b/utils/routes.ts
@@ -1,5 +1,34 @@
 // utils/routes.ts
 
+/*Usage*/
+/*
+Basic - no idea if we are going to namespace it just an example
+routePath('app.login');
+Output: "/en-US/login"
+
+Route with Path Parameters
+routePath('projects.show', { projectId: '123' });
+Output: "/en-US/projects/123"
+
+routePath('projects.dmp.section', { projectId: '123', dmpId: '456', sectionId: '789' });
+Output: "/en-US/projects/123/dmp/456/s/789"
+
+Route with Query Parameters
+routePath('projects.index', {}, { page: 2, limit: 10 });
+Output: "/en-US/projects?page=2&limit=10"
+
+routePath('projects.index', {}, { filters: ['active', 'draft'] });
+Output: "/en-US/projects?filters[]=active&filters[]=draft"
+
+Example of both params and query string
+routePath('projects.members.search', { projectId: '123' }, { role: 'PI', status: 'active' });
+Output: "/en-US/projects/123/members/search?role=PI&status=active"
+
+Different locales can be passed if needed but defaults to en-US and should still work with middleware
+routePath('projects.show', { projectId: '123' }, {}, 'pt-BR');
+Output: "/pt-BR/projects/123"
+*/
+
 // Define query param value types
 type QueryParamValue =
   string


### PR DESCRIPTION
## Description

- Updated both the `QuestionAdd` and `QuestionEdit` components to include radio buttons to set the question as `required`
- Made some small changes to `QuestionAdd` to use `routePath` in places that weren't using it
- Updated `utils/routes` to include `usage description`
- Fixed a small bug in `Multistate` component.
- Updated associated unit tests
- Removed a margin from below the TinyMCEEditor, because it was causing the `help text` to be far below the editor in the QuestionAdd and QuestionEdit pages
- Added translation keys

Fixes # ([562](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/562))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manual and unit tests.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshots

### QuestionAdd page
<img width="743" height="939" alt="image" src="https://github.com/user-attachments/assets/7f8add86-3e40-4838-909c-4c8d56dd050c" />


### QuestionEdit page
<img width="725" height="945" alt="image" src="https://github.com/user-attachments/assets/221fd91b-1a0a-4c6d-8a1a-5228ead61b96" />

### Answer page showing that "Required by funder" text displays when question is required
<img width="756" height="855" alt="image" src="https://github.com/user-attachments/assets/751162bc-b1d1-484d-a4a6-9a60ebb6f535" />
