### PR TITLE
[Bug fix] - Fixed inconsistent naming for question type Affiliation Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added the ability to edit the `Plan title` [#608]
 
 ### Fixed
+- Fixed inconsistent naming of question type `Affiliation Search` [#645]
 - Fixed bugs related to the `Project Funding` page [#643,650]
   - Updated `Project Funding` page to use correct `projectFundingId` when clicking `edit` and changed the `fetchPolicy` to make sure it always grabs latest list of `funding` when the user arrives at the page
   - Added `commas` in between `funder` names on the `Project Overview` page

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -287,7 +287,7 @@
       "dateRange": "Date range",
       "filteredSearch": "Filtered search",
       "table": "Table",
-      "typeaheadSearch": "Typeahead search"
+      "typeaheadSearch": "Affiliation search"
     }
   }
 }


### PR DESCRIPTION
## Description

- Updated the translation used for `typeaheadSearch` to `Affiliation search`

Fixes # ([645](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/645))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manual test

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
