### PR TITLE
Added the ability to edit the plan title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added the ability to edit the `Plan title` [#608]
 - Added three more `icons` for solid down, left and right arrows for the Date Picker [#597]
 - Added a new `ExpandableContentSection` component that allows use to `expand` and `collapse` content, especially for the `Best Practices` right sidebar, but can be used for any content [#578]
 - Added the `Question details` page that allows users to answer a question [#320]

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/index.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/index.tsx
@@ -1,2 +1,3 @@
 export { publishPlanAction } from './publishPlanAction';
 export { updatePlanStatusAction } from './updatePlanStatusAction';
+export { updatePlanTitleAction } from './updatePlanTitleAction';

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/updatePlanTitleAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/updatePlanTitleAction.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
+import logger from "@/utils/server/logger";
+import { ActionResponse } from "@/app/types";
+import { UpdatePlanTitleDocument } from "@/generated/graphql";
+
+export async function updatePlanTitleAction({
+  planId,
+  title
+}: {
+  planId: number;
+  title: string;
+}): Promise<ActionResponse> {
+  try {
+    // Execute the mutation using the shared handler
+    return await executeGraphQLMutation({
+      document: UpdatePlanTitleDocument,
+      variables: { planId, title },
+      dataPath: "updatePlanTitle"
+    });
+
+  } catch (error) {
+    logger.error(`[Update Plan Title Error]: ${error}`, { error });
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
+}

--- a/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
@@ -514,13 +514,13 @@ describe("TemplateEditPage", () => {
       render(<TemplateEditPage />);
     });
 
-    const editButton = screen.getByRole('button', { name: /edit template name/i });
+    const editButton = screen.getByRole('button', { name: 'links.editTemplateTitle' });
 
     await act(async () => {
       fireEvent.click(editButton);
     })
 
-    const input = screen.getByPlaceholderText(/enter new template title/i);
+    const input = screen.getByPlaceholderText('edittitle');
     fireEvent.change(input, { target: { value: 'New template name' } });
 
     const saveButton = screen.getByTestId('save-button');
@@ -670,11 +670,11 @@ describe("TemplateEditPage", () => {
     });
 
 
-    const editTemplateButton = screen.getByRole('button', { name: /Edit template name/i });
+    const editTemplateButton = screen.getByRole('button', { name: 'links.editTemplateTitle' });
     fireEvent.click(editTemplateButton);
 
     // Check if the input field is displayed
-    const inputField = screen.getByRole('textbox', { name: /Template title/i });
+    const inputField = screen.getByPlaceholderText('edittitle');
     expect(inputField).toBeInTheDocument();
   });
 
@@ -708,13 +708,13 @@ describe("TemplateEditPage", () => {
     });
 
     // Simulate clicking the "Edit template name" button
-    const editTemplateButton = screen.getByRole('button', { name: /Edit template name/i });
+    const editTemplateButton = screen.getByRole('button', { name: 'links.editTemplateTitle' });
     await act(async () => {
       fireEvent.click(editTemplateButton);
     });
 
     // Simulate typing a new title into the input field
-    const inputField = screen.getByPlaceholderText('Enter new template title');
+    const inputField = screen.getByPlaceholderText('edittitle');
     await act(async () => {
       fireEvent.change(inputField, { target: { value: 'New Template Title' } });
     });
@@ -768,13 +768,13 @@ describe("TemplateEditPage", () => {
     });
 
     // Simulate clicking the "Edit template name" button
-    const editTemplateButton = screen.getByRole('button', { name: /Edit template name/i });
+    const editTemplateButton = screen.getByRole('button', { name: 'links.editTemplateTitle' });
     await act(async () => {
       fireEvent.click(editTemplateButton);
     });
 
     // Simulate typing a new title into the input field
-    const inputField = screen.getByPlaceholderText('Enter new template title');
+    const inputField = screen.getByPlaceholderText('edittitle');
     await act(async () => {
       fireEvent.change(inputField, { target: { value: 'New Template Title' } });
     });

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -495,6 +495,8 @@ const TemplateEditPage: React.FC = () => {
       <PageHeaderWithTitleChange
         title={template.name}
         description={description}
+        linkText={EditTemplate('links.editTemplateTitle')}
+        labelText={EditTemplate('templateTitleLabel')}
         showBackButton={false}
         breadcrumbs={
           <Breadcrumbs>

--- a/components/PageHeaderWithTitleChange/__tests__/index.spec.tsx
+++ b/components/PageHeaderWithTitleChange/__tests__/index.spec.tsx
@@ -16,6 +16,8 @@ describe('PageHeaderWithTitleChange', () => {
   const defaultProps = {
     title: 'Test Title',
     description: 'This is a test description.',
+    linkText: 'Edit template title',
+    labelText: 'Template Title',
     showBackButton: true,
     breadcrumbs: <div>Mock Breadcrumbs</div>,
     actions: <button>Mock Action</button>,
@@ -43,10 +45,10 @@ describe('PageHeaderWithTitleChange', () => {
     render(<PageHeaderWithTitleChange {...defaultProps} />);
 
     // Click the "Edit template name" button
-    fireEvent.click(screen.getByText('Edit template name'));
+    fireEvent.click(screen.getByText('Edit template title'));
 
     // Check if the input field is rendered
-    const input = screen.getByPlaceholderText('Enter new template title');
+    const input = screen.getByPlaceholderText('edittitle');
     expect(input).toBeInTheDocument();
   });
 
@@ -54,7 +56,7 @@ describe('PageHeaderWithTitleChange', () => {
     render(<PageHeaderWithTitleChange {...defaultProps} />);
 
     // Click the "Edit template name" button
-    fireEvent.click(screen.getByText('Edit template name'));
+    fireEvent.click(screen.getByText('Edit template title'));
 
     // NOTE: We deliberately do not change the title text before we submit
     // because we need to test that the callback was NOT called
@@ -71,10 +73,10 @@ describe('PageHeaderWithTitleChange', () => {
     render(<PageHeaderWithTitleChange {...defaultProps} />);
 
     // Click the "Edit template name" button
-    fireEvent.click(screen.getByText('Edit template name'));
+    fireEvent.click(screen.getByText('Edit template title'));
 
     // Change the title Text
-    const input = screen.getByPlaceholderText('Enter new template title');
+    const input = screen.getByPlaceholderText('edittitle');
     fireEvent.change(input, { target: { value: 'Updated Title' } });
 
     // Submit the form
@@ -89,7 +91,7 @@ describe('PageHeaderWithTitleChange', () => {
     render(<PageHeaderWithTitleChange {...defaultProps} />);
 
     // Click the "Edit template name" button
-    fireEvent.click(screen.getByText('Edit template name'));
+    fireEvent.click(screen.getByText('Edit template title'));
 
     // Click the cancel button
     const cancelButton = screen.getByText('buttons.cancel');

--- a/components/PageHeaderWithTitleChange/index.tsx
+++ b/components/PageHeaderWithTitleChange/index.tsx
@@ -15,6 +15,12 @@ interface PageHeaderProps {
   title: string;
   /** Optional description text below the title */
   description?: string;
+  /** Required link text, such as 'Edit template title' */
+  linkText: string;
+  /** Required text for label */
+  labelText: string;
+  /** Optional placeholder title */
+  placeholder?: string;
   /** Whether to show the back button - defaults to true */
   showBackButton?: boolean;
   /** Optional breadcrumbs component */
@@ -30,6 +36,9 @@ interface PageHeaderProps {
 const PageHeaderWithTitleChange: React.FC<PageHeaderProps> = ({
   title,
   description,
+  linkText,
+  labelText,
+  placeholder,
   showBackButton = true,
   breadcrumbs,
   actions,
@@ -40,6 +49,11 @@ const PageHeaderWithTitleChange: React.FC<PageHeaderProps> = ({
   const [isEditing, setIsEditing] = useState(false);
   const [newTitle, setNewTitle] = useState<string>(title);
   const Global = useTranslations('Global');
+
+  const handleEdit = () => {
+    setNewTitle(title);
+    setIsEditing(true);
+  }
 
   function handleChange(ev: React.ChangeEvent<HTMLInputElement>) {
     ev.preventDefault();
@@ -75,16 +89,16 @@ const PageHeaderWithTitleChange: React.FC<PageHeaderProps> = ({
 
       <div className="pageheader-container">
         {/* Title and description section */}
-        <div>
+        <div className="title-form-container">
           <Form onSubmit={handleFormSubmit} className="pageheader-title-form">
             {isEditing ? (
               <FormInput
                 name={title}
                 type="text"
-                label="Template title"
+                label={labelText}
                 value={newTitle}
                 inputClasses="titleChange-input"
-                placeholder="Enter new template title"
+                placeholder={placeholder ?? Global('edittitle')}
                 onChange={handleChange}
               />
             ) : (
@@ -92,9 +106,9 @@ const PageHeaderWithTitleChange: React.FC<PageHeaderProps> = ({
                 <h1 className="pageheader-title">{title}</h1>
                 <Button
                   className='link'
-                  onPress={() => setIsEditing(true)}
+                  onPress={handleEdit}
                 >
-                  Edit template name
+                  {linkText ?? Global('links.editTitle')}
                 </Button>
               </div>
             )}

--- a/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
+++ b/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
@@ -25,10 +25,8 @@
 
     @include r.device(md) {
       flex-direction: row;
-      //gap: var(--brand-space2);
-      justify-content: space-between;
       gap: var(--brand-space2);
-
+      justify-content: space-between;
     }
   
     .pageheader-title {
@@ -85,7 +83,6 @@
   
   .react-aria-TextField {
     margin-bottom: 0;
-    //max-width: 70%; // This was squeezed on mobile
   }
 
   // Custom input class

--- a/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
+++ b/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
@@ -26,7 +26,6 @@
     @include r.device(md) {
       flex-direction: row;
       gap: var(--brand-space2);
-      justify-content: space-between;
     }
   
     .pageheader-title {

--- a/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
+++ b/components/PageHeaderWithTitleChange/pageheaderWithTitle.scss
@@ -25,12 +25,15 @@
 
     @include r.device(md) {
       flex-direction: row;
+      //gap: var(--brand-space2);
+      justify-content: space-between;
       gap: var(--brand-space2);
+
     }
   
     .pageheader-title {
       margin-bottom: 0;
-      max-width: 70%;
+      max-width: 80%;
     }
 
     .link {
@@ -55,7 +58,16 @@
     align-items: center;
     gap: 0.25rem;
   }
+
+  .title-form-container {
+    width: 100%;
+    @include r.device(lg) {
+      width: 80%;
+    }
+  }
 }
+
+
 
 // Form styles
 .pageheader-title-form{
@@ -73,13 +85,17 @@
   
   .react-aria-TextField {
     margin-bottom: 0;
-    max-width: 70%;
+    //max-width: 70%; // This was squeezed on mobile
   }
 
   // Custom input class
   .titleChange-input {
     margin-bottom: 0;
     max-width: 100%;
+    white-space: nowrap;        /* Prevents text from wrapping */
+    overflow: hidden;           /* Hides overflow text */
+    text-overflow: ellipsis;    /* Shows ellipsis when text overflows */
+    
   }
   
   // Field wrapper takes most of the space

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -870,6 +870,8 @@ export type Mutation = {
   updatePlanMember?: Maybe<PlanMember>;
   /** Change the plan's status */
   updatePlanStatus?: Maybe<Plan>;
+  /** Change the plan's title */
+  updatePlanTitle?: Maybe<Plan>;
   /** Edit a project */
   updateProject?: Maybe<Project>;
   /** Change a collaborator's accessLevel on a Plan */
@@ -1280,6 +1282,12 @@ export type MutationUpdatePlanMemberArgs = {
 export type MutationUpdatePlanStatusArgs = {
   planId: Scalars['Int']['input'];
   status: PlanStatus;
+};
+
+
+export type MutationUpdatePlanTitleArgs = {
+  planId: Scalars['Int']['input'];
+  title: Scalars['String']['input'];
 };
 
 
@@ -3828,6 +3836,14 @@ export type UpdatePlanStatusMutationVariables = Exact<{
 
 export type UpdatePlanStatusMutation = { __typename?: 'Mutation', updatePlanStatus?: { __typename?: 'Plan', id?: number | null, status?: PlanStatus | null, visibility?: PlanVisibility | null, errors?: { __typename?: 'PlanErrors', general?: string | null, status?: string | null } | null } | null };
 
+export type UpdatePlanTitleMutationVariables = Exact<{
+  planId: Scalars['Int']['input'];
+  title: Scalars['String']['input'];
+}>;
+
+
+export type UpdatePlanTitleMutation = { __typename?: 'Mutation', updatePlanTitle?: { __typename?: 'Plan', id?: number | null, title?: string | null, errors?: { __typename?: 'PlanErrors', general?: string | null, title?: string | null } | null } | null };
+
 export type AddPlanFundingMutationVariables = Exact<{
   planId: Scalars['Int']['input'];
   projectFundingId: Scalars['Int']['input'];
@@ -4589,6 +4605,45 @@ export function useUpdatePlanStatusMutation(baseOptions?: Apollo.MutationHookOpt
 export type UpdatePlanStatusMutationHookResult = ReturnType<typeof useUpdatePlanStatusMutation>;
 export type UpdatePlanStatusMutationResult = Apollo.MutationResult<UpdatePlanStatusMutation>;
 export type UpdatePlanStatusMutationOptions = Apollo.BaseMutationOptions<UpdatePlanStatusMutation, UpdatePlanStatusMutationVariables>;
+export const UpdatePlanTitleDocument = gql`
+    mutation UpdatePlanTitle($planId: Int!, $title: String!) {
+  updatePlanTitle(planId: $planId, title: $title) {
+    errors {
+      general
+      title
+    }
+    id
+    title
+  }
+}
+    `;
+export type UpdatePlanTitleMutationFn = Apollo.MutationFunction<UpdatePlanTitleMutation, UpdatePlanTitleMutationVariables>;
+
+/**
+ * __useUpdatePlanTitleMutation__
+ *
+ * To run a mutation, you first call `useUpdatePlanTitleMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdatePlanTitleMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updatePlanTitleMutation, { data, loading, error }] = useUpdatePlanTitleMutation({
+ *   variables: {
+ *      planId: // value for 'planId'
+ *      title: // value for 'title'
+ *   },
+ * });
+ */
+export function useUpdatePlanTitleMutation(baseOptions?: Apollo.MutationHookOptions<UpdatePlanTitleMutation, UpdatePlanTitleMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdatePlanTitleMutation, UpdatePlanTitleMutationVariables>(UpdatePlanTitleDocument, options);
+      }
+export type UpdatePlanTitleMutationHookResult = ReturnType<typeof useUpdatePlanTitleMutation>;
+export type UpdatePlanTitleMutationResult = Apollo.MutationResult<UpdatePlanTitleMutation>;
+export type UpdatePlanTitleMutationOptions = Apollo.BaseMutationOptions<UpdatePlanTitleMutation, UpdatePlanTitleMutationVariables>;
 export const AddPlanFundingDocument = gql`
     mutation AddPlanFunding($planId: Int!, $projectFundingId: Int!) {
   addPlanFunding(planId: $planId, projectFundingId: $projectFundingId) {

--- a/graphql/mutations/plans.mutations.graphql
+++ b/graphql/mutations/plans.mutations.graphql
@@ -75,6 +75,18 @@ mutation UpdatePlanStatus($planId: Int!, $status: PlanStatus!) {
   }
 }
 
+mutation UpdatePlanTitle($planId: Int!, $title: String!) {
+  updatePlanTitle(planId: $planId, title: $title) {
+    errors {
+      general
+      title
+    }
+    id
+    title
+  }
+}
+
+
 
 mutation AddPlanFunding($planId: Int!, $projectFundingId: Int!) {
   addPlanFunding(planId: $planId, projectFundingId: $projectFundingId) {

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -64,7 +64,7 @@
     "headingRelatedActions": "Related actions",
     "primaryEmailDesc": "This email will be used for your account login. It can also be used for password resets.",
     "SSODesc": "This email address is managed by cdl.edu and connected to the institution.",
-    "notificationsDesc": "This email address will be used for DMP notifications. &lt;manage&gt; Manage your notifications &lt;/manage&gt;.",
+    "notificationsDesc": "This email address will be used for DMP notifications. <manage> Manage your notifications </manage>.",
     "aliasEmailDesc": "Alias email addresses may be used to help others find you, for example if they‘d like to share a DMP with you.",
     "linkMakePrimary": "Make primary email address",
     "helpTextForAddAlias": "You will be sent an email to confirm this addition",

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -64,7 +64,7 @@
     "headingRelatedActions": "Related actions",
     "primaryEmailDesc": "This email will be used for your account login. It can also be used for password resets.",
     "SSODesc": "This email address is managed by cdl.edu and connected to the institution.",
-    "notificationsDesc": "This email address will be used for DMP notifications. <manage> Manage your notifications </manage>.",
+    "notificationsDesc": "This email address will be used for DMP notifications. &lt;manage&gt; Manage your notifications &lt;/manage&gt;.",
     "aliasEmailDesc": "Alias email addresses may be used to help others find you, for example if they‘d like to share a DMP with you.",
     "linkMakePrimary": "Make primary email address",
     "helpTextForAddAlias": "You will be sent an email to confirm this addition",
@@ -186,6 +186,7 @@
     "published": "Published",
     "visibility": "Visibility",
     "notPublished": "Not published",
+    "editTitle": "Edit title",
     "buttons": {
       "search": "Search",
       "select": "Select",
@@ -227,7 +228,8 @@
       "learnMore": "Learn more",
       "update": "Update",
       "expand": "Expand",
-      "collapse": "Collapse"
+      "collapse": "Collapse",
+      "editTitle": "Edit title"
     },
     "messaging": {
       "loading": "Loading",

--- a/messages/en-US/planBuilderPlanOverview.json
+++ b/messages/en-US/planBuilderPlanOverview.json
@@ -16,7 +16,8 @@
     },
     "labels": {
       "saveAnswer": "Save answer",
-      "returnToSection": "Return to section overview"
+      "returnToSection": "Return to section overview",
+      "planTitle": "Plan title"
     },
     "page": {
       "pageDescription": "Overview of plan details",
@@ -27,7 +28,8 @@
       "viewSampleAnswer": "View sample answer",
       "guidanceBy": "Guidance by {funder}",
       "funderSampleText": "{funder} sample text",
-      "participantsWillBeNotified": "Participants will be notified once submitted."
+      "participantsWillBeNotified": "Participants will be notified once submitted.",
+      "planTitlePlaceholder": "Enter plan title"
     },
     "funding": {
       "title": "Funding for this plan",
@@ -109,6 +111,19 @@
         },
         "publishButton": "Publish"
       }
+    },
+    "messages": {
+      "errors": {
+        "updateTitleError": "There was an error updating the plan title"
+      },
+      "success": {
+        "successfullyUpdatedTitle": "Successfully updated the plan title",
+        "successfullyPublished": "Successfully published the plan",
+        "successfullyUpdatedStatus": "Successfully updated the plan status"
+      }
+    },
+    "links": {
+      "editTitle": "Edit plan title"
     }
   },
   "PlanCreate": {

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -18,6 +18,7 @@
   },
   "EditTemplates": {
     "title": "Edit template",
+    "templateTitleLabel": "Template title",
     "titleStatus": "Status",
     "draft": "Draft",
     "notPublished": "Not Published",
@@ -30,7 +31,8 @@
       "addSection": "Add section",
       "edit": "Edit",
       "manageAccess": "Manage access",
-      "templateHistory": "Template history"
+      "templateHistory": "Template history",
+      "editTemplateTitle": "Edit template title"
     },
     "button": {
       "archiveTemplate": "Archive template",

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -117,6 +117,7 @@
   "FunderSearch": {
     "headerTitle": "Procurar por fragmentos",
     "funder": "Finalizações",
+    "popularTitle": "Financiadores mais populares",
     "found": "{count} erros encontrados",
     "noResults": "Nenhum resultado encontrado",
     "showCount": "Mostrando {count} de {total}",
@@ -185,6 +186,7 @@
     "published": "Publicada",
     "visibility": "Visibilidade",
     "notPublished": "Não publicado",
+    "editTitle": "Editar título",
     "buttons": {
       "search": "Buscar",
       "select": "Select",
@@ -226,7 +228,8 @@
       "learnMore": "Saiba mais",
       "update": "Atualização",
       "expand": "Expandir",
-      "collapse": "Recolher"
+      "collapse": "Recolher",
+      "editTitle": "Editar título"
     },
     "messaging": {
       "loading": "Baixar",

--- a/messages/pt-BR/planBuilderPlanOverview.json
+++ b/messages/pt-BR/planBuilderPlanOverview.json
@@ -16,7 +16,8 @@
     },
     "labels": {
       "saveAnswer": "Resposta salva",
-      "returnToSection": "Voltar à visão geral da seção"
+      "returnToSection": "Voltar à visão geral da seção",
+      "planTitle": "Título do Plano"
     },
     "page": {
       "pageDescription": "Visão geral dos detalhes do plano",
@@ -27,7 +28,8 @@
       "viewSampleAnswer": "Ver amostra da resposta",
       "guidanceBy": "Guia por {funder}",
       "funderSampleText": "{funder} texto de exemplo",
-      "participantsWillBeNotified": "Os participantes serão notificados assim que submetidos."
+      "participantsWillBeNotified": "Os participantes serão notificados assim que submetidos.",
+      "planTitlePlaceholder": "Inserir título do plano"
     },
     "funding": {
       "title": "Financiamento para este plano",
@@ -109,6 +111,19 @@
         },
         "publishButton": "Publicar"
       }
+    },
+    "messages": {
+      "errors": {
+        "updateTitleError": "Ocorreu um erro ao atualizar o título do plano"
+      },
+      "success": {
+        "successfullyUpdatedTitle": "Título do plano atualizado com êxito",
+        "successfullyPublished": "Plano publicado com sucesso",
+        "successfullyUpdatedStatus": "Status do plano atualizado com sucesso"
+      }
+    },
+    "links": {
+      "editTitle": "Editar título do plano"
     }
   },
   "PlanCreate": {

--- a/messages/pt-BR/planBuilderProjectOverview.json
+++ b/messages/pt-BR/planBuilderProjectOverview.json
@@ -139,7 +139,7 @@
     "description": "Atualizar informações da fonte de financiamento",
     "labels": {
       "funderName": "Nome da planta",
-      "fundingStatus": "Funding Status",
+      "fundingStatus": "Status do financiamento",
       "grantNumber": "Conceder número/url",
       "projectNumber": "Número ou ID do projeto",
       "opportunity": "No. de Prêmio Oportunidade/Federal"

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -18,6 +18,7 @@
   },
   "EditTemplates": {
     "title": "Editar modelo",
+    "templateTitleLabel": "Título do modelo",
     "titleStatus": "Status",
     "draft": "Rascunho",
     "notPublished": "Não publicado",
@@ -30,7 +31,8 @@
       "addSection": "Adicionar seção",
       "edit": "Alterar",
       "manageAccess": "Gerenciar acesso",
-      "templateHistory": "Histórico do modelo"
+      "templateHistory": "Histórico do modelo",
+      "editTemplateTitle": "Editar título do modelo"
     },
     "button": {
       "archiveTemplate": "Template de arquivo",

--- a/utils/errorHandler.ts
+++ b/utils/errorHandler.ts
@@ -89,3 +89,26 @@ export const handleErrors = async (
       break;
   }
 };
+
+
+/**
+ * Shared function to extract specified errors from an error object.
+ * @param errs - The error object (can be any shape)
+ * @param keys - The keys to extract errors from
+ * @returns Array of error messages (non-empty strings)
+ */
+export function extractErrors<T extends Record<string, string | undefined>>(
+  errs: T,
+  keys: (keyof T)[]
+): string[] {
+  const newErrors: string[] = [];
+
+  for (const key of keys) {
+    const val = errs[key];
+    if (val) {
+      newErrors.push(val);
+    }
+  }
+
+  return newErrors;
+}


### PR DESCRIPTION
## Description
- Updated the `Plan Overview` page to use the `PageHeaderWithTitleChange` component to allow users to edit the `Plan title`
- Made updates to the `PageHeaderWithTitleChange` to allow link text and label text to be passed in as props. 
- Added a `updatePlanTitleAction` to be used for to call the `updatePlan` mutation
- Made updates to the `Template Edit` page in order to pass in the new `linkText` and `label` props to `PageHeaderWithTitleChange`
- Added a shared `extractErrors` function to extract the field-level errors returned from the backend
- Added translation keys
- Updated associated unit tests

Fixes # ([608](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/608))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually and via unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules

*Note: There is a backend change in PR review that goes with this ticket. It adds the `updatePlanTitle` resolver ([356](https://github.com/CDLUC3/dmsp_backend_prototype/pull/356))

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshot
### Edit title link is now in the header
<img width="811" height="850" alt="image" src="https://github.com/user-attachments/assets/fee39127-6fa3-4bac-9cd0-2497ce94ea77" />

### View when user clicks to edit title
Notice ellipsis added for long titles

<img width="884" height="799" alt="image" src="https://github.com/user-attachments/assets/31268488-6824-41ef-93aa-0097995bdc57" />

### For mobile devices, the `Edit plan title` wraps below the title
<img width="364" height="500" alt="image" src="https://github.com/user-attachments/assets/4d00d81e-c4f3-4e28-a555-139b523045c2" />

### For mobile, I fixed the input so that it extends across the full length
<img width="362" height="683" alt="image" src="https://github.com/user-attachments/assets/4244c61c-ad29-415f-9ca7-ce0525a0cdb9" />
