### PR TITLE
[Bug] - Fixed bug where links in Plan Overview sidebar were of different sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Added the ability to edit the `Plan title` [#608]
 
 ### Fixed
+- Fixed bug where links in `Plan Overview` sidebar were of different sizes [#634]
+- Fixed the bug where `Plan Status` was displayed in all caps in the sidebar for the `Plan Overview` page [#634]
 - Make `plan` and `template` title changes more smooth by optimistically updating title [#625]
 - Made the project title change smoother by optimistically updated title [#608]
 - Updated the `Plan Overview` page so that it uses the `Plan` title instead of the `template` title [#303]

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/PlanOverviewPage.module.scss
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/PlanOverviewPage.module.scss
@@ -171,14 +171,6 @@
     margin-bottom: var(--space-8);
   }
 }
-
-.sidePanelLink {
-  font-size: var(--fs-small);
-    color: var(--slate-800);
-    margin-top: var(--space-1);
-    display: inline-block;
-}
-
 .sidePanel {
   a {
     font-size: var(--fs-small);
@@ -196,6 +188,15 @@
   .panelRow {
     display: flex;
     justify-content: space-between;
+
+    .buttonLink {
+      font-size: var(--fs-small);
+      font-weight: 300;
+      color: var(--slate-800);
+      margin-top: var(--space-1);
+      display: inline-block;
+      margin: 0;
+    }
   }
 }
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
@@ -132,7 +132,7 @@ describe('PlanOverviewPage', () => {
     expect(within(sidebar).getByRole('heading', { name: 'status.feedback.title' })).toBeInTheDocument();
     expect(within(sidebar).getByRole('link', { name: 'links.request' })).toBeInTheDocument();
     expect(within(sidebar).getByRole('heading', { name: 'status.title' })).toBeInTheDocument();
-    expect(within(sidebar).getByText('DRAFT')).toBeInTheDocument();
+    expect(within(sidebar).getByText('Draft')).toBeInTheDocument();
     expect(within(sidebar).getByText('buttons.linkUpdate')).toBeInTheDocument();
     expect(within(sidebar).getByRole('heading', { name: 'status.publish.title' })).toBeInTheDocument();
     expect(within(sidebar).getByText('status.publish.label')).toBeInTheDocument();
@@ -181,7 +181,7 @@ describe('PlanOverviewPage', () => {
     expect(within(sidebar).getByRole('heading', { name: 'status.feedback.title' })).toBeInTheDocument();
     expect(within(sidebar).getByRole('link', { name: 'links.request' })).toBeInTheDocument();
     expect(within(sidebar).getByRole('heading', { name: 'status.title' })).toBeInTheDocument();
-    expect(within(sidebar).queryByText('DRAFT')).not.toBeInTheDocument();
+    expect(within(sidebar).queryByText('Draft')).not.toBeInTheDocument();
     expect(within(sidebar).getByText('buttons.linkUpdate')).toBeInTheDocument();
     expect(within(sidebar).getByRole('heading', { name: 'status.publish.title' })).toBeInTheDocument();
     expect(within(sidebar).getByText('status.publish.label')).toBeInTheDocument();
@@ -527,7 +527,7 @@ describe('PlanOverviewPage', () => {
     render(<PlanOverviewPage />);
 
     // First check that inital Plan Status is DRAFT
-    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
 
     // Click the Update link next to Plan Status to reveal the select dropdown
     const updateLink = screen.getByTestId('updateLink');
@@ -578,7 +578,7 @@ describe('PlanOverviewPage', () => {
     render(<PlanOverviewPage />);
 
     // First check that inital Plan Status is DRAFT
-    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
 
     // Click the Update link next to Plan Status to reveal the select dropdown
     const updateLink = screen.getByTestId('updateLink');
@@ -631,7 +631,7 @@ describe('PlanOverviewPage', () => {
     render(<PlanOverviewPage />);
 
     // First check that inital Plan Status is DRAFT
-    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
 
     // Click the Update link next to Plan Status to reveal the select dropdown
     const updateLink = screen.getByTestId('updateLink');
@@ -692,7 +692,7 @@ describe('PlanOverviewPage', () => {
     render(<PlanOverviewPage />);
 
     // First check that inital Plan Status is DRAFT
-    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
 
     // Click the Update link next to Plan Status to reveal the select dropdown
     const updateLink = screen.getByTestId('updateLink');
@@ -754,7 +754,7 @@ describe('PlanOverviewPage', () => {
     render(<PlanOverviewPage />);
 
     // First check that inital Plan Status is DRAFT
-    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
 
     // Click the Update link next to Plan Status to reveal the select dropdown
     const updateLink = screen.getByTestId('updateLink');

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
@@ -33,6 +33,7 @@ import { FormSelect, RadioGroupComponent } from '@/components/Form';
 import PageHeaderWithTitleChange from "@/components/PageHeaderWithTitleChange";
 
 import { routePath } from '@/utils/routes';
+import { toTitleCase } from '@/utils/general';
 import { extractErrors } from '@/utils/errorHandler';
 import { useToast } from '@/context/ToastContext';
 import {
@@ -281,12 +282,25 @@ const PlanOverviewPage: React.FC = () => {
             payload: errs
           });
         } else {
+
+          // Optimistically update status so UI reflects it smoothly
+          dispatch({
+            type: 'SET_PLAN_STATUS',
+            payload: status
+          });
+
+          // ALSO update the planData.status so the display paragraph updates
+          dispatch({
+            type: 'SET_PLAN_DATA',
+            payload: {
+              ...state.planData,
+              status
+            }
+          });
           const successMessage = t('messages.success.successfullyUpdatedStatus');
           toastState.add(successMessage, { type: 'success' });
         }
       }
-      //Need to refetch plan data to refresh the info that was changed
-      await refetch();
     }
   }
 
@@ -684,7 +698,7 @@ const PlanOverviewPage: React.FC = () => {
                 <div>
                   <h3>{t('status.feedback.title')}</h3>
                 </div>
-                <Link href={FEEDBACK_URL} aria-label={Global('links.request')} >
+                <Link className={styles.sidePanelLink} href={FEEDBACK_URL} aria-label={Global('links.request')} >
                   {Global('links.request')}
                 </Link >
               </div >
@@ -711,11 +725,11 @@ const PlanOverviewPage: React.FC = () => {
                 <div className={`${styles.panelRow} mb-5`}>
                   <div>
                     <h3>{t('status.title')}</h3>
-                    <p>{state.planData.status}</p>
+                    <p>{toTitleCase(state.planData.status)}</p>
                   </div>
-                  <Link className={`${styles.sidePanelLink} react-aria-Link`} data-testid="updateLink" onPress={handlePlanStatusChange} aria-label={t('status.select.changeLabel')}>
+                  <Button className={`${styles.buttonLink} link`} data-testid="updateLink" onPress={handlePlanStatusChange} aria-label={t('status.select.changeLabel')}>
                     {Global('buttons.linkUpdate')}
-                  </Link>
+                  </Button>
                 </div>
               )}
 
@@ -724,7 +738,7 @@ const PlanOverviewPage: React.FC = () => {
                   <h3>{t('status.publish.title')}</h3>
                   <p>{state.planData.registered ? PUBLISHED : UNPUBLISHED}</p>
                 </div>
-                <Link className={`${styles.sidePanelLink} react-aria-Link`} onPress={() => dispatch({ type: 'SET_IS_MODAL_OPEN', payload: true })} aria-label={t('status.publish.label')}>
+                <Link href="#" onPress={() => dispatch({ type: 'SET_IS_MODAL_OPEN', payload: true })} aria-label={t('status.publish.label')}>
                   {t('status.publish.label')}
                 </Link>
               </div>

--- a/utils/general.ts
+++ b/utils/general.ts
@@ -42,4 +42,5 @@ export const stripHtmlTags = (input: string): string => {
   return input.replace(/<[^>]*>/g, '');
 };
 
+export const toTitleCase = (str: string) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 


### PR DESCRIPTION
s and the Plan Status displayed was in all caps

## Description

On the Plan Overview page, the links in the side panel were different sizes. The cause was because a couple of the `<Link/>` tags didn't include an `href` since it cause some flashing when switching to a Select dropdown, say. I updated the `Update` link to use a `<Button>` component instead.
- I smoothed out the Plan Status update
- I updated unit tests

Fixes # ([634](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/634))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manual testing and unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshot

<img width="992" height="716" alt="image" src="https://github.com/user-attachments/assets/b7d8a4cc-8c7b-4592-b1b0-d03d71179839" />

