### PR TITLE
[Bug fix] - Made updates to use optimistic updates for Plan and Template title changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Added the ability to edit the `Plan title` [#608]
 
 ### Fixed
+- Make `plan` and `template` title changes more smooth by optimistically updating title [#625]
+- Made the project title change smoother by optimistically updated title [#608]
 - Updated the `Plan Overview` page so that it uses the `Plan` title instead of the `template` title [#303]
 
 ====================================================================================================================================

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
@@ -404,13 +404,22 @@ const PlanOverviewPage: React.FC = () => {
             type: 'SET_ERROR_MESSAGES',
             payload: errs
           });
-        } else {
-          const successMessage = t('messages.success.successfullyUpdatedTitle');
-          toastState.add(successMessage, { type: 'success' });
+          return;
         }
+
+        // Optimistically update state so UI reflects it smoothly
+        dispatch({
+          type: 'SET_PLAN_DATA',
+          payload: {
+            ...state.planData,
+            title: newTitle
+          }
+        });
+
+        const successMessage = t('messages.success.successfullyUpdatedTitle');
+        toastState.add(successMessage, { type: 'success' });
+
       }
-      //Need to refetch plan data to refresh the info that was changed
-      await refetch();
     }
   }
 

--- a/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
@@ -520,7 +520,7 @@ describe("TemplateEditPage", () => {
       fireEvent.click(editButton);
     })
 
-    const input = screen.getByPlaceholderText('edittitle');
+    const input = screen.getByPlaceholderText('editTitle');
     fireEvent.change(input, { target: { value: 'New template name' } });
 
     const saveButton = screen.getByTestId('save-button');
@@ -674,7 +674,7 @@ describe("TemplateEditPage", () => {
     fireEvent.click(editTemplateButton);
 
     // Check if the input field is displayed
-    const inputField = screen.getByPlaceholderText('edittitle');
+    const inputField = screen.getByPlaceholderText('editTitle');
     expect(inputField).toBeInTheDocument();
   });
 
@@ -714,7 +714,7 @@ describe("TemplateEditPage", () => {
     });
 
     // Simulate typing a new title into the input field
-    const inputField = screen.getByPlaceholderText('edittitle');
+    const inputField = screen.getByPlaceholderText('editTitle');
     await act(async () => {
       fireEvent.change(inputField, { target: { value: 'New Template Title' } });
     });
@@ -774,7 +774,7 @@ describe("TemplateEditPage", () => {
     });
 
     // Simulate typing a new title into the input field
-    const inputField = screen.getByPlaceholderText('edittitle');
+    const inputField = screen.getByPlaceholderText('editTitle');
     await act(async () => {
       fireEvent.change(inputField, { target: { value: 'New Template Title' } });
     });

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -40,6 +40,7 @@ import { useFormatDate } from '@/hooks/useFormatDate';
 import logECS from '@/utils/clientLogger';
 import { useToast } from '@/context/ToastContext';
 import { routePath } from '@/utils/routes';
