### PR TITLE
Ae 497 add funder manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Hooked up the Project Funding Search page at `/projects/[projectId]/fundings/search` [#606]
 - Added auto-save to the `Question Answer` page [#585]
 - Added the ability to edit the `Plan title` [#608]
+- Added the page for adding a funder manually [#497]
+- Updated the funding-search page on the create project step to link to the new page to add the funder manually [#497]
 
 ### Fixed
 - Updated `ProjectsProjectPlanAdjustFunding` component to use `checkboxes` instead of `radiobuttons` for funders [#631]

--- a/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/__tests__/page.spec.tsx
@@ -706,7 +706,8 @@ describe("CreateProjectSearchFunder", () => {
 
 
   it("Should allow adding a funder manually", async () => {
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => { });
+    const mockPush = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
 
     render(
       <MockedProvider mocks={mocks} addTypename={false}>
@@ -728,10 +729,9 @@ describe("CreateProjectSearchFunder", () => {
       fireEvent.click(addBtn);
     });
 
-    expect(logSpy).toHaveBeenCalledWith('TODO: Navigate to create funder page.');
-
-    // Cleanup
-    logSpy.mockRestore();
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(expect.stringMatching(/\/projects\/123\/fundings\/add/));
+    });
   });
 
   it('should pass accessibility tests', async () => {

--- a/app/[locale]/projects/[projectId]/funding-search/page.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/page.tsx
@@ -123,11 +123,10 @@ const CreateProjectSearchFunder = () => {
   };
 
   async function handleAddFunderManually() {
-    // TODO:: Handle manual addition of funders
-    // NOTE:: Reason we didn't implement this is because the template for the
-    // target // URL doesn't exist. There is a separate ticket tracking this.
-    // TODO:: Remember to update the test when this is finally updated
-    console.log('TODO: Navigate to create funder page.');
+    const projectId = params.projectId as string;
+    router.push(routePath('projects.fundings.add', {
+      projectId: projectId,
+    }));
   };
 
   function onResults(results: FunderSearchResults, isNew: boolean) {

--- a/app/[locale]/projects/[projectId]/funding-search/page.tsx
+++ b/app/[locale]/projects/[projectId]/funding-search/page.tsx
@@ -125,7 +125,7 @@ const CreateProjectSearchFunder = () => {
   async function handleAddFunderManually() {
     const projectId = params.projectId as string;
     router.push(routePath('projects.fundings.add', {
-      projectId: projectId,
+      projectId,
     }));
   };
 

--- a/app/[locale]/projects/[projectId]/fundings/add/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/add/__tests__/page.spec.tsx
@@ -37,7 +37,7 @@ const successMocks = [
           errors: {
             name: null,
           },
-          id: "222",
+          uri: "https://dmptool/123",
         }
       }
     },
@@ -50,7 +50,7 @@ const successMocks = [
       variables: {
         input: {
           projectId: 111,
-          affiliationId: "222",
+          affiliationId: "https://dmptool/123",
           funderOpportunityNumber: 'New-opportunity-123',
           funderProjectNumber: 'New-projectNumber-123',
           grantId: 'New-grantNumber-123',
@@ -97,7 +97,7 @@ const errorMocks = [
           errors: {
             name: "Error with affiliate name",
           },
-          id: null,
+          uri: null,
         }
       }
     },
@@ -120,7 +120,7 @@ const errorMocks = [
           errors: {
             name: null,
           },
-          id: "222",
+          uri: "https://dmptool/123",
         }
       }
     },
@@ -133,7 +133,7 @@ const errorMocks = [
       variables: {
         input: {
           projectId: 111,
-          affiliationId: "222",
+          affiliationId: "https://dmptool/123",
           funderOpportunityNumber: '',
           funderProjectNumber: '',
           grantId: '',

--- a/app/[locale]/projects/[projectId]/fundings/add/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/add/__tests__/page.spec.tsx
@@ -1,0 +1,365 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useParams, useRouter } from 'next/navigation';
+import { MockedProvider } from '@apollo/client/testing';
+import {
+  AddAffiliationDocument,
+  AddProjectFundingDocument,
+} from '@/generated/graphql';
+
+import logECS from '@/utils/clientLogger';
+
+import { mockScrollIntoView, mockScrollTo } from "@/__mocks__/common";
+
+import AddProjectFunderManually from '../page';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+
+expect.extend(toHaveNoViolations);
+
+
+const successMocks = [
+  // For creating the Affiliate
+  {
+    request: {
+      query: AddAffiliationDocument,
+      variables: {
+        input: {
+          funder: true,
+          name: "New-funderName-123",
+        },
+      },
+    },
+
+    result: {
+      data: {
+        addAffiliation: {
+          errors: {
+            name: null,
+          },
+          id: "222",
+        }
+      }
+    },
+  },
+
+  // Second part for creating the ProjectFunding connection
+  {
+    request: {
+      query: AddProjectFundingDocument,
+      variables: {
+        input: {
+          projectId: 111,
+          affiliationId: "222",
+          funderOpportunityNumber: 'New-opportunity-123',
+          funderProjectNumber: 'New-projectNumber-123',
+          grantId: 'New-grantNumber-123',
+          status: 'PLANNED',
+        }
+      },
+    },
+
+    result: {
+      data: {
+        addProjectFunding: {
+          id: "333",
+          errors: {
+            projectId: null,
+            affiliationId: null,
+            funderOpportunityNumber: null,
+            funderProjectNumber: null,
+            grantId: null,
+            general: null,
+            status: null,
+          },
+        },
+      },
+    },
+  },
+];
+
+const errorMocks = [
+  // For creating the Affiliate
+  {
+    request: {
+      query: AddAffiliationDocument,
+      variables: {
+        input: {
+          funder: true,
+          name: "Affiliate Field Error",
+        },
+      },
+    },
+
+    result: {
+      data: {
+        addAffiliation: {
+          errors: {
+            name: "Error with affiliate name",
+          },
+          id: null,
+        }
+      }
+    },
+  },
+
+  {
+    request: {
+      query: AddAffiliationDocument,
+      variables: {
+        input: {
+          funder: true,
+          name: "Valid Affiliate",
+        },
+      },
+    },
+
+    result: {
+      data: {
+        addAffiliation: {
+          errors: {
+            name: null,
+          },
+          id: "222",
+        }
+      }
+    },
+  },
+
+  // Second part for creating the ProjectFunding connection
+  {
+    request: {
+      query: AddProjectFundingDocument,
+      variables: {
+        input: {
+          projectId: 111,
+          affiliationId: "222",
+          funderOpportunityNumber: '',
+          funderProjectNumber: '',
+          grantId: '',
+          status: 'PLANNED',
+        }
+      },
+    },
+
+    result: {
+      data: {
+        addProjectFunding: {
+          id: "333",
+          errors: {
+            projectId: null,
+            affiliationId: null,
+            funderOpportunityNumber: "Opportunity number is required",
+            funderProjectNumber: "Project number is required",
+            grantId: "Grant id is required",
+            general: null,
+            status: null,
+          },
+        },
+      },
+    },
+  },
+
+  // Apollo Errors
+  {
+    request: {
+      query: AddAffiliationDocument,
+      variables: {
+        input: {
+          funder: true,
+          name: "Affiliate Exception",
+        },
+      },
+    },
+    error: new Error('Server Error')
+  }
+];
+
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  useRouter: jest.fn()
+}));
+
+
+describe('AddProjectFunderManually', () => {
+
+  beforeEach(() => {
+    const mockParams = useParams as jest.Mock;
+    mockParams.mockReturnValue({ projectId: '111' });
+
+    HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
+    mockScrollTo();
+  });
+
+  it('should render the project details form', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={successMocks} addTypename={false}>
+          <AddProjectFunderManually />
+        </MockedProvider>
+      );
+    });
+
+    expect(screen.getByLabelText('labels.funderName')).toBeInTheDocument();
+    expect(screen.getByLabelText('labels.funderName')).toBeInTheDocument();
+    expect(screen.getByText('labels.grantNumber')).toBeInTheDocument();
+    expect(screen.getByLabelText('labels.projectNumber')).toBeInTheDocument();
+    expect(screen.getByLabelText('labels.opportunity')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /buttons.saveChanges/i })).toBeInTheDocument();
+  });
+
+  it('should run correct mutations and redirect on submitting valid data', async () => {
+    const mockPush = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+
+    await act(async () => {
+      render(
+        <MockedProvider mocks={successMocks} addTypename={false}>
+          <AddProjectFunderManually />
+        </MockedProvider>
+      );
+    });
+
+    // Update data
+    fireEvent.change(
+      screen.getByLabelText('labels.funderName'),
+      {target: { value: 'New-funderName-123' }}
+    );
+
+    fireEvent.change(
+      screen.getByLabelText('labels.fundingStatus'),
+      { target: { value: 'PLANNED' } }
+    );
+
+    // To change the value in FormSelect, we need to "click" one of the options
+    // const optionGranted = screen.getByRole('option', { name: 'GRANTED' });
+    // await fireEvent.click(optionGranted);
+
+    fireEvent.change(
+      screen.getByLabelText('labels.grantNumber'),
+      { target: { value: 'New-grantNumber-123' } }
+    );
+
+    fireEvent.change(
+      screen.getByLabelText('labels.projectNumber'),
+      { target: { value: 'New-projectNumber-123' } }
+    );
+
+    fireEvent.change(
+      screen.getByLabelText('labels.opportunity'),
+      { target: { value: 'New-opportunity-123' } }
+    );
+
+    // Submit the form
+    fireEvent.submit(screen.getByRole('button', { name: /buttons.saveChanges/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(expect.stringMatching(/\/projects\/111\/fundings/));
+    });
+  });
+
+  it('should display errors for the affiliation name', async () => {
+    const mockPush = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+
+    await act(async () => {
+      render(
+        <MockedProvider mocks={errorMocks} addTypename={false}>
+          <AddProjectFunderManually />
+        </MockedProvider>
+      );
+    });
+
+    fireEvent.change(
+      screen.getByLabelText('labels.funderName'),
+      {target: { value: 'Affiliate Field Error' }}
+    );
+
+    // Submit the form
+    fireEvent.submit(screen.getByRole('button', { name: /buttons.saveChanges/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('messages.errors.projectFundingUpdateFailed')).toBeInTheDocument();
+      expect(screen.getByText('Error with affiliate name')).toBeInTheDocument();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should display errors for the projectfunding fields', async () => {
+    const mockPush = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+
+    await act(async () => {
+      render(
+        <MockedProvider mocks={errorMocks} addTypename={false}>
+          <AddProjectFunderManually />
+        </MockedProvider>
+      );
+    });
+
+    fireEvent.change(
+      screen.getByLabelText('labels.funderName'),
+      {target: { value: 'Valid Affiliate' }}
+    );
+
+    // Submit the form
+    fireEvent.submit(screen.getByRole('button', { name: /buttons.saveChanges/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('messages.errors.projectFundingUpdateFailed')).toBeInTheDocument();
+      expect(screen.getByText('Opportunity number is required')).toBeInTheDocument();
+      expect(screen.getByText('Project number is required')).toBeInTheDocument();
+      expect(screen.getByText('Grant id is required')).toBeInTheDocument();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should handle errors thrown by the graphql mutations promise chain', async() => {
+    const mockPush = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+
+    await act(async () => {
+      render(
+        <MockedProvider mocks={errorMocks} addTypename={false}>
+          <AddProjectFunderManually />
+        </MockedProvider>
+      );
+    });
+
+    fireEvent.change(
+      screen.getByLabelText('labels.funderName'),
+      {target: { value: 'Affiliate Exception' }}
+    );
+
+    // Submit the form
+    fireEvent.submit(screen.getByRole('button', { name: /buttons.saveChanges/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('messages.errors.projectFundingUpdateFailed')).toBeInTheDocument();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(logECS).toHaveBeenCalledWith(
+        'error',
+        'addProjectFunderManually',
+        expect.objectContaining({
+          err: expect.anything(),
+          url: { path: '/projects/[projectId]/fundings/add' },
+        })
+      );
+    });
+  });
+
+  it('should pass axe accessibility test', async () => {
+    const { container } = render(
+      <MockedProvider mocks={successMocks} addTypename={false}>
+        <AddProjectFunderManually />
+      </MockedProvider>
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/app/[locale]/projects/[projectId]/fundings/add/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/add/__tests__/page.spec.tsx
@@ -54,7 +54,7 @@ const successMocks = [
           funderOpportunityNumber: 'New-opportunity-123',
           funderProjectNumber: 'New-projectNumber-123',
           grantId: 'New-grantNumber-123',
-          status: 'PLANNED',
+          status: 'GRANTED',
         }
       },
     },
@@ -227,14 +227,13 @@ describe('AddProjectFunderManually', () => {
       {target: { value: 'New-funderName-123' }}
     );
 
-    fireEvent.change(
-      screen.getByLabelText('labels.fundingStatus'),
-      { target: { value: 'PLANNED' } }
-    );
+    // To change the value in FormSelect, we need to "click" to open the options
+    const statusSelect = screen.getByRole('button', { name: /fundingStatus/ });
+    await fireEvent.click(statusSelect);
 
-    // To change the value in FormSelect, we need to "click" one of the options
-    // const optionGranted = screen.getByRole('option', { name: 'GRANTED' });
-    // await fireEvent.click(optionGranted);
+    // Now we need to click on one of the options
+    const optionGranted = screen.getByRole('option', { name: /granted/i });
+    await fireEvent.click(optionGranted);
 
     fireEvent.change(
       screen.getByLabelText('labels.grantNumber'),

--- a/app/[locale]/projects/[projectId]/fundings/add/addFunderManually.module.scss
+++ b/app/[locale]/projects/[projectId]/fundings/add/addFunderManually.module.scss
@@ -1,0 +1,3 @@
+.fundingStatusSelect {
+  max-width: 600px;
+}

--- a/app/[locale]/projects/[projectId]/fundings/add/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/add/page.tsx
@@ -162,6 +162,8 @@ const AddProjectFunderManually = () => {
     }).then((result) => {
       if (result && result.data) {
         const data = result.data;
+        const affiliationId = data!.addAffiliation!.uri;
+
         const hasErrors = hasAffiliationErrors(data?.addAffiliation?.errors as AffiliationErrors);
         if (hasErrors) {
           setFieldErrors({
@@ -170,12 +172,11 @@ const AddProjectFunderManually = () => {
           });
           setErrors([editFunding('messages.errors.projectFundingUpdateFailed')]);
         } else {
-          const affiliationId = data!.addAffiliation!.id;
           return addProjectFunding({
             variables: {
               input: {
                 projectId,
-                affiliationId: String(affiliationId),
+                affiliationId,
                 funderOpportunityNumber: fundingData.funderOpportunityNumber,
                 funderProjectNumber: fundingData.funderProjectNumber,
                 grantId: fundingData.funderGrantId,

--- a/app/[locale]/projects/[projectId]/fundings/add/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/add/page.tsx
@@ -3,6 +3,7 @@
 import React, { useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useParams, useRouter } from 'next/navigation';
+import { routePath } from '@/utils/routes';
 import {
   Breadcrumb,
   Breadcrumbs,
@@ -202,7 +203,7 @@ const AddProjectFunderManually = () => {
           setErrors([addFunding('messages.errors.projectFundingUpdateFailed')]);
         } else {
           showSuccessToast();
-          router.push(`/projects/${projectId}/fundings`);
+          router.push(routePath('projects.fundings.index', {projectId}));
         }
       }
     }).catch((err) => {
@@ -223,9 +224,10 @@ const AddProjectFunderManually = () => {
         showBackButton={false}
         breadcrumbs={
           <Breadcrumbs>
-            <Breadcrumb><Link href="/">{global('breadcrumbs.home')}</Link></Breadcrumb>
-            <Breadcrumb><Link href="/projects">{global('breadcrumbs.projects')}</Link></Breadcrumb>
-            <Breadcrumb><Link href={`/projects/${projectId}/fundings`}>{global('breadcrumbs.projectFunding')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('app.home')}>{global('breadcrumbs.home')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.index', {projectId})}>{global('breadcrumbs.projects')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.show', {projectId})}>{global('breadcrumbs.projectOverview')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.fundings.index', {projectId})}>{global('breadcrumbs.projectFunding')}</Link></Breadcrumb>
             <Breadcrumb>{addFunding('title')}</Breadcrumb>
           </Breadcrumbs>
         }

--- a/app/[locale]/projects/[projectId]/fundings/add/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/add/page.tsx
@@ -49,7 +49,7 @@ interface ProjectFundingInterface {
 }
 
 const AddProjectFunderManually = () => {
-  const editFunding = useTranslations('ProjectsProjectFundingEdit');
+  const addFunding = useTranslations('ProjectsProjectFundingAdd');
   const global = useTranslations('Global');
 
   const toastState = useToast();
@@ -96,7 +96,7 @@ const AddProjectFunderManually = () => {
 
   // Show Success Message
   function showSuccessToast() {
-    const successMessage = editFunding('messages.success.projectFundingUpdated');
+    const successMessage = addFunding('messages.success.projectFundingUpdated');
     toastState.add(successMessage, { type: 'success' });
     scrollToTop(topRef);
   }
@@ -173,7 +173,7 @@ const AddProjectFunderManually = () => {
           ...fieldErrors,
           funderName: String(errs.name),
         });
-        setErrors([editFunding('messages.errors.projectFundingUpdateFailed')]);
+        setErrors([addFunding('messages.errors.projectFundingUpdateFailed')]);
       } else {
         return addProjectFunding({
           variables: {
@@ -199,7 +199,7 @@ const AddProjectFunderManually = () => {
             funderOpportunityNumber: String(errs.funderOpportunityNumber),
             funderProjectNumber: String(errs.funderProjectNumber),
           });
-          setErrors([editFunding('messages.errors.projectFundingUpdateFailed')]);
+          setErrors([addFunding('messages.errors.projectFundingUpdateFailed')]);
         } else {
           showSuccessToast();
           router.push(`/projects/${projectId}/fundings`);
@@ -210,7 +210,7 @@ const AddProjectFunderManually = () => {
         err,
         url: { path: '/projects/[projectId]/fundings/add' }
       });
-      setErrors(prevErrors => [...prevErrors, editFunding('messages.errors.projectFundingUpdateFailed')]);
+      setErrors(prevErrors => [...prevErrors, addFunding('messages.errors.projectFundingUpdateFailed')]);
     });
   };
 
@@ -218,15 +218,15 @@ const AddProjectFunderManually = () => {
     <>
       <div ref={topRef} />
       <PageHeader
-        title={editFunding('title')}
-        description={editFunding('description')}
+        title={addFunding('title')}
+        description={addFunding('description')}
         showBackButton={false}
         breadcrumbs={
           <Breadcrumbs>
             <Breadcrumb><Link href="/">{global('breadcrumbs.home')}</Link></Breadcrumb>
             <Breadcrumb><Link href="/projects">{global('breadcrumbs.projects')}</Link></Breadcrumb>
             <Breadcrumb><Link href={`/projects/${projectId}/fundings`}>{global('breadcrumbs.projectFunding')}</Link></Breadcrumb>
-            <Breadcrumb>{editFunding('title')}</Breadcrumb>
+            <Breadcrumb>{addFunding('title')}</Breadcrumb>
           </Breadcrumbs>
         }
         className="page-funding-edit"
@@ -239,15 +239,15 @@ const AddProjectFunderManually = () => {
               name="funderName"
               type="text"
               isRequired={true}
-              label={editFunding('labels.funderName')}
+              label={addFunding('labels.funderName')}
               value={fundingData.funderName}
               onChange={handleInputChange}
               isInvalid={(!fundingData.funderName || !!fieldErrors.funderName)}
-              errorMessage={fieldErrors.funderName.length > 0 ? fieldErrors.funderName : editFunding('messages.errors.fundingName')}
+              errorMessage={fieldErrors.funderName.length > 0 ? fieldErrors.funderName : addFunding('messages.errors.fundingName')}
             />
 
             <FormSelect
-              label={editFunding('labels.fundingStatus')}
+              label={addFunding('labels.fundingStatus')}
               isRequired
               name="fundingStatus"
               items={fundingStatuses}
@@ -266,33 +266,33 @@ const AddProjectFunderManually = () => {
               name="funderGrantId"
               type="text"
               isRequired={true}
-              label={editFunding('labels.grantNumber')}
+              label={addFunding('labels.grantNumber')}
               value={fundingData.funderGrantId}
               onChange={handleInputChange}
               isInvalid={(!fundingData.funderGrantId || !!fieldErrors.funderGrantId)}
-              errorMessage={fieldErrors.funderGrantId.length > 0 ? fieldErrors.funderGrantId : editFunding('messages.errors.fundingGrantId')}
+              errorMessage={fieldErrors.funderGrantId.length > 0 ? fieldErrors.funderGrantId : addFunding('messages.errors.fundingGrantId')}
             />
 
             <FormInput
               name="funderProjectNumber"
               type="text"
               isRequired={true}
-              label={editFunding('labels.projectNumber')}
+              label={addFunding('labels.projectNumber')}
               value={fundingData.funderProjectNumber}
               onChange={handleInputChange}
               isInvalid={(!fundingData.funderProjectNumber || !!fieldErrors.funderProjectNumber)}
-              errorMessage={fieldErrors.funderProjectNumber.length > 0 ? fieldErrors.funderProjectNumber : editFunding('messages.errors.fundingProjectNumber')}
+              errorMessage={fieldErrors.funderProjectNumber.length > 0 ? fieldErrors.funderProjectNumber : addFunding('messages.errors.fundingProjectNumber')}
             />
 
             <FormInput
               name="funderOpportunityNumber"
               type="text"
               isRequired={true}
-              label={editFunding('labels.opportunity')}
+              label={addFunding('labels.opportunity')}
               value={fundingData.funderOpportunityNumber}
               onChange={handleInputChange}
               isInvalid={(!fundingData.funderOpportunityNumber || !!fieldErrors.funderOpportunityNumber)}
-              errorMessage={fieldErrors.funderOpportunityNumber.length > 0 ? fieldErrors.funderOpportunityNumber : editFunding('messages.errors.fundingProjectNumber')}
+              errorMessage={fieldErrors.funderOpportunityNumber.length > 0 ? fieldErrors.funderOpportunityNumber : addFunding('messages.errors.fundingProjectNumber')}
             />
 
             <Button type="submit" className="submit-button">{global('buttons.saveChanges')}</Button>

--- a/app/[locale]/projects/[projectId]/fundings/add/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/add/page.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useParams, useRouter } from 'next/navigation';
+import {
+  Breadcrumb,
+  Breadcrumbs,
+  Button,
+  Form,
+  Link,
+  ListBoxItem,
+} from "react-aria-components";
+
+import {
+  ProjectFundingStatus,
+  AffiliationErrors,
+  ProjectFundingErrors,
+  useAddAffiliationMutation,
+  useAddProjectFundingMutation,
+} from '@/generated/graphql';
+
+// Components
+import PageHeader from "@/components/PageHeader";
+import { ContentContainer, LayoutContainer } from "@/components/Container";
+import { FormInput, FormSelect } from "@/components/Form";
+import ErrorMessages from '@/components/ErrorMessages';
+
+import { scrollToTop } from '@/utils/general';
+import logECS from '@/utils/clientLogger';
+import { useToast } from '@/context/ToastContext';
+
+import styles from './addFunderManually.module.scss';
+
+
+interface FieldErrorsInterface {
+  funderName: string;
+  funderGrantId: string;
+  funderOpportunityNumber: string;
+  funderProjectNumber: string;
+}
+
+interface ProjectFundingInterface {
+  funderName: string;
+  fundingStatus: ProjectFundingStatus;
+  funderGrantId: string;
+  funderOpportunityNumber: string;
+  funderProjectNumber: string;
+}
+
+const AddProjectFunderManually = () => {
+  const editFunding = useTranslations('ProjectsProjectFundingEdit');
+  const global = useTranslations('Global');
+
+  const toastState = useToast();
+  const topRef = useRef<HTMLDivElement | null>(null);
+  const errorRef = useRef<HTMLDivElement | null>(null);
+
+  const router = useRouter();
+  const params = useParams();
+  const projectId = Number(params.projectId);
+
+  if (isNaN(projectId)) {
+    // TODO:: Big Error, shouldn't happen what to do here?
+    // Redirect?
+    // 400?
+    // definitely log the error
+  }
+
+  const [addAffiliation] = useAddAffiliationMutation();
+  const [addProjectFunding] = useAddProjectFundingMutation();
+
+  const [fundingData, setFundingData] = useState<ProjectFundingInterface>({
+    funderName: '',
+    fundingStatus: ProjectFundingStatus.Planned,
+    funderGrantId: '',
+    funderOpportunityNumber: '',
+    funderProjectNumber: ''
+  });
+
+  const fundingStatuses = Object.values(ProjectFundingStatus).map(status => ({
+    id: status,
+    name: status.toLowerCase()
+  }));
+
+  const [errors, setErrors] = useState<string[]>([]);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrorsInterface>({
+    funderName: '',
+    funderGrantId: '',
+    funderOpportunityNumber: '',
+    funderProjectNumber: ''
+  });
+
+
+  function clearAllFieldErrors() {
+    setFieldErrors({
+      funderName: '',
+      funderGrantId: '',
+      funderOpportunityNumber: '',
+      funderProjectNumber: ''
+    });
+  }
+
+  // Show Success Message
+  function showSuccessToast() {
+    const successMessage = editFunding('messages.success.projectFundingUpdated');
+    toastState.add(successMessage, { type: 'success' });
+    scrollToTop(topRef);
+  }
+
+  /**
+   * Check if there are any errors from our two graphql queries.
+   * returns true if any error was detected.
+   */
+  function hasAffiliationErrors(errs: AffiliationErrors): boolean {
+    if (!errs) return false;
+
+    const keys: (keyof AffiliationErrors)[] = [
+      "name",
+    ];
+    return keys.some((k) => !!errs[k]);
+  }
+
+  function hasProjectFundingErrors(errs: ProjectFundingErrors): boolean {
+    if (!errs) return false;
+
+    // is ProjectFunding error
+    const keys: (keyof ProjectFundingErrors)[] = [
+      "projectId",
+      "affiliationId",
+      "funderOpportunityNumber",
+      "funderProjectNumber",
+      "grantId",
+      "general",
+      "status",
+    ];
+    return keys.some((k) => !!errs[k]);
+  }
+
+  // Handle any changes to form field values
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = e.target;
+    setFundingData({ ...fundingData, [name]: value });
+  }
+
+  function handleFormSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    // Clear previous error messages
+    clearAllFieldErrors();
+    setErrors([]);
+
+    // First we need to add the Affiliation
+    addAffiliation({
+      variables: {
+        input: {
+          funder: true,
+          name: fundingData.funderName,
+      
+        },
+      }
+    }).then((result) => {
+      if (result && result.data) {
+        const data = result.data;
+        const hasErrors = hasAffiliationErrors(data?.addAffiliation?.errors as AffiliationErrors);
+        if (hasErrors) {
+          setFieldErrors({
+            ...fieldErrors,
+            funderName: data?.addAffiliation?.errors?.name || '',
+          });
+          setErrors([editFunding('messages.errors.projectFundingUpdateFailed')]);
+        } else {
+          const affiliationId = data!.addAffiliation!.id;
+          return addProjectFunding({
+            variables: {
+              input: {
+                projectId,
+                affiliationId: String(affiliationId),
+                funderOpportunityNumber: fundingData.funderOpportunityNumber,
+                funderProjectNumber: fundingData.funderProjectNumber,
+                grantId: fundingData.funderGrantId,
+                status: fundingData.fundingStatus,
+              },
+            },
+          });
+        }
+      }
+    }).then((result) => {
+      if (result && result.data) {
+        const data = result.data;
+        const hasErrors = hasProjectFundingErrors(data?.addProjectFunding?.errors as ProjectFundingErrors);
+        if (hasErrors) {
+          const errs = data?.addProjectFunding?.errors;
+          setFieldErrors({
+            ...fieldErrors,
+            funderGrantId: errs?.grantId || '',
+            funderOpportunityNumber: errs?.funderOpportunityNumber || '',
+            funderProjectNumber: errs?.funderProjectNumber || '',
+          });
+          setErrors([editFunding('messages.errors.projectFundingUpdateFailed')]);
+        } else {
+          showSuccessToast();
+          router.push(`/projects/${projectId}/fundings`);
+        }
+      }
+    }).catch((err) => {
+      logECS('error', 'addProjectFunderManually', {
+        err,
+        url: { path: '/projects/[projectId]/fundings/add' }
+      });
+      setErrors(prevErrors => [...prevErrors, editFunding('messages.errors.projectFundingUpdateFailed')]);
+    });
+  };
+
+  return (
+    <>
+      <div ref={topRef} />
+      <PageHeader
+        title={editFunding('title')}
+        description={editFunding('description')}
+        showBackButton={false}
+        breadcrumbs={
+          <Breadcrumbs>
+            <Breadcrumb><Link href="/">{global('breadcrumbs.home')}</Link></Breadcrumb>
+            <Breadcrumb><Link href="/projects">{global('breadcrumbs.projects')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={`/projects/${projectId}/fundings`}>{global('breadcrumbs.projectFunding')}</Link></Breadcrumb>
+            <Breadcrumb>{editFunding('title')}</Breadcrumb>
+          </Breadcrumbs>
+        }
+        className="page-funding-edit"
+      />
+      <LayoutContainer>
+        <ContentContainer>
+          <ErrorMessages errors={errors} ref={errorRef} />
+          <Form onSubmit={handleFormSubmit}>
+            <FormInput
+              name="funderName"
+              type="text"
+              isRequired={true}
+              label={editFunding('labels.funderName')}
+              value={fundingData.funderName}
+              onChange={handleInputChange}
+              isInvalid={(!fundingData.funderName || !!fieldErrors.funderName)}
+              errorMessage={fieldErrors.funderName.length > 0 ? fieldErrors.funderName : editFunding('messages.errors.funderName')}
+            />
+
+            <FormSelect
+              label={editFunding('labels.fundingStatus')}
+              isRequired
+              name="fundingStatus"
+              items={fundingStatuses}
+              selectClasses={styles.fundingStatusSelect}
+              onChange={value => setFundingData({ ...fundingData, fundingStatus: value as ProjectFundingStatus})}
+              selectedKey={fundingData.fundingStatus}
+            >
+              {fundingStatuses && fundingStatuses.map((status) => {
+                return (
+                  <ListBoxItem key={status.id}>{status.name}</ListBoxItem>
+                )
+              })}
+            </FormSelect>
+
+            <FormInput
+              name="funderGrantId"
+              type="text"
+              isRequired={true}
+              label={editFunding('labels.grantNumber')}
+              value={fundingData.funderGrantId}
+              onChange={handleInputChange}
+              isInvalid={(!fundingData.funderGrantId || !!fieldErrors.funderGrantId)}
+              errorMessage={fieldErrors.funderGrantId.length > 0 ? fieldErrors.funderGrantId : editFunding('messages.errors.fundingGrantId')}
+            />
+
+            <FormInput
+              name="funderProjectNumber"
+              type="text"
+              isRequired={true}
+              label={editFunding('labels.projectNumber')}
+              value={fundingData.funderProjectNumber}
+              onChange={handleInputChange}
+              isInvalid={(!fundingData.funderProjectNumber || !!fieldErrors.funderProjectNumber)}
+              errorMessage={fieldErrors.funderProjectNumber.length > 0 ? fieldErrors.funderProjectNumber : editFunding('messages.errors.fundingProjectNumber')}
+            />
+
+            <FormInput
+              name="funderOpportunityNumber"
+              type="text"
+              isRequired={true}
+              label={editFunding('labels.opportunity')}
+              value={fundingData.funderOpportunityNumber}
+              onChange={handleInputChange}
+              isInvalid={(!fundingData.funderOpportunityNumber || !!fieldErrors.funderOpportunityNumber)}
+              errorMessage={fieldErrors.funderOpportunityNumber.length > 0 ? fieldErrors.funderOpportunityNumber : editFunding('messages.errors.fundingProjectNumber')}
+            />
+
+            <Button type="submit" className="submit-button">{global('buttons.saveChanges')}</Button>
+          </Form>
+        </ContentContainer>
+      </LayoutContainer>
+    </>
+  );
+};
+
+export default AddProjectFunderManually;

--- a/app/[locale]/projects/[projectId]/fundings/add/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/add/page.tsx
@@ -241,7 +241,7 @@ const AddProjectFunderManually = () => {
               value={fundingData.funderName}
               onChange={handleInputChange}
               isInvalid={(!fundingData.funderName || !!fieldErrors.funderName)}
-              errorMessage={fieldErrors.funderName.length > 0 ? fieldErrors.funderName : editFunding('messages.errors.funderName')}
+              errorMessage={fieldErrors.funderName.length > 0 ? fieldErrors.funderName : editFunding('messages.errors.fundingName')}
             />
 
             <FormSelect

--- a/app/[locale]/projects/[projectId]/fundings/add/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/add/page.tsx
@@ -265,34 +265,31 @@ const AddProjectFunderManually = () => {
             <FormInput
               name="funderGrantId"
               type="text"
-              isRequired={true}
               label={addFunding('labels.grantNumber')}
               value={fundingData.funderGrantId}
               onChange={handleInputChange}
-              isInvalid={(!fundingData.funderGrantId || !!fieldErrors.funderGrantId)}
-              errorMessage={fieldErrors.funderGrantId.length > 0 ? fieldErrors.funderGrantId : addFunding('messages.errors.fundingGrantId')}
+              isInvalid={!!fieldErrors.funderGrantId}
+              errorMessage={fieldErrors.funderGrantId}
             />
 
             <FormInput
               name="funderProjectNumber"
               type="text"
-              isRequired={true}
               label={addFunding('labels.projectNumber')}
               value={fundingData.funderProjectNumber}
               onChange={handleInputChange}
-              isInvalid={(!fundingData.funderProjectNumber || !!fieldErrors.funderProjectNumber)}
-              errorMessage={fieldErrors.funderProjectNumber.length > 0 ? fieldErrors.funderProjectNumber : addFunding('messages.errors.fundingProjectNumber')}
+              isInvalid={!!fieldErrors.funderProjectNumber}
+              errorMessage={fieldErrors.funderProjectNumber}
             />
 
             <FormInput
               name="funderOpportunityNumber"
               type="text"
-              isRequired={true}
               label={addFunding('labels.opportunity')}
               value={fundingData.funderOpportunityNumber}
               onChange={handleInputChange}
-              isInvalid={(!fundingData.funderOpportunityNumber || !!fieldErrors.funderOpportunityNumber)}
-              errorMessage={fieldErrors.funderOpportunityNumber.length > 0 ? fieldErrors.funderOpportunityNumber : addFunding('messages.errors.fundingProjectNumber')}
+              isInvalid={!!fieldErrors.funderOpportunityNumber}
+              errorMessage={fieldErrors.funderOpportunityNumber}
             />
 
             <Button type="submit" className="submit-button">{global('buttons.saveChanges')}</Button>

--- a/app/[locale]/projects/[projectId]/fundings/search/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/search/__tests__/page.spec.tsx
@@ -689,7 +689,8 @@ describe("ProjectsProjectFundingSearch", () => {
 
 
   it("Should allow adding a funder manually", async () => {
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => { });
+    const mockPush = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
 
     render(
       <MockedProvider mocks={mocks} addTypename={false}>
@@ -711,10 +712,9 @@ describe("ProjectsProjectFundingSearch", () => {
       fireEvent.click(addBtn);
     });
 
-    expect(logSpy).toHaveBeenCalledWith('TODO: Navigate to create funder page.');
-
-    // Cleanup
-    logSpy.mockRestore();
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(expect.stringMatching(/\/projects\/123\/fundings\/add/));
+    });
   });
 
   it('should pass accessibility tests', async () => {

--- a/app/[locale]/projects/[projectId]/fundings/search/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/search/page.tsx
@@ -135,11 +135,10 @@ const ProjectsProjectFundingSearch = () => {
   };
 
   async function handleAddFunderManually() {
-    // TODO:: Handle manual addition of funders
-    // NOTE:: Reason we didn't implement this is because the template for the
-    // target // URL doesn't exist. There is a separate ticket tracking this.
-    // TODO:: Remember to update the test when this is finally updated
-    console.log('TODO: Navigate to create funder page.');
+    const projectId = params.projectId as string;
+    router.push(routePath('projects.fundings.add', {
+      projectId,
+    }));
   };
 
   function onResults(results: FunderSearchResults, isNew: boolean) {

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -3779,6 +3779,13 @@ export type VersionedTemplateSearchResult = {
   visibility?: Maybe<TemplateVisibility>;
 };
 
+export type AddAffiliationMutationVariables = Exact<{
+  input: AffiliationInput;
+}>;
+
+
+export type AddAffiliationMutation = { __typename?: 'Mutation', addAffiliation?: { __typename?: 'Affiliation', id?: number | null, errors?: { __typename?: 'AffiliationErrors', name?: string | null } | null } | null };
+
 export type AddAnswerMutationVariables = Exact<{
   planId: Scalars['Int']['input'];
   versionedSectionId: Scalars['Int']['input'];
@@ -4267,6 +4274,42 @@ export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id?: number | null, givenName?: string | null, surName?: string | null, languageId: string, emails?: Array<{ __typename?: 'UserEmail', id?: number | null, email: string, isPrimary: boolean, isConfirmed: boolean } | null> | null, errors?: { __typename?: 'UserErrors', general?: string | null, email?: string | null, password?: string | null, role?: string | null } | null, affiliation?: { __typename?: 'Affiliation', id?: number | null, name: string, searchName: string, uri: string } | null } | null };
 
 
+export const AddAffiliationDocument = gql`
+    mutation AddAffiliation($input: AffiliationInput!) {
+  addAffiliation(input: $input) {
+    errors {
+      name
+    }
+    id
+  }
+}
+    `;
+export type AddAffiliationMutationFn = Apollo.MutationFunction<AddAffiliationMutation, AddAffiliationMutationVariables>;
+
+/**
+ * __useAddAffiliationMutation__
+ *
+ * To run a mutation, you first call `useAddAffiliationMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddAffiliationMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addAffiliationMutation, { data, loading, error }] = useAddAffiliationMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useAddAffiliationMutation(baseOptions?: Apollo.MutationHookOptions<AddAffiliationMutation, AddAffiliationMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddAffiliationMutation, AddAffiliationMutationVariables>(AddAffiliationDocument, options);
+      }
+export type AddAffiliationMutationHookResult = ReturnType<typeof useAddAffiliationMutation>;
+export type AddAffiliationMutationResult = Apollo.MutationResult<AddAffiliationMutation>;
+export type AddAffiliationMutationOptions = Apollo.BaseMutationOptions<AddAffiliationMutation, AddAffiliationMutationVariables>;
 export const AddAnswerDocument = gql`
     mutation AddAnswer($planId: Int!, $versionedSectionId: Int!, $versionedQuestionId: Int!, $json: String!) {
   addAnswer(

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -3784,7 +3784,7 @@ export type AddAffiliationMutationVariables = Exact<{
 }>;
 
 
-export type AddAffiliationMutation = { __typename?: 'Mutation', addAffiliation?: { __typename?: 'Affiliation', id?: number | null, errors?: { __typename?: 'AffiliationErrors', name?: string | null } | null } | null };
+export type AddAffiliationMutation = { __typename?: 'Mutation', addAffiliation?: { __typename?: 'Affiliation', uri: string, errors?: { __typename?: 'AffiliationErrors', name?: string | null } | null } | null };
 
 export type AddAnswerMutationVariables = Exact<{
   planId: Scalars['Int']['input'];
@@ -4280,7 +4280,7 @@ export const AddAffiliationDocument = gql`
     errors {
       name
     }
-    id
+    uri
   }
 }
     `;

--- a/graphql/mutations/affiliations.mutation.graphql
+++ b/graphql/mutations/affiliations.mutation.graphql
@@ -3,6 +3,6 @@ mutation AddAffiliation($input: AffiliationInput!) {
     errors {
       name
     }
-    id
+    uri
   }
 }

--- a/graphql/mutations/affiliations.mutation.graphql
+++ b/graphql/mutations/affiliations.mutation.graphql
@@ -1,0 +1,8 @@
+mutation AddAffiliation($input: AffiliationInput!) {
+  addAffiliation(input: $input) {
+    errors {
+      name
+    }
+    id
+  }
+}

--- a/messages/en-US/planBuilderProjectOverview.json
+++ b/messages/en-US/planBuilderProjectOverview.json
@@ -156,6 +156,28 @@
       }
     }
   },
+  "ProjectsProjectFundingAdd": {
+    "title": "Add Funding Details",
+    "description": "Manually add a new fundting source",
+    "labels": {
+      "funderName": "Funder name",
+      "fundingStatus": "Funding Status",
+      "grantNumber": "Grant number/url",
+      "projectNumber": "Project number or ID",
+      "opportunity": "Opportunity/Federal Award Number"
+    },
+    "messages": {
+      "errors": {
+        "projectFundingUpdateFailed": "Error updating project funding details",
+        "fundingGrantId": "Invalid funder grant ID value",
+        "fundingProjectNumber": "Invalid funder project number value",
+        "fundingName": "Invalid funder name value"
+      },
+      "success": {
+        "projectFundingUpdated": "Successfully updated project funding details"
+      }
+    }
+  },
   "ProjectsProjectMembers": {
     "title": "Project Members",
     "description": "Define contributors and team members and their role in this project.",

--- a/utils/routes.ts
+++ b/utils/routes.ts
@@ -58,6 +58,7 @@ const routes = {
   'projects.fundings.index': '/projects/:projectId/fundings',
   'projects.fundings.show': '/projects/:projectId/fundings/:projectFundingId',
   'projects.fundings.search': '/projects/:projectId/fundings/search',
+  'projects.fundings.add': '/projects/:projectId/fundings/add',
   'projects.fundings.edit': '/projects/:projectId/fundings/:projectFundingId/edit',
   'projects.members.index': '/projects/:projectId/members',
   'projects.members.edit': '/projects/:projectId/members/:memberId/edit',


### PR DESCRIPTION
## Description

- Added the missing page for adding a funder manually.
- Added new routes for this page.
- Added new graphql mutations related to this page.

Fixes #497

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Added unit tests to test that we get the expected behaviour.
- Manual testing by running through the create-project workflow, and choosing "Add Funder Manually" button during the search for funder step. Entered the details and checked that the funder is created and we are redirected to the project funding page.

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
