### PR TITLE
[Bug fix] - Fixed issue with text turning white when hovering over Back button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added the ability to edit the `Plan title` [#608]
 
 ### Fixed
+- Fixed bug when hovering over the `Back` button turns text white (essentially invisible) [#651]
 - Fixed bugs related to the `Project Funding` page [#643,650]
   - Updated `Project Funding` page to use correct `projectFundingId` when clicking `edit` and changed the `fetchPolicy` to make sure it always grabs latest list of `funding` when the user arrives at the page
   - Added `commas` in between `funder` names on the `Project Overview` page

--- a/app/[locale]/__tests__/layout.spec.tsx
+++ b/app/[locale]/__tests__/layout.spec.tsx
@@ -78,8 +78,22 @@ describe('LocaleLayout', () => {
       params: Promise.resolve({ locale: routing.locales[0] }), // Wrap params in a Promise
     });
 
-    // Wrap with empty fragment to match expected DOM structure
-    render(<>{TestComponent}</>);
+    const htmlChildren = TestComponent?.props?.children;
+
+    // Extract children to test, since <html>, <head> and <body> tags are invalid to render inside React Testing Library's test
+    //const bodyContent = (TestComponent as any).props.children.props.children;
+    const bodyNode = Array.isArray(htmlChildren)
+      /* eslint-disable @typescript-eslint/no-explicit-any*/
+      ? htmlChildren.find((el: any) => el?.type === 'body')
+      : null;
+
+    if (!bodyNode) {
+      throw new Error('<body> not found in LocaleLayout output');
+    }
+
+    const bodyContent = bodyNode.props?.children;
+
+    render(<>{bodyContent}</>);
 
     expect(screen.getByText('Mock Header')).toBeInTheDocument();
     expect(screen.getByText('Main Content')).toBeInTheDocument();

--- a/styles/_page.scss
+++ b/styles/_page.scss
@@ -186,7 +186,7 @@ footer {
 
 .back-link-button:hover,
 .back-link-button:focus {
-  color: var(--slate-900);
+  color: var(--slate-900) !important;
   text-decoration: underline;
   background: transparent !important;
 }


### PR DESCRIPTION
## Description

Fixed issue with the `Back` button link turning white when a user hovers over it. This is because a base style of buttons sets the color white. I just made sure that for the `Back` button link, that it keeps the default gray color.

I created another ticket, #657 , to think about what we expect the `Back` button to do, and how often we want to use it, since we also have `breadcrumb` links.

Fixes # ([651](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/651))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