+import { extractErrors } from '@/utils/errorHandler';
 import {
   updateTemplateAction,
   updateSectionDisplayOrderAction
@@ -50,6 +51,13 @@ interface TemplateInfoInterface {
   name: string;
   visibility: TemplateVisibility;
 }
+
+type UpdateTemplateErrors = {
+  general?: string;
+  name?: string;
+  description?: string;
+};
+
 const TemplateEditPage: React.FC = () => {
   const formatDate = useFormatDate();
 
@@ -263,14 +271,21 @@ const TemplateEditPage: React.FC = () => {
     if (!result.success) {
       setErrorMessages([EditTemplate('errors.updateTitleError')])
     } else {
-      if (
-        result.data?.errors &&
-        typeof result.data.errors.general === 'string') {
+      if (result.data?.errors) {
         // Handle errors as an object with general or field-level errors
-        setErrorMessages(prev => [...prev, result.data?.errors?.general || EditTemplate('errors.updateTitleError')]);
+        const errs = extractErrors<UpdateTemplateErrors>(result?.data?.errors, ['general', 'name', 'description']);
+        if (errs.length > 0) {
+          setErrorMessages(errs);
+          return;
+        }
+        setTemplateInfoState({
+          ...templateInfo,
+          name: newTitle
+        })
+
+        const successMessage = EditTemplate('messages.successfullyUpdatedTitle');
+        toastState.add(successMessage, { type: 'success' });
       }
-      //Need to refetch plan data to refresh the info that was changed
-      await refetch();
     }
   }
 
@@ -480,7 +495,6 @@ const TemplateEditPage: React.FC = () => {
   const formattedPublishDate = template.latestPublishDate ? formatDate(template.latestPublishDate) : null;
 
 
-
   // Use localSections instead of sortedSections in render
   const sectionsToRender = localSections.length > 0 ? localSections :
     (template.sections ? sortSections(template.sections.filter((section): section is Section => section !== null)) : []);
@@ -490,10 +504,11 @@ const TemplateEditPage: React.FC = () => {
     (template?.latestPublishDate || formattedPublishDate ? ` - ${Global('lastUpdated')}: ${formattedPublishDate || template.latestPublishDate}` : '');
 
 
+
   return (
     <div>
       <PageHeaderWithTitleChange
-        title={template.name}
+        title={templateInfo.name}
         description={description}
         linkText={EditTemplate('links.editTemplateTitle')}
         labelText={EditTemplate('templateTitleLabel')}

--- a/components/PageHeaderWithTitleChange/__tests__/index.spec.tsx
+++ b/components/PageHeaderWithTitleChange/__tests__/index.spec.tsx
@@ -48,7 +48,7 @@ describe('PageHeaderWithTitleChange', () => {
     fireEvent.click(screen.getByText('Edit template title'));
 
     // Check if the input field is rendered
-    const input = screen.getByPlaceholderText('edittitle');
+    const input = screen.getByPlaceholderText('editTitle');
     expect(input).toBeInTheDocument();
   });
 
@@ -76,7 +76,7 @@ describe('PageHeaderWithTitleChange', () => {
     fireEvent.click(screen.getByText('Edit template title'));
 
     // Change the title Text
-    const input = screen.getByPlaceholderText('edittitle');
+    const input = screen.getByPlaceholderText('editTitle');
     fireEvent.change(input, { target: { value: 'Updated Title' } });
 
     // Submit the form

--- a/components/PageHeaderWithTitleChange/index.tsx
+++ b/components/PageHeaderWithTitleChange/index.tsx
@@ -98,7 +98,7 @@ const PageHeaderWithTitleChange: React.FC<PageHeaderProps> = ({
                 label={labelText}
                 value={newTitle}
                 inputClasses="titleChange-input"
-                placeholder={placeholder ?? Global('edittitle')}
+                placeholder={placeholder ?? Global('editTitle')}
                 onChange={handleChange}
               />
             ) : (

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -4012,7 +4012,7 @@ export type UpdateTemplateMutationVariables = Exact<{
 }>;
 
 
-export type UpdateTemplateMutation = { __typename?: 'Mutation', updateTemplate?: { __typename?: 'Template', id?: number | null, name: string, visibility: TemplateVisibility } | null };
+export type UpdateTemplateMutation = { __typename?: 'Mutation', updateTemplate?: { __typename?: 'Template', id?: number | null, name: string, visibility: TemplateVisibility, errors?: { __typename?: 'TemplateErrors', general?: string | null, name?: string | null, description?: string | null } | null } | null };
 
 export type UpdateUserProfileMutationVariables = Exact<{
   input: UpdateUserProfileInput;
@@ -5587,6 +5587,11 @@ export const UpdateTemplateDocument = gql`
     id
     name
     visibility
+    errors {
+      general
+      name
+      description
+    }
   }
 }
     `;

--- a/graphql/mutations/templates.mutation.graphql
+++ b/graphql/mutations/templates.mutation.graphql
@@ -39,5 +39,10 @@ mutation UpdateTemplate($templateId: Int!, $name: String!, $visibility: Template
     id
     name
     visibility
+    errors {
+      general
+      name
+      description
+    }
   }
 }

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -60,7 +60,8 @@
     },
     "messages": {
       "successfullyArchived": "Successfully archived the template",
-      "sectionMoved": "Section moved to position {displayOrder}"
+      "sectionMoved": "Section moved to position {displayOrder}",
+      "successfullyUpdatedTitle": "Successfully updated the template title"
     }
   },
   "PublishTemplate": {

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -60,7 +60,8 @@
     },
     "messages": {
       "successfullyArchived": "Modelo arquivado com sucesso",
-      "sectionMoved": "Seção movida para a posição {displayOrder}"
+      "sectionMoved": "Seção movida para a posição {displayOrder}",
+      "successfullyUpdatedTitle": "Título do modelo atualizado com sucesso"
     }
   },
   "PublishTemplate": {


### PR DESCRIPTION
## Description

We recently updated `Plan Overview` and `Template Edit` pages to allow users to change the plan and template titles. However, after saving the new title, we were calling `refetch` to reload the data, but the experience was jerky. So `optimistic updates` were applied in both cases

Fixes # ([625](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/625))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
This was tested manually and using unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screen Recordings
### Previous experience

https://github.com/user-attachments/assets/10258019-51da-4fe4-82b2-d1b570035592

### New experience with optimistic updates

https://github.com/user-attachments/assets/ddfd8827-2061-45f5-a205-e6d19c6bc299


