### PR TITLE
Added the new expanding/collapsing Best Practices to Question Detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added the ability to edit the `Plan title` [#608]
 
 ### Fixed
+- Added the missing expanding/collapsing `Best Practices` to the sidebar of the `Question Details` page [#638]
 - Fixed bug where links in `Plan Overview` sidebar were of different sizes [#634]
 - Fixed the bug where `Plan Status` was displayed in all caps in the sidebar for the `Plan Overview` page [#634]
 - Make `plan` and `template` title changes more smooth by optimistically updating title [#625]

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
@@ -48,25 +48,11 @@
   }
 }
 
-/* Best Practices Sidebar Styles */
-.bestPracticesPanel {
-  background-color: var(--color-background-subtle);
-  border-radius: var(--border-radius-lg);
-  padding: var(--space-4);
-
-  h3 {
-    font-size: var(--fs-base);
-    font-weight: 500;
-    margin: 0;
-    margin-bottom: var(--space-2);
-  }
-
-  p {
-    font-size: var(--fs-sm);
-    color: var(--gray-600);
-    margin: 0;
-    margin-bottom: var(--space-4);
-  }
+/* Best Practices Sidebar Style */
+.headerWithLogo {
+  display: flex;
+  align-items: center; // vertically center the image and text
+  gap: 0.5rem;
 }
 
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
@@ -171,6 +171,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
         <PlanOverviewQuestionPage />
       );
     });
+
     // Check for Requirements content
     expect(screen.getByRole('heading', { level: 3, name: 'page.requirementsBy' })).toBeInTheDocument();
     const boldedRequirements = screen.getByText('Requirements - Lorem Ipsum');
@@ -210,14 +211,13 @@ describe('PlanOverviewQuestionPage render of questions', () => {
 
     // Check for best practice content in sidebar
     expect(screen.getByTestId('sidebar-panel')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 3, name: 'Best practice by DMP Tool' })).toBeInTheDocument();
-    const bestPracticeSubHeading = screen.getByText(/Most relevant best practice guide/i);
-    expect(bestPracticeSubHeading).toBeInTheDocument();
-    expect(bestPracticeSubHeading.tagName).toBe('P');
-    expect(screen.getByRole('link', { name: /Data sharing/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Data preservation/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Data protection/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /All topics/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'bestPractice' })).toBeInTheDocument();
+    const bestPracticeDataDescription = screen.getByRole('heading', { level: 3, name: 'dataDescription' });
+    expect(bestPracticeDataDescription).toBeInTheDocument();
+    const bestPracticeDataFormat = screen.getByRole('heading', { level: 3, name: 'dataFormat' });
+    expect(bestPracticeDataFormat).toBeInTheDocument();
+    const bestPracticeDataVolume = screen.getByRole('heading', { level: 3, name: 'dataVolume' });
+    expect(bestPracticeDataVolume).toBeInTheDocument();
   })
 
   it('should load correct question content for checkbox question', async () => {

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import Image from 'next/image';
 import classNames from 'classnames';
 import {
   Breadcrumb,
@@ -44,6 +45,7 @@ import ErrorMessages from '@/components/ErrorMessages';
 import { getParsedQuestionJSON } from '@/components/hooks/getParsedQuestionJSON';
 import { DmpIcon } from "@/components/Icons";
 import { useRenderQuestionField } from '@/components/hooks/useRenderQuestionField';
+import ExpandableContentSection from '@/components/ExpandableContentSection';
 
 // Context
 import { useToast } from '@/context/ToastContext';
@@ -405,7 +407,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
       selectedSelectValue: value
     }));
     setHasUnsavedChanges(true);
-    };
+  };
 
 
   // Handler for MultiSelect changes
@@ -440,7 +442,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
     }));
     setHasUnsavedChanges(true);
   };
-  
+
 
   // Handler for number changes
   const handleNumberChange = (value: number) => {
@@ -471,7 +473,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
   }
 
   function hasAttributes(obj: AnyParsedQuestion | undefined): obj is AnyParsedQuestion & { attributes: { multiple?: boolean } } {
-    if(obj){
+    if (obj) {
       return obj && typeof obj === 'object' && 'attributes' in obj;
     }
     return false;
@@ -514,10 +516,10 @@ const PlanOverviewQuestionPage: React.FC = () => {
         }
         if (hasAttributes(parsed) && parsed.attributes.multiple === true) {
           setFormData(prev => ({
-          ...prev,
-          selectedMultiSelectValues: answer
-        }));
-      }
+            ...prev,
+            selectedMultiSelectValues: answer
+          }));
+        }
 
         break;
       case 'boolean':
@@ -678,7 +680,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
   // Call Server Action updateAnswerAction or addAnswerAction to save answer
   const addAnswer = async (isAutoSave = false) => {
 
-    if(isAutoSave) {
+    if (isAutoSave) {
       setIsAutoSaving(true);
     }
 
@@ -717,10 +719,10 @@ const PlanOverviewQuestionPage: React.FC = () => {
           }
         });
       } finally {
-        if(isAutoSave) {
+        if (isAutoSave) {
           setIsAutoSaving(false);
           setHasUnsavedChanges(false);
-        } 
+        }
       }
     }
     return {
@@ -860,7 +862,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
       if (!sectionBelongsToPlan) {
         router.push('/not-found')
       }
-      
+
       const planInfo = {
         funder: planData?.plan?.project?.fundings?.[0]?.affiliation?.displayName ?? '',
         funderName: planData?.plan?.project?.fundings?.[0]?.affiliation?.name ?? '',
@@ -1201,56 +1203,71 @@ const PlanOverviewQuestionPage: React.FC = () => {
         </ContentContainer >
 
         <SidebarPanel isOpen={isSideBarPanelOpen}>
-          <div
-            className={styles.bestPracticesPanel}
-            aria-labelledby="best-practices-title"
-          >
-            <h3 id="best-practices-title">Best practice by DMP Tool</h3>
-            <p>Most relevant best practice guide</p>
 
-            <div role="navigation" aria-label="Best practices navigation"
-              className={styles.bestPracticesLinks}>
-              <Link href="/best-practices/sharing">
-                Data sharing
-                <svg width="20" height="20" viewBox="0 0 20 20"
-                  fill="currentColor">
-                  <path fillRule="evenodd"
-                    d="M5.22 14.78a.75.75 0 001.06 0l7.22-7.22v5.69a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75h-7.5a.75.75 0 000 1.5h5.69l-7.22 7.22a.75.75 0 000 1.06z"
-                    clipRule="evenodd" />
-                </svg>
-              </Link>
-
-              <Link href="/best-practices/preservation">
-                Data preservation
-                <svg width="20" height="20" viewBox="0 0 20 20"
-                  fill="currentColor">
-                  <path fillRule="evenodd"
-                    d="M5.22 14.78a.75.75 0 001.06 0l7.22-7.22v5.69a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75h-7.5a.75.75 0 000 1.5h5.69l-7.22 7.22a.75.75 0 000 1.06z"
-                    clipRule="evenodd" />
-                </svg>
-              </Link>
-
-              <Link href="/best-practices/protection">
-                Data protection
-                <svg width="20" height="20" viewBox="0 0 20 20"
-                  fill="currentColor">
-                  <path fillRule="evenodd"
-                    d="M5.22 14.78a.75.75 0 001.06 0l7.22-7.22v5.69a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75h-7.5a.75.75 0 000 1.5h5.69l-7.22 7.22a.75.75 0 000 1.06z"
-                    clipRule="evenodd" />
-                </svg>
-              </Link>
-
-              <Link href="/best-practices/all">
-                All topics
-                <svg width="20" height="20" viewBox="0 0 20 20"
-                  fill="currentColor">
-                  <path fillRule="evenodd"
-                    d="M5.22 14.78a.75.75 0 001.06 0l7.22-7.22v5.69a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75h-7.5a.75.75 0 000 1.5h5.69l-7.22 7.22a.75.75 0 000 1.06z"
-                    clipRule="evenodd" />
-                </svg>
-              </Link>
-            </div>
+          <div className={styles.headerWithLogo}>
+            <h2 className="h4">{Global('bestPractice')}</h2>
+            <Image
+              className={styles.Logo}
+              src="/images/DMP-logo.svg"
+              width="140"
+              height="16"
+              alt="DMP Tool"
+            />
           </div>
+
+
+          <ExpandableContentSection
+            id="data-description"
+            heading={Global('dataDescription')}
+            expandLabel={Global('links.expand')}
+            summaryCharLimit={200}
+          >
+            <p>
+              Give a summary of the data you will collect or create, noting the content, coverage and data type, e.g., tabular data, survey data, experimental measurements, models, software, audiovisual data, physical samples, etc.
+            </p>
+            <p>
+              Consider how your data could complement and integrate with existing data, or whether there are any existing data or methods that you could reuse.
+            </p>
+            <p>
+              Indicate which data are of long-term value and should be shared and/or preserved.
+
+            </p>
+            <p>
+              If purchasing or reusing existing data, explain how issues such as copyright and IPR have been addressed. You should aim to minimize any restrictions on the reuse (and subsequent sharing) of third-party data.
+
+            </p>
+
+          </ExpandableContentSection>
+
+          <ExpandableContentSection
+            id="data-format"
+            heading={Global('dataFormat')}
+            expandLabel={Global('links.expand')}
+            summaryCharLimit={200}
+
+          >
+            <p>
+              Clearly note what format(s) your data will be in, e.g., plain text (.txt), comma-separated values (.csv), geo-referenced TIFF (.tif, .tfw).
+            </p>
+
+          </ExpandableContentSection>
+
+          <ExpandableContentSection
+            id="data-volume"
+            heading={Global('dataVolume')}
+            expandLabel={Global('links.expand')}
+            summaryCharLimit={200}
+          >
+            <p>
+              Note what volume of data you will create in MB/GB/TB. Indicate the proportions of raw data, processed data, and other secondary outputs (e.g., reports).
+            </p>
+            <p>
+              Consider the implications of data volumes in terms of storage, access, and preservation. Do you need to include additional costs?
+            </p>
+            <p>
+              Consider whether the scale of the data will pose challenges when sharing or transferring data between sites; if so, how will you address these challenges?
+            </p>
+          </ExpandableContentSection>
         </SidebarPanel>
 
         {/** Sample text drawer. Only include for question types = Text Area */}

--- a/app/[locale]/projects/[projectId]/funding-search/page.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/page.tsx
@@ -54,7 +54,7 @@ const CreateProjectSearchFunder = () => {
   useEffect(() => {
     // Manually calling the effect because the query specifies that some items
     // can be null, and we need to filter those potential null results out.
-    popularFundersQuery().then(({data}) => {
+    popularFundersQuery().then(({ data }) => {
       if (data?.popularFunders && data.popularFunders.length > 0) {
         const cleaned = data.popularFunders.filter((item) => item !== null)
         setPopularFunders(cleaned);
@@ -103,11 +103,11 @@ const CreateProjectSearchFunder = () => {
         } else {
           if (funder.apiTarget) {
             router.push(routePath('projects.create.projects.search', {
-              projectId: projectId,
+              projectId,
             }));
           } else {
             router.push(routePath('projects.project.info', {
-              projectId: projectId,
+              projectId,
             }));
           }
         }
@@ -116,7 +116,7 @@ const CreateProjectSearchFunder = () => {
         logECS(
           'error',
           'createProjectSearchFunder.addProjectFunding',
-          {error: err.message}
+          { error: err.message }
         );
         setErrors([...errors, err.message])
       });
@@ -184,7 +184,7 @@ const CreateProjectSearchFunder = () => {
             moreTrigger={moreCounter}
           />
 
-          {((popularFunders.length > 0) && !hasSearched)  && (
+          {((popularFunders.length > 0) && !hasSearched) && (
             <section aria-labelledby="popular-funders">
               <h3>{trans('popularTitle')}</h3>
               <div className={styles.popularFunders}>

--- a/components/ExpandableContentSection/index.tsx
+++ b/components/ExpandableContentSection/index.tsx
@@ -100,7 +100,7 @@ export default function ExpandableContentSection({
 
   return (
     <section className={styles.section}>
-      <h3 id={`${id}-heading`}>{heading}</h3>
+      <h3 id={`${id}-heading`} className="h5">{heading}</h3>
 
       {/**Don't show the summaryElements if the content is expanded */}
       <div className={styles.summaryContent} id={contentId}>

--- a/components/QuestionView/QuestionView.module.scss
+++ b/components/QuestionView/QuestionView.module.scss
@@ -17,3 +17,10 @@
 .numberRange {
   max-width: 400px;
 }
+
+/* Best Practices Sidebar Style */
+.headerWithLogo {
+  display: flex;
+  align-items: center; // vertically center the image and text
+  gap: 0.5rem;
+}

--- a/components/QuestionView/index.tsx
+++ b/components/QuestionView/index.tsx
@@ -497,8 +497,8 @@ const QuestionView: React.FC<QuestionViewProps> = ({
       </ContentContainer>
 
       <SidebarPanel>
-        <p>
-          {trans('bestPractice')}
+        <div className={styles.headerWithLogo}>
+          <h2 className="h4">{Global('bestPractice')}</h2>
           <Image
             className={styles.Logo}
             src="/images/DMP-logo.svg"
@@ -506,7 +506,7 @@ const QuestionView: React.FC<QuestionViewProps> = ({
             height="16"
             alt="DMP Tool"
           />
-        </p>
+        </div>
 
         <ExpandableContentSection
           id="data-description"

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -187,6 +187,10 @@
     "visibility": "Visibility",
     "notPublished": "Not published",
     "editTitle": "Edit title",
+    "bestPractice": "Best practice by",
+    "dataDescription": "Data description",
+    "dataFormat": "Data format",
+    "dataVolume": "Data volume",
     "buttons": {
       "search": "Search",
       "select": "Select",

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -187,6 +187,10 @@
     "visibility": "Visibilidade",
     "notPublished": "Não publicado",
     "editTitle": "Editar título",
+    "bestPractice": "Melhores práticas por",
+    "dataDescription": "Descrição dos dados",
+    "dataFormat": "Formato de dados",
+    "dataVolume": "Volume de dados",
     "buttons": {
       "search": "Buscar",
       "select": "Select",


### PR DESCRIPTION
## Description

Even though the Best Practices are just hard-coded right now, I wanted to add the new expanding/collapsing Best Practices that was added to the `Question Preview` to the `Question Details` page for consistency.

Fixes # ([638](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/638))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Tested manually and with unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshot
<img width="1033" height="944" alt="image" src="https://github.com/user-attachments/assets/dba3b0b7-7d71-4e12-8eea-c55be302f48b" />

