### PR TITLE
Updated Plan Create page to use new pagination queries and added Pagination component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Updated
 - Updated the `Plan Create` page to switch off of manual `Load more` to new `pagination` queries [#686]
+- Updated unit test for `Plan Create` to use new `MockProvider` [#686]
 - Updated all plan pages to use the proper section and question ids. They were using `Section.id` and `Question.id` but should be using `VersionedSection.id` and `VersionedQuestion.id` since the plan is based on a published template and so should be referencing the components of the published version
 - Renamed existing `__mocks__` to be clear that they represent non-versioned questions (for use with the template pages)
 - Update `@dmptool/types` version [#322](https://github.com/CDLUC3/dmsp_backend_prototype/issues/322)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 ### Added
+- Added `Pagination` component to be used on different pages with a large number of search results [#686]
 - Added JSON mocks to `__mocks__` for all types of versioned questions (for use with the project/plan pages)
 - Hooked up the Project Funding Search page at `/projects/[projectId]/fundings/search` [#606]
 - Added auto-save to the `Question Answer` page [#585]
@@ -8,6 +9,7 @@
 - Added missing `planId` from the `PlanFundings` errors [#322](https://github.com/CDLUC3/dmsp_backend_prototype/issues/322)
 
 ### Updated
+- Updated the `Plan Create` page to switch off of manual `Load more` to new `pagination` queries [#686]
 - Updated all plan pages to use the proper section and question ids. They were using `Section.id` and `Question.id` but should be using `VersionedSection.id` and `VersionedQuestion.id` since the plan is based on a published template and so should be referencing the components of the published version
 - Renamed existing `__mocks__` to be clear that they represent non-versioned questions (for use with the template pages)
 - Update `@dmptool/types` version [#322](https://github.com/CDLUC3/dmsp_backend_prototype/issues/322)

--- a/app/[locale]/projects/[projectId]/dmp/create/PlanCreate.md
+++ b/app/[locale]/projects/[projectId]/dmp/create/PlanCreate.md
@@ -1,0 +1,54 @@
+# Plan Create Page
+
+## Overview
+
+The Plan Create page loads the published templates associated with the given `project id`. The templates can be filtered on specific`funder templates` and on `best practice` templates, and users can search the template list. Pagination is available for long lists.
+
+---
+
+## Business Requirements
+
+### Template Filtering Logic
+
+#### Scenario 1: Project with Funders
+- **Condition**: Project has associated funders AND published templates exist that match those funders
+- **Behavior**: 
+  - Funder checkboxes are initially checked
+  - Template list is filtered to show only templates matching project funders
+  - Other filtering options remain available
+
+#### Scenario 2: No Funders, Best Practice Available
+- **Condition**: Project has no funders AND template list contains best practice templates
+- **Behavior**:
+  - "Best Practice" checkbox is displayed and initially checked
+  - Template list is filtered to show only best practice templates
+  - Funder checkboxes are not displayed
+
+#### Scenario 3: No Funders, No Best Practice
+- **Condition**: Project has no funders AND no best practice templates available
+- **Behavior**:
+  - No checkboxes are displayed initially
+  - All available templates are shown
+  - Users can still apply filters manually if desired
+
+---
+
+## User Interface Components
+
+### Filter Controls
+- **Funder Checkboxes**: Dynamic based on project funders and available templates
+- **Best Practice Checkbox**: Shown when best practice templates are available
+- **Search Bar**: Text-based filtering of templates
+- **Clear Filters Button**: Reset all applied filters
+
+### Template List
+- **Template Cards**: Display template name, description, owner, and metadata
+- **Template Actions**: Select template button, preview options
+- **Loading States**: Skeleton loading while fetching data
+- **Empty States**: Messaging when no templates match filters
+
+### Pagination Controls
+- **Navigation**: Previous/Next buttons for sequential browsing
+- **Direct Access**: Clickable page numbers for jumping to specific pages
+- **Ellipsis**: Prevents overcrowding when many pages exist
+- **Page Info**: Shows current page and total results

--- a/app/[locale]/projects/[projectId]/dmp/create/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/create/__tests__/page.spec.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within, cleanup } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import PlanCreate from '../page';
 import { useParams, useRouter } from 'next/navigation';
-import { print } from 'graphql';
+import { useTranslations, useFormatter } from 'next-intl';
 import { useToast } from '@/context/ToastContext';
 import logECS from '@/utils/clientLogger';
-
-
-
 import {
   ProjectFundingsDocument,
   PublishedTemplatesDocument,
@@ -56,7 +53,7 @@ const mocks = [
           selectOwnerURIs: [],
           bestPractice: false
         },
-        "term": ""
+        term: ""
       },
     },
     result: {
@@ -69,6 +66,7 @@ const mocks = [
           hasBestPracticeTemplates: false,
         },
       },
+      loading: false
     },
   },
   // PublishedTemplatesMetaData query
@@ -84,7 +82,7 @@ const mocks = [
           selectOwnerURIs: [],
           bestPractice: false
         },
-        "term": ""
+        term: ""
       },
     },
     result: {
@@ -97,6 +95,7 @@ const mocks = [
           hasBestPracticeTemplates: false,
         },
       },
+      loading: false
     },
   },
   {
@@ -111,15 +110,15 @@ const mocks = [
           selectOwnerURIs: [],
           bestPractice: false
         },
-        "term": ""
+        term: ""
       },
     },
     result: {
       data: {
         publishedTemplates: {
-          limit: 10,
+          limit: 5,
           nextCursor: null,
-          totalCount: 4,
+          totalCount: 10,
           availableSortFields: ['vt.bestPractice'],
           currentOffset: 1,
           hasNextPage: true,
@@ -224,6 +223,56 @@ const mocks = [
           ]
         },
       },
+      loading: false
+    },
+  },
+  // Unchecking funders updates to offset of 5
+  {
+    request: {
+      query: PublishedTemplatesDocument,
+      variables: {
+        paginationOptions: {
+          offset: 5,
+          limit: 5,
+          type: "OFFSET",
+          sortDir: "DESC",
+          selectOwnerURIs: [],
+          bestPractice: false
+        },
+        term: ""
+      },
+    },
+    result: {
+      data: {
+        publishedTemplates: {
+          limit: 5,
+          nextCursor: null,
+          totalCount: 10,
+          availableSortFields: ['vt.bestPractice'],
+          currentOffset: 1,
+          hasNextPage: true,
+          hasPreviousPage: true,
+          items: [
+            {
+              bestPractice: false,
+              description: "Page 2",
+              id: "14",
+              name: "Page 2",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Science Foundation (nsf.gov)",
+              ownerURI: "http://nsf.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: "John Doe",
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 4,
+              ownerSearchName: "National Science Foundation | nsf.gov | NSF"
+            },
+          ]
+        },
+      },
+      loading: false
     },
   },
   {
@@ -238,15 +287,15 @@ const mocks = [
           selectOwnerURIs: ["http://nsf.gov", "http://nih.gov"],
           bestPractice: false
         },
-        "term": ""
+        term: ""
       },
     },
     result: {
       data: {
         publishedTemplates: {
-          limit: 10,
+          limit: 5,
           nextCursor: null,
-          totalCount: 4,
+          totalCount: 10,
           availableSortFields: ['vt.bestPractice'],
           currentOffset: 1,
           hasNextPage: true,
@@ -351,6 +400,264 @@ const mocks = [
           ]
         },
       },
+      loading: false
+    },
+  },
+  {
+    request: {
+      query: PublishedTemplatesDocument,
+      variables: {
+        paginationOptions: {
+          offset: 0,
+          limit: 5,
+          type: "OFFSET",
+          sortDir: "DESC",
+          selectOwnerURIs: ["http://nsf.gov"],
+          bestPractice: false
+        },
+        term: ""
+      },
+    },
+    result: {
+      data: {
+        publishedTemplates: {
+          limit: 5,
+          nextCursor: null,
+          totalCount: 10,
+          availableSortFields: ['vt.bestPractice'],
+          currentOffset: 1,
+          hasNextPage: true,
+          hasPreviousPage: true,
+          items: [
+            {
+              bestPractice: false,
+              description: "Template 1",
+              id: "1",
+              name: "Agency for Healthcare Research and Quality",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Science Foundation (nsf.gov)",
+              ownerURI: "http://nsf.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: "John Doe",
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 4,
+              ownerSearchName: "National Science Foundation | nsf.gov | NSF"
+            },
+            {
+              bestPractice: false,
+              description: "Arctic Data Center",
+              id: "20",
+              name: "Arctic Data Center: NSF Polar Programs",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Science Foundation (nsf.gov)",
+              ownerURI: "http://nsf.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 5,
+              ownerSearchName: "National Science Foundation | nsf.gov | NSF"
+            },
+            {
+              bestPractice: false,
+              description: "Develop data plans",
+              id: "10",
+              name: "Data Curation Centre",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Institute of Health",
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v2",
+              templateId: 3,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+            {
+              bestPractice: false,
+              description: "Develop data plans",
+              id: "40",
+              name: "Practice Template",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Institute of Health",
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v3",
+              templateId: 2,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+            {
+              bestPractice: false,
+              description: "Develop data plans",
+              id: "50",
+              name: "Detailed DMP Template",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Institute of Health",
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 1,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+            {
+              bestPractice: true,
+              description: "Best Practice Template",
+              id: "12",
+              name: "Best Practice Template",
+              visibility: "PUBLIC",
+              ownerDisplayName: null,
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v6",
+              templateId: 7,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+          ]
+        },
+      },
+      loading: false
+    },
+  },
+  {
+    request: {
+      query: PublishedTemplatesDocument,
+      variables: {
+        paginationOptions: {
+          offset: 5,
+          limit: 5,
+          type: "OFFSET",
+          sortDir: "DESC",
+          selectOwnerURIs: ["http://nsf.gov"],
+          bestPractice: false
+        },
+        term: ""
+      },
+    },
+    result: {
+      data: {
+        publishedTemplates: {
+          limit: 5,
+          nextCursor: null,
+          totalCount: 10,
+          availableSortFields: ['vt.bestPractice'],
+          currentOffset: 1,
+          hasNextPage: true,
+          hasPreviousPage: true,
+          items: [
+            {
+              bestPractice: false,
+              description: "Template 2",
+              id: "1",
+              name: "Template 2",
+              visibility: "PUBLIC",
+              ownerDisplayName: "Template 2",
+              ownerURI: "http://template.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: "Jane Smith",
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 4,
+              ownerSearchName: "Template 2"
+            },
+          ]
+        },
+      },
+      loading: false
+    },
+  },
+  // For search for NSF
+  {
+    request: {
+      query: PublishedTemplatesDocument,
+      variables: {
+        paginationOptions: {
+          offset: 0,
+          limit: 5,
+          type: "OFFSET",
+          sortDir: "DESC",
+          selectOwnerURIs: [],
+          bestPractice: false
+        },
+        term: "NSF"
+      },
+    },
+    result: {
+      data: {
+        publishedTemplates: {
+          limit: 5,
+          nextCursor: null,
+          totalCount: 10,
+          availableSortFields: ['vt.bestPractice'],
+          currentOffset: 1,
+          hasNextPage: true,
+          hasPreviousPage: true,
+          items: [
+            {
+              bestPractice: false,
+              description: "NSF SEARCH",
+              id: "1",
+              name: "NSF Search",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Science Foundation (nsf.gov)",
+              ownerURI: "http://nsf.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: "John Doe",
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 4,
+              ownerSearchName: "National Science Foundation | nsf.gov | NSF"
+            },
+          ]
+        },
+      },
+      loading: false
+    },
+  },
+  // For search for test
+  {
+    request: {
+      query: PublishedTemplatesDocument,
+      variables: {
+        paginationOptions: {
+          offset: 0,
+          limit: 5,
+          type: "OFFSET",
+          sortDir: "DESC",
+          selectOwnerURIs: [],
+          bestPractice: false
+        },
+        term: "test"
+      },
+    },
+    result: {
+      data: {
+        publishedTemplates: {
+          limit: 5,
+          nextCursor: null,
+          totalCount: 10,
+          availableSortFields: ['vt.bestPractice'],
+          currentOffset: 1,
+          hasNextPage: true,
+          hasPreviousPage: true,
+          items: []
+        },
+      },
+      loading: false
     },
   },
   // Initial ProjectFundings query
@@ -399,6 +706,7 @@ const mocks = [
           }
         ]
       },
+      loading: false
     },
   },
   // AddPlan mutation
@@ -414,17 +722,27 @@ const mocks = [
       data: {
         addPlan: {
           id: 7,
-          "__typename": "Plan"
+          __typename: "Plan"
         }
       },
     },
   },
 ]
 
-describe('PlanCreate Component', () => {
+describe('PlanCreate Component using base mock', () => {
   const mockUseParams = useParams as jest.Mock;
+  const mockUseTranslations = useTranslations as jest.Mock;
+  const mockUseFormatter = useFormatter as jest.Mock;
+
 
   beforeEach(() => {
+    mockUseTranslations.mockImplementation(() => {
+      return jest.fn((key) => key);
+    });
+
+    mockUseFormatter.mockImplementation(() => ({
+      dateTime: jest.fn(() => '01-01-2023'),
+    }));
     HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
     mockScrollTo();
     mockUseParams.mockReturnValue({ projectId: '1' });
@@ -438,8 +756,10 @@ describe('PlanCreate Component', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks()
-  });
+    jest.clearAllMocks();
+    cleanup();
+  })
+
 
   it('should render PlanCreate component with funder checkbox', async () => {
     await act(async () => {
@@ -511,6 +831,177 @@ describe('PlanCreate Component', () => {
     })
   });
 
+  it('should handle no items found in search', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <PlanCreate />
+        </MockedProvider>
+      );
+    });
+
+    await waitFor(() => {
+      const searchInput = screen.getByLabelText('Template search');
+      // Enter search term
+      fireEvent.change(searchInput, { target: { value: 'test' } });
+      // Click search button
+      const searchButton = screen.getByText('buttons.search');
+      fireEvent.click(searchButton);
+
+      expect(searchInput).toHaveValue('test');
+    });
+    // There should be two matches to the search for 'test'
+    await waitFor(() => {
+      const heading3 = screen.queryAllByRole('heading', { level: 3 });
+      expect(heading3).toHaveLength(0);
+      expect(screen.getByText('messaging.noItemsFound')).toBeInTheDocument();
+    })
+  });
+
+  it('should handle page navigation', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <PlanCreate />
+        </MockedProvider>
+      );
+    });
+
+    await waitFor(() => {
+      // We should have two checkboxes for project funders checked
+      const nihCheckbox = screen.getByRole('checkbox', { name: /National Institute of Health/i });
+      expect(nihCheckbox).toBeInTheDocument();
+
+      fireEvent.click(nihCheckbox);
+    })
+
+    await act(async () => {
+      const nsfCheckbox = screen.getByRole('checkbox', { name: /National Science Foundation \(nsf.gov\)/i });
+      expect(nsfCheckbox).toBeInTheDocument();
+      fireEvent.click(nsfCheckbox);
+    })
+
+    const nextBtn = screen.getAllByRole('button', { name: "labels.nextPage" });
+    fireEvent.click(nextBtn[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Page 2" })).toBeInTheDocument();
+    })
+  })
+
+  it('should return matching templates on search item', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <PlanCreate />
+        </MockedProvider>
+      );
+    });
+
+    await waitFor(() => {
+      const searchInput = screen.getByLabelText('Template search');
+      // Enter matching search term
+      fireEvent.change(searchInput, { target: { value: 'NSF' } });
+
+      // Click search button
+      const searchButton = screen.getByText('buttons.search');
+      fireEvent.click(searchButton);
+    })
+
+    await waitFor(() => {
+      // Should bring up this matching template
+      expect(screen.getByRole('heading', { level: 3, name: /NSF Search/i })).toBeInTheDocument();
+    });
+
+    //Empty out the search text
+    const searchInput = screen.getByLabelText('Template search');
+    fireEvent.change(searchInput, { target: { value: '' } });
+
+    await waitFor(() => {
+      // Should expect to see a template from initial load
+      screen.getByRole('heading', { level: 3, name: /Arctic Data Center: NSF Polar Programs/i })
+    })
+  });
+
+  it('should rest templates if user clicks on \'clear filter\' link', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <PlanCreate />
+        </MockedProvider>
+      );
+    });
+
+    await waitFor(() => {
+      const searchInput = screen.getByLabelText('Template search');
+      // Enter matching search term
+      fireEvent.change(searchInput, { target: { value: 'NSF' } });
+
+      // Click search button
+      const searchButton = screen.getByText('buttons.search');
+      fireEvent.click(searchButton);
+    })
+
+    await waitFor(() => {
+      // Should bring up this matching template
+      expect(screen.getByRole('heading', { level: 3, name: /NSF Search/i })).toBeInTheDocument();
+    });
+
+    //Click clear filter button
+    const clearFilterBtn = screen.getByTestId('clear-filter');
+    fireEvent.click(clearFilterBtn);
+
+    await waitFor(() => {
+      // Should expect to see a template from initial load
+      screen.getByRole('heading', { level: 3, name: /Arctic Data Center: NSF Polar Programs/i })
+    })
+  });
+
+  it('should pass axe accessibility test', async () => {
+    const { container } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <PlanCreate />
+      </MockedProvider>
+    );
+
+    await act(async () => {
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  })
+});
+
+
+describe('Testing scenarios that don\'t use the base mock', () => {
+  const mockUseParams = useParams as jest.Mock;
+  const mockUseTranslations = useTranslations as jest.Mock;
+  const mockUseFormatter = useFormatter as jest.Mock;
+
+
+  beforeEach(() => {
+    mockUseTranslations.mockImplementation(() => {
+      return jest.fn((key) => key);
+    });
+
+    mockUseFormatter.mockImplementation(() => ({
+      dateTime: jest.fn(() => '01-01-2023'),
+    }));
+    HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
+    mockScrollTo();
+    mockUseParams.mockReturnValue({ projectId: '1' });
+    // mock router
+    mockRouter = { push: jest.fn() };
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+
+    // Mock Toast
+    (useToast as jest.Mock).mockReturnValue(mockToast);
+
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+  })
 
   it('should not show any checkboxes if no project funders and no best practice', async () => {
     const mocksWithNoProjectFunders = [
@@ -527,7 +1018,7 @@ describe('PlanCreate Component', () => {
               selectOwnerURIs: [],
               bestPractice: false
             },
-            "term": ""
+            term: ""
           },
         },
         result: {
@@ -554,13 +1045,13 @@ describe('PlanCreate Component', () => {
               selectOwnerURIs: [],
               bestPractice: false
             },
-            "term": ""
+            term: ""
           },
         },
         result: {
           data: {
             publishedTemplates: {
-              limit: 10,
+              limit: 5,
               nextCursor: null,
               totalCount: 4,
               availableSortFields: ['vt.bestPractice'],
@@ -666,7 +1157,7 @@ describe('PlanCreate Component', () => {
           data: {
             addPlan: {
               id: 7,
-              "__typename": "Plan"
+              __typename: "Plan"
             }
           },
         },
@@ -702,7 +1193,7 @@ describe('PlanCreate Component', () => {
               selectOwnerURIs: [],
               bestPractice: false
             },
-            "term": ""
+            term: ""
           },
         },
         result: {
@@ -729,13 +1220,13 @@ describe('PlanCreate Component', () => {
               selectOwnerURIs: [],
               bestPractice: false
             },
-            "term": ""
+            term: ""
           },
         },
         result: {
           data: {
             publishedTemplates: {
-              limit: 10,
+              limit: 5,
               nextCursor: null,
               totalCount: 4,
               availableSortFields: ['vt.bestPractice'],
@@ -793,13 +1284,13 @@ describe('PlanCreate Component', () => {
               selectOwnerURIs: [],
               bestPractice: true
             },
-            "term": ""
+            term: ""
           },
         },
         result: {
           data: {
             publishedTemplates: {
-              limit: 10,
+              limit: 5,
               nextCursor: null,
               totalCount: 4,
               availableSortFields: ['vt.bestPractice'],
@@ -871,7 +1362,7 @@ describe('PlanCreate Component', () => {
           data: {
             addPlan: {
               id: 7,
-              "__typename": "Plan"
+              __typename: "Plan"
             }
           },
         },
@@ -896,97 +1387,40 @@ describe('PlanCreate Component', () => {
       expect(listItems).toHaveLength(2);
       expect(screen.getByRole('heading', { level: 3, name: "Data Curation Centre" })).toBeInTheDocument();
       expect(screen.getByRole('heading', { level: 3, name: "Best Practice Template" })).toBeInTheDocument();
-
     })
   });
+})
+
+describe('Query errors', () => {
+  const mockUseParams = useParams as jest.Mock;
+  const mockUseTranslations = useTranslations as jest.Mock;
+  const mockUseFormatter = useFormatter as jest.Mock;
 
 
-  it('should display loading state', async () => {
-    const mocksLoading = [
-      // PublishedTemplatesMetaData query
-      {
-        request: {
-          query: PublishedTemplatesMetaDataDocument,
-          variables: {
-            paginationOptions: {
-              offset: 0,
-              limit: 5,
-              type: "OFFSET",
-              sortDir: "DESC",
-              selectOwnerURIs: [],
-              bestPractice: false
-            },
-            "term": ""
-          },
-        },
-        result: {
-          data: null,
-          loading: true,
-          error: null
-        },
-      },
-      {
-        request: {
-          query: PublishedTemplatesDocument,
-          variables: {
-            paginationOptions: {
-              offset: 0,
-              limit: 5,
-              type: "OFFSET",
-              sortDir: "DESC",
-              selectOwnerURIs: [],
-              bestPractice: false
-            },
-            "term": ""
-          },
-        },
-        result: {
-          data: null,
-          loading: true,
-          error: null
-        },
-      },
-      {
-        request: {
-          query: ProjectFundingsDocument,
-          variables: {
-            projectId: 1
-          },
-        },
-        result: {
-          data: {
-            projectFundings: []
-          },
-        },
-      },
-      // AddPlan mutation
-      {
-        request: {
-          query: AddPlanDocument,
-          variables: {
-            projectId: 1,
-            versionedTemplateId: 1
-          },
-        },
-        result: {
-          data: {
-            addPlan: {
-              id: 7,
-              "__typename": "Plan"
-            }
-          },
-        },
-      },
-    ];
-    await act(async () => {
-      render(
-        <MockedProvider mocks={mocksLoading} addTypename={false}>
-          <PlanCreate />
-        </MockedProvider>
-      );
+  beforeEach(() => {
+    mockUseTranslations.mockImplementation(() => {
+      return jest.fn((key) => key);
     });
-    expect(screen.getByText(/...messaging.loading/i)).toBeInTheDocument();
+
+    mockUseFormatter.mockImplementation(() => ({
+      dateTime: jest.fn(() => '01-01-2023'),
+    }));
+    HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
+    mockScrollTo();
+    mockUseParams.mockReturnValue({ projectId: '1' });
+    // mock router
+    mockRouter = { push: jest.fn() };
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+
+    // Mock Toast
+    (useToast as jest.Mock).mockReturnValue(mockToast);
+
   });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+  })
 
   it('should display error state', async () => {
     const mocksError = [
@@ -1003,7 +1437,7 @@ describe('PlanCreate Component', () => {
               selectOwnerURIs: [],
               bestPractice: false
             },
-            "term": ""
+            term: ""
           },
         },
         error: new Error("There was an error"),
@@ -1020,7 +1454,7 @@ describe('PlanCreate Component', () => {
               selectOwnerURIs: [],
               bestPractice: false
             },
-            "term": ""
+            term: ""
           },
         },
         error: new Error("There was an error"),
@@ -1037,7 +1471,7 @@ describe('PlanCreate Component', () => {
               selectOwnerURIs: [],
               bestPractice: false
             },
-            "term": ""
+            term: ""
           },
         },
         error: new Error("There was an error"),
@@ -1078,103 +1512,4 @@ describe('PlanCreate Component', () => {
       expect(mockRouter.push).toHaveBeenCalledWith('/en-US/projects/1');
     });
   });
-
-  // it('should handle no items found in search', async () => {
-  //   mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-  //   mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
-  //   await act(async () => {
-  //     render(
-  //       <PlanCreate />
-  //     );
-  //   });
-  //   const searchInput = screen.getByLabelText('Template search');
-  //   // Enter search term
-  //   fireEvent.change(searchInput, { target: { value: 'test' } });
-  //   // Click search button
-  //   const searchButton = screen.getByText('buttons.search');
-  //   fireEvent.click(searchButton);
-
-  //   expect(searchInput).toHaveValue('test');
-
-  //   // There should be no matches to the search for 'test'
-  //   await waitFor(() => {
-  //     const heading3 = screen.queryAllByRole('heading', { level: 3 });
-  //     expect(heading3).toHaveLength(0);
-  //     expect(screen.getByText('messaging.noItemsFound')).toBeInTheDocument();
-  //   })
-
-  // });
-
-  // it('should return matching templates on search item', async () => {
-  //   mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-  //   mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
-  //   await act(async () => {
-  //     render(
-  //       <PlanCreate />
-  //     );
-  //   });
-
-  //   const searchInput = screen.getByLabelText('Template search');
-  //   // Enter matching search term
-  //   fireEvent.change(searchInput, { target: { value: 'Arctic' } });
-
-  //   // Click search button
-  //   const searchButton = screen.getByText('buttons.search');
-  //   fireEvent.click(searchButton);
-
-
-  //   await waitFor(() => {
-  //     // Should bring up this matching template
-  //     expect(screen.getByRole('heading', { level: 3, name: /Arctic Data Center: NSF Polar Programs/i })).toBeInTheDocument();
-  //   });
-  // });
-
-  // it('should handle Load More functionality', async () => {
-  //   mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-  //   mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
-  //   await act(async () => {
-  //     render(
-  //       <PlanCreate />
-  //     );
-  //   });
-
-  //   // Get all checkboxes with name="funders"
-  //   const funderCheckboxes = screen.getAllByRole('checkbox').filter(
-  //     (checkbox) => checkbox.getAttribute('name') === 'funders'
-  //   );
-
-  //   // Uncheck each one if it's checked
-  //   for (const checkbox of funderCheckboxes) {
-  //     if ((checkbox as HTMLInputElement).checked) {
-  //       await act(async () => {
-  //         fireEvent.click(checkbox);
-  //       });
-  //       expect((checkbox as HTMLInputElement).checked).toBe(false); // Confirm it's unchecked
-  //     }
-  //   }
-
-  //   const loadMoreButton = screen.getByRole('button', { name: /buttons.loadMore/i });
-  //   await waitFor(() => {
-  //     // Should bring up this matching template
-  //     expect(loadMoreButton).toBeInTheDocument();
-  //     fireEvent.click(loadMoreButton);
-  //   });
-
-  //   const listItems = screen.getAllByRole('listitem').filter(item => item.classList.contains('templateItem'));
-  //   expect(listItems).toHaveLength(6);
-  // });
-
-
-  // it('should pass axe accessibility test', async () => {
-  //   mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-  //   mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
-
-  //   const { container } = render(
-  //     <PlanCreate />
-  //   );
-  //   await act(async () => {
-  //     const results = await axe(container);
-  //     expect(results).toHaveNoViolations();
-  //   });
-  // });
 });

--- a/app/[locale]/projects/[projectId]/dmp/create/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/create/__tests__/page.spec.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
 import PlanCreate from '../page';
 import { useParams, useRouter } from 'next/navigation';
+import { print } from 'graphql';
+import { useToast } from '@/context/ToastContext';
+import logECS from '@/utils/clientLogger';
+
+
+
 import {
-  useAddPlanMutation,
-  useProjectFundingsQuery,
-  usePublishedTemplatesQuery
+  ProjectFundingsDocument,
+  PublishedTemplatesDocument,
+  PublishedTemplatesMetaDataDocument,
+  AddPlanDocument,
 } from '@/generated/graphql';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { mockScrollIntoView, mockScrollTo } from '@/__mocks__/common';
@@ -18,11 +26,6 @@ jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
 }));
 
-jest.mock('@/generated/graphql', () => ({
-  useProjectFundingsQuery: jest.fn(),
-  usePublishedTemplatesQuery: jest.fn(),
-  useAddPlanMutation: jest.fn(),
-}));
 
 // Mock useFormatter from next-intl
 jest.mock('next-intl', () => ({
@@ -33,109 +36,405 @@ jest.mock('next-intl', () => ({
 }));
 
 
+let mockRouter;
 
-const mockPublishedTemplates = {
-  items: [
-    {
-      bestPractice: false,
-      description: "Template 1",
-      id: "1",
-      name: "Agency for Healthcare Research and Quality",
-      visibility: "PUBLIC",
-      ownerDisplayName: "National Science Foundation (nsf.gov)",
-      ownerURI: "http://nsf.gov",
-      modifiedByName: "John Doe",
-    },
-    {
-      bestPractice: false,
-      description: "Arctic Data Center",
-      id: "20",
-      name: "Arctic Data Center: NSF Polar Programs",
-      visibility: "PUBLIC",
-      ownerDisplayName: "National Science Foundation (nsf.gov)",
-      ownerURI: "http://nsf.gov",
-      modified: "2021-10-25 18:42:37",
-      modifiedByName: 'John Doe'
-    },
-    {
-      bestPractice: false,
-      description: "Develop data plans",
-      id: "10",
-      name: "Data Curation Centre",
-      visibility: "PUBLIC",
-      ownerDisplayName: "National Institute of Health",
-      ownerURI: "http://nih.gov",
-      modified: "2021-10-25 18:42:37",
-      modifiedByName: 'John Doe'
-    },
-    {
-      bestPractice: false,
-      description: "Develop data plans",
-      id: "40",
-      name: "Practice Template",
-      visibility: "PUBLIC",
-      ownerDisplayName: "National Institute of Health",
-      ownerURI: "http://nih.gov"
-    },
-    {
-      bestPractice: false,
-      description: "Develop data plans",
-      id: "50",
-      name: "Detailed DMP Template",
-      visibility: "PUBLIC",
-      ownerDisplayName: "National Institute of Health",
-      ownerURI: "http://nih.gov"
-    },
-    {
-      bestPractice: true,
-      description: "Best Practice Template",
-      id: "12",
-      name: "Best Practice Template",
-      visibility: "PUBLIC",
-      ownerDisplayName: null,
-      ownerURI: null,
-      modified: "2021-10-25 18:42:37",
-      modifiedByName: 'John Doe'
-    },
-  ]
-}
+const mockToast = {
+  add: jest.fn(),
+};
 
-const mockProjectFundings = [
+const mocks = [
+  // PublishedTemplatesMetaData query
   {
-    id: 1,
-    affiliation: {
-      displayName: "National Science Foundation (nsf.gov)",
-      uri: "http://nsf.gov"
-    }
+    request: {
+      query: PublishedTemplatesMetaDataDocument,
+      variables: {
+        paginationOptions: {
+          offset: 0,
+          limit: 5,
+          type: "OFFSET",
+          sortDir: "DESC",
+          selectOwnerURIs: [],
+          bestPractice: false
+        },
+        "term": ""
+      },
+    },
+    result: {
+      data: {
+        publishedTemplatesMetaData: {
+          availableAffiliations: [
+            "http://nsf.gov",
+            "http://nih.gov"
+          ],
+          hasBestPracticeTemplates: false,
+        },
+      },
+    },
+  },
+  // PublishedTemplatesMetaData query
+  {
+    request: {
+      query: PublishedTemplatesMetaDataDocument,
+      variables: {
+        paginationOptions: {
+          offset: 0,
+          limit: 5,
+          type: "OFFSET",
+          sortDir: "DESC",
+          selectOwnerURIs: [],
+          bestPractice: false
+        },
+        "term": ""
+      },
+    },
+    result: {
+      data: {
+        publishedTemplatesMetaData: {
+          availableAffiliations: [
+            "http://nsf.gov",
+            "http://nih.gov"
+          ],
+          hasBestPracticeTemplates: false,
+        },
+      },
+    },
   },
   {
-    id: 11,
-    affiliation: {
-      displayName: "National Science Foundation (nsf.gov)",
-      uri: "http://nsf.gov"
-    }
+    request: {
+      query: PublishedTemplatesDocument,
+      variables: {
+        paginationOptions: {
+          offset: 0,
+          limit: 5,
+          type: "OFFSET",
+          sortDir: "DESC",
+          selectOwnerURIs: [],
+          bestPractice: false
+        },
+        "term": ""
+      },
+    },
+    result: {
+      data: {
+        publishedTemplates: {
+          limit: 10,
+          nextCursor: null,
+          totalCount: 4,
+          availableSortFields: ['vt.bestPractice'],
+          currentOffset: 1,
+          hasNextPage: true,
+          hasPreviousPage: true,
+          items: [
+            {
+              bestPractice: false,
+              description: "Template 1",
+              id: "1",
+              name: "Agency for Healthcare Research and Quality",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Science Foundation (nsf.gov)",
+              ownerURI: "http://nsf.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: "John Doe",
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 4,
+              ownerSearchName: "National Science Foundation | nsf.gov | NSF"
+            },
+            {
+              bestPractice: false,
+              description: "Arctic Data Center",
+              id: "20",
+              name: "Arctic Data Center: NSF Polar Programs",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Science Foundation (nsf.gov)",
+              ownerURI: "http://nsf.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 5,
+              ownerSearchName: "National Science Foundation | nsf.gov | NSF"
+            },
+            {
+              bestPractice: false,
+              description: "Develop data plans",
+              id: "10",
+              name: "Data Curation Centre",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Institute of Health",
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v2",
+              templateId: 3,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+            {
+              bestPractice: false,
+              description: "Develop data plans",
+              id: "40",
+              name: "Practice Template",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Institute of Health",
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v3",
+              templateId: 2,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+            {
+              bestPractice: false,
+              description: "Develop data plans",
+              id: "50",
+              name: "Detailed DMP Template",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Institute of Health",
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 1,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+            {
+              bestPractice: true,
+              description: "Best Practice Template",
+              id: "12",
+              name: "Best Practice Template",
+              visibility: "PUBLIC",
+              ownerDisplayName: null,
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v6",
+              templateId: 7,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+          ]
+        },
+      },
+    },
   },
   {
-    id: 2,
-    affiliation: {
-      displayName: "National Institute of health",
-      uri: "http://nih.gov"
-    }
-  }
+    request: {
+      query: PublishedTemplatesDocument,
+      variables: {
+        paginationOptions: {
+          offset: 0,
+          limit: 5,
+          type: "OFFSET",
+          sortDir: "DESC",
+          selectOwnerURIs: ["http://nsf.gov", "http://nih.gov"],
+          bestPractice: false
+        },
+        "term": ""
+      },
+    },
+    result: {
+      data: {
+        publishedTemplates: {
+          limit: 10,
+          nextCursor: null,
+          totalCount: 4,
+          availableSortFields: ['vt.bestPractice'],
+          currentOffset: 1,
+          hasNextPage: true,
+          hasPreviousPage: true,
+          items: [
+            {
+              bestPractice: false,
+              description: "Template 1",
+              id: "1",
+              name: "Agency for Healthcare Research and Quality",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Science Foundation (nsf.gov)",
+              ownerURI: "http://nsf.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: "John Doe",
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 4,
+              ownerSearchName: "National Science Foundation | nsf.gov | NSF"
+            },
+            {
+              bestPractice: false,
+              description: "Arctic Data Center",
+              id: "20",
+              name: "Arctic Data Center: NSF Polar Programs",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Science Foundation (nsf.gov)",
+              ownerURI: "http://nsf.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 5,
+              ownerSearchName: "National Science Foundation | nsf.gov | NSF"
+            },
+            {
+              bestPractice: false,
+              description: "Develop data plans",
+              id: "10",
+              name: "Data Curation Centre",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Institute of Health",
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v2",
+              templateId: 3,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+            {
+              bestPractice: false,
+              description: "Develop data plans",
+              id: "40",
+              name: "Practice Template",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Institute of Health",
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v3",
+              templateId: 2,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+            {
+              bestPractice: false,
+              description: "Develop data plans",
+              id: "50",
+              name: "Detailed DMP Template",
+              visibility: "PUBLIC",
+              ownerDisplayName: "National Institute of Health",
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v5",
+              templateId: 1,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+            {
+              bestPractice: true,
+              description: "Best Practice Template",
+              id: "12",
+              name: "Best Practice Template",
+              visibility: "PUBLIC",
+              ownerDisplayName: null,
+              ownerURI: "http://nih.gov",
+              modified: "2021-10-25 18:42:37",
+              modifiedByName: 'John Doe',
+              modifiedById: 14,
+              ownerId: 122,
+              version: "v6",
+              templateId: 7,
+              ownerSearchName: "National Institute of Health | nih.gov | NIH"
+            },
+          ]
+        },
+      },
+    },
+  },
+  // Initial ProjectFundings query
+  {
+    request: {
+      query: ProjectFundingsDocument,
+      variables: {
+        projectId: 1
+      },
+    },
+    result: {
+      data: {
+        projectFundings: [
+          {
+            id: 1,
+            affiliation: {
+              displayName: "National Science Foundation (nsf.gov)",
+              uri: "http://nsf.gov"
+            },
+            status: "PLANNED",
+            grantId: null,
+            funderOpportunityNumber: "NSF-23456-ABC",
+            funderProjectNumber: null
+          },
+          {
+            id: 11,
+            affiliation: {
+              displayName: "National League of Voters",
+              uri: "http://nlov.gov"
+            },
+            status: "PLANNED",
+            grantId: null,
+            funderOpportunityNumber: "NLV-23456-ABC",
+            funderProjectNumber: null
+          },
+          {
+            id: 2,
+            affiliation: {
+              displayName: "National Institute of health",
+              uri: "http://nih.gov"
+            },
+            status: "PLANNED",
+            grantId: null,
+            funderOpportunityNumber: "NIH-23456-ABC",
+            funderProjectNumber: null
+          }
+        ]
+      },
+    },
+  },
+  // AddPlan mutation
+  {
+    request: {
+      query: AddPlanDocument,
+      variables: {
+        projectId: 1,
+        versionedTemplateId: 1
+      },
+    },
+    result: {
+      data: {
+        addPlan: {
+          id: 7,
+          "__typename": "Plan"
+        }
+      },
+    },
+  },
 ]
+
 describe('PlanCreate Component', () => {
   const mockUseParams = useParams as jest.Mock;
-  const mockUseRouter = useRouter as jest.Mock;
-  const mockUseProjectFundingsQuery = useProjectFundingsQuery as jest.Mock;
-  const mockUsePublishedTemplatesQuery = usePublishedTemplatesQuery as jest.Mock;
-  const mockUseAddPlanMutation = useAddPlanMutation as jest.Mock;
 
   beforeEach(() => {
     HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
     mockScrollTo();
     mockUseParams.mockReturnValue({ projectId: '1' });
-    mockUseRouter.mockReturnValue({ push: jest.fn() });
-    mockUseAddPlanMutation.mockReturnValue([jest.fn()]);
+    // mock router
+    mockRouter = { push: jest.fn() };
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+
+    // Mock Toast
+    (useToast as jest.Mock).mockReturnValue(mockToast);
+
   });
 
   afterEach(() => {
@@ -143,122 +442,243 @@ describe('PlanCreate Component', () => {
   });
 
   it('should render PlanCreate component with funder checkbox', async () => {
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
     await act(async () => {
       render(
-        <PlanCreate />
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <PlanCreate />
+        </MockedProvider>
       );
     });
 
-    expect(screen.getByRole('heading', { name: /title/i })).toBeInTheDocument();
-    expect(screen.getByLabelText('labels.searchByKeyword')).toBeInTheDocument();
-    expect(screen.getByText('helpText.searchHelpText')).toBeInTheDocument();
-    expect(screen.getByText('buttons.search')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /title/i })).toBeInTheDocument();
+      expect(screen.getByLabelText('labels.searchByKeyword')).toBeInTheDocument();
+      expect(screen.getByText('helpText.searchHelpText')).toBeInTheDocument();
+      expect(screen.getByText('buttons.search')).toBeInTheDocument();
+      expect(screen.getByRole('group', { name: /checkbox.filterByFunderLabel/i })).toBeInTheDocument();
+      expect(screen.getByText('checkbox.filterByFunderDescription')).toBeInTheDocument();
 
-    expect(screen.getByRole('group', { name: /checkbox.filterByFunderLabel/i })).toBeInTheDocument();
-    expect(screen.getByText('checkbox.filterByFunderDescription')).toBeInTheDocument();
+      // We should have two checkboxes for project funders checked
+      expect(screen.getByRole('checkbox', { name: /National Science Foundation \(nsf.gov\)/i })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: /National Institute of Health/i })).toBeInTheDocument();
 
-    // We should have two checkboxes for project funders checked
-    expect(screen.getByRole('checkbox', { name: /National Science Foundation \(nsf.gov\)/i })).toBeInTheDocument();
-    // Expected three funder templates to display by default
-    expect(screen.getByRole('heading', { level: 3, name: /Agency for Healthcare Research and Quality/i })).toBeInTheDocument();
-    const templateData = screen.getAllByTestId('template-metadata');
-    const lastRevisedBy1 = within(templateData[0]).getByText(/lastRevisedBy.*John Doe/);
-    const publishStatus1 = within(templateData[0]).getByText('published');
-    const visibility1 = within(templateData[0]).getByText(/visibility.*Public/);
-    expect(lastRevisedBy1).toBeInTheDocument();
-    expect(publishStatus1).toBeInTheDocument();
-    expect(visibility1).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 3, name: /Arctic Data Center: NSF Polar Programs/i })).toBeInTheDocument();
-    const lastRevisedBy2 = within(templateData[1]).getByText(/lastRevisedBy.*John Doe/);
-    const lastUpdated2 = within(templateData[1]).getByText(/lastUpdated.*01-01-2023/);
-    const publishStatus2 = within(templateData[1]).getByText('published');
-    const visibility2 = within(templateData[1]).getByText(/visibility.*Public/);
-    expect(lastRevisedBy2).toBeInTheDocument();
-    expect(lastUpdated2).toBeInTheDocument();
-    expect(publishStatus2).toBeInTheDocument();
-    expect(visibility2).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 3, name: /Data Curation Centre/i })).toBeInTheDocument();
-    const lastRevisedBy3 = within(templateData[2]).getByText(/lastRevisedBy.*John Doe/);
-    const lastUpdated3 = within(templateData[2]).getByText(/lastUpdated.*01-01-2023/);
-    const publishStatus3 = within(templateData[2]).getByText('published');
-    const visibility3 = within(templateData[2]).getByText(/visibility.*Public/);
-    expect(lastRevisedBy3).toBeInTheDocument();
-    expect(lastUpdated3).toBeInTheDocument();
-    expect(publishStatus3).toBeInTheDocument();
-    expect(visibility3).toBeInTheDocument();
-    // Should not show the best practice template on first load
-    expect(screen.queryByRole('heading', { level: 3, name: /Best Practice Template/i })).not.toBeInTheDocument();
-    expect(screen.getAllByText('buttons.select')).toHaveLength(5);
+      // Expected three funder templates to display by default
+      expect(screen.getByRole('heading', { level: 3, name: /Agency for Healthcare Research and Quality/i })).toBeInTheDocument();
+      const templateData = screen.getAllByTestId('template-metadata');
+      const lastRevisedBy1 = within(templateData[0]).getByText(/lastRevisedBy.*John Doe/);
+      const publishStatus1 = within(templateData[0]).getByText('published');
+      const visibility1 = within(templateData[0]).getByText(/visibility.*Public/);
+      expect(lastRevisedBy1).toBeInTheDocument();
+      expect(publishStatus1).toBeInTheDocument();
+      expect(visibility1).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /Arctic Data Center: NSF Polar Programs/i })).toBeInTheDocument();
+      const lastRevisedBy2 = within(templateData[1]).getByText(/lastRevisedBy.*John Doe/);
+      const lastUpdated2 = within(templateData[1]).getByText(/lastUpdated.*01-01-2023/);
+      const publishStatus2 = within(templateData[1]).getByText('published');
+      const visibility2 = within(templateData[1]).getByText(/visibility.*Public/);
+      expect(lastRevisedBy2).toBeInTheDocument();
+      expect(lastUpdated2).toBeInTheDocument();
+      expect(publishStatus2).toBeInTheDocument();
+      expect(visibility2).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /Data Curation Centre/i })).toBeInTheDocument();
+      const lastRevisedBy3 = within(templateData[2]).getByText(/lastRevisedBy.*John Doe/);
+      const lastUpdated3 = within(templateData[2]).getByText(/lastUpdated.*01-01-2023/);
+      const publishStatus3 = within(templateData[2]).getByText('published');
+      const visibility3 = within(templateData[2]).getByText(/visibility.*Public/);
+      expect(lastRevisedBy3).toBeInTheDocument();
+      expect(lastUpdated3).toBeInTheDocument();
+      expect(publishStatus3).toBeInTheDocument();
+      expect(visibility3).toBeInTheDocument();
+      // Should not show the best practice template on first load
+      expect(screen.queryByRole('heading', { level: 3, name: /labels.dmpBestPractice/i })).not.toBeInTheDocument();
+      expect(screen.getAllByText('buttons.select')).toHaveLength(6);
+    });
   });
 
   it('should not display duplicate project funder checkboxes', async () => {
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
     await act(async () => {
       render(
-        <PlanCreate />
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <PlanCreate />
+        </MockedProvider>
       );
     });
-
-    // We should have just two checkboxes for project funders checked, even through projectFunders returns duplicates for National Science Foundation
-    const NSFCheckbox = screen.getAllByRole('checkbox', { name: /National Science Foundation \(nsf.gov\)/i });
-    expect(NSFCheckbox).toHaveLength(1);
-    expect(screen.getByRole('checkbox', { name: /National Institute of Health/i })).toBeInTheDocument();
-  });
-
-  it('should sort correctly so that project funders are at the top of the list', async () => {
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
-    await act(async () => {
-      render(
-        <PlanCreate />
-      );
-    });
-
-    // We should have just two checkboxes for project funders checked, even through projectFunders returns duplicates for National Science Foundation
-    const funderCheckboxes = screen.getAllByRole('checkbox');
-    // Uncheck initially checked project funder checkboxes
-    fireEvent.click(funderCheckboxes[0]);
     await waitFor(() => {
-      // It should now show the initial three templates before Load More button, with the project funder templates at the top
-      const listItems = screen.getAllByRole('listitem').filter(item => item.classList.contains('templateItem'));
-      expect(listItems).toHaveLength(3);
-      expect(listItems[0]).toHaveTextContent(/Data Curation Centre/);
-      const heading = within(listItems[1]).getByRole('heading', { name: /Practice Template/ });
-      expect(heading).toBeInTheDocument();
-      const heading2 = within(listItems[2]).getByRole('heading', { name: /Detailed DMP Template/ });
-      expect(heading2).toBeInTheDocument();
-    });
+      // We should have just two checkboxes for project funders checked, even through projectFunders returns duplicates for National Science Foundation
+      const NSFCheckbox = screen.getAllByRole('checkbox', { name: /National Science Foundation \(nsf.gov\)/i });
+      expect(NSFCheckbox).toHaveLength(1);
+      expect(screen.getByRole('checkbox', { name: /National Institute of Health/i })).toBeInTheDocument();
+    })
   });
+
 
   it('should not show any checkboxes if no project funders and no best practice', async () => {
-    const mockTemplates = [
+    const mocksWithNoProjectFunders = [
+      // PublishedTemplatesMetaData query
       {
-        bestPractice: false,
-        description: "Develop data plans",
-        id: "10",
-        name: "Data Curation Centre",
-        visibility: "PUBLIC",
-        ownerDisplayName: "UC Davis",
-        ownerURI: "http://ucd.gov"
+        request: {
+          query: PublishedTemplatesMetaDataDocument,
+          variables: {
+            paginationOptions: {
+              offset: 0,
+              limit: 5,
+              type: "OFFSET",
+              sortDir: "DESC",
+              selectOwnerURIs: [],
+              bestPractice: false
+            },
+            "term": ""
+          },
+        },
+        result: {
+          data: {
+            publishedTemplatesMetaData: {
+              availableAffiliations: [
+                "http://nsf.gov",
+                "http://nih.gov"
+              ],
+              hasBestPracticeTemplates: false,
+            },
+          },
+        },
       },
       {
-        bestPractice: false,
-        description: "Best Practice Template",
-        id: "12",
-        name: "Best Practice Template",
-        ownerDisplayName: 'NIH',
-        visibility: "PUBLIC",
-        owner: null
+        request: {
+          query: PublishedTemplatesDocument,
+          variables: {
+            paginationOptions: {
+              offset: 0,
+              limit: 5,
+              type: "OFFSET",
+              sortDir: "DESC",
+              selectOwnerURIs: [],
+              bestPractice: false
+            },
+            "term": ""
+          },
+        },
+        result: {
+          data: {
+            publishedTemplates: {
+              limit: 10,
+              nextCursor: null,
+              totalCount: 4,
+              availableSortFields: ['vt.bestPractice'],
+              currentOffset: 1,
+              hasNextPage: true,
+              hasPreviousPage: true,
+              items: [
+                {
+                  bestPractice: false,
+                  description: "Develop data plans",
+                  id: "10",
+                  name: "Data Curation Centre",
+                  visibility: "PUBLIC",
+                  ownerDisplayName: "UC Davis",
+                  ownerURI: "http://ucd.gov",
+                  modified: "2021-10-25 18:42:37",
+                  modifiedByName: 'John Doe',
+                  modifiedById: 14,
+                  ownerId: 122,
+                  version: "v2",
+                  templateId: 10,
+                  ownerSearchName: "UC Davis"
+                },
+                {
+                  id: "12",
+                  templateId: 11,
+                  name: "Best Practice Template",
+                  description: "Best Practice Template",
+                  visibility: "PUBLIC",
+                  bestPractice: false,
+                  version: "v2",
+                  modified: "2021-10-25 18:42:37",
+                  modifiedById: 14,
+                  modifiedByName: 'John Doe',
+                  ownerId: 122,
+                  ownerURI: "http://nih.gov",
+                  ownerDisplayName: 'NIH',
+                  ownerSearchName: "National Institute of Health | nih.gov | NIH",
+                }
+
+              ]
+            },
+          },
+        },
+      },
+      {
+        request: {
+          query: ProjectFundingsDocument,
+          variables: {
+            projectId: 1
+          },
+        },
+        result: {
+          data: {
+            projectFundings: [
+              {
+                id: 1,
+                affiliation: {
+                  displayName: "National Science Foundation (nsf.gov)",
+                  uri: "http://nsf1.gov"
+                },
+                status: "PLANNED",
+                grantId: null,
+                funderOpportunityNumber: "NSF-23456-ABC",
+                funderProjectNumber: null
+              },
+              {
+                id: 11,
+                affiliation: {
+                  displayName: "National League of Voters",
+                  uri: "http://nlov2.gov"
+                },
+                status: "PLANNED",
+                grantId: null,
+                funderOpportunityNumber: "NLV-23456-ABC",
+                funderProjectNumber: null
+              },
+              {
+                id: 2,
+                affiliation: {
+                  displayName: "National Institute of health",
+                  uri: "http://nih3.gov"
+                },
+                status: "PLANNED",
+                grantId: null,
+                funderOpportunityNumber: "NIH-23456-ABC",
+                funderProjectNumber: null
+              }
+            ]
+          },
+        },
+      },
+      // AddPlan mutation
+      {
+        request: {
+          query: AddPlanDocument,
+          variables: {
+            projectId: 1,
+            versionedTemplateId: 1
+          },
+        },
+        result: {
+          data: {
+            addPlan: {
+              id: 7,
+              "__typename": "Plan"
+            }
+          },
+        },
       },
     ]
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: [] }, loading: false, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockTemplates }, loading: false, error: null });
+
+
     await act(async () => {
       render(
-        <PlanCreate />
+        <MockedProvider mocks={mocksWithNoProjectFunders} addTypename={false}>
+          <PlanCreate />
+        </MockedProvider>
       );
     });
 
@@ -267,180 +687,494 @@ describe('PlanCreate Component', () => {
   });
 
   it('should display best practices template when no funder templates', async () => {
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: [] }, loading: false, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
+
+    const mocksWithOnlyBestPractice = [
+      // PublishedTemplatesMetaData query
+      {
+        request: {
+          query: PublishedTemplatesMetaDataDocument,
+          variables: {
+            paginationOptions: {
+              offset: 0,
+              limit: 5,
+              type: "OFFSET",
+              sortDir: "DESC",
+              selectOwnerURIs: [],
+              bestPractice: false
+            },
+            "term": ""
+          },
+        },
+        result: {
+          data: {
+            publishedTemplatesMetaData: {
+              availableAffiliations: [
+                "http://nsf.gov",
+                "http://nih.gov"
+              ],
+              hasBestPracticeTemplates: true,
+            },
+          },
+        },
+      },
+      {
+        request: {
+          query: PublishedTemplatesDocument,
+          variables: {
+            paginationOptions: {
+              offset: 0,
+              limit: 5,
+              type: "OFFSET",
+              sortDir: "DESC",
+              selectOwnerURIs: [],
+              bestPractice: false
+            },
+            "term": ""
+          },
+        },
+        result: {
+          data: {
+            publishedTemplates: {
+              limit: 10,
+              nextCursor: null,
+              totalCount: 4,
+              availableSortFields: ['vt.bestPractice'],
+              currentOffset: 1,
+              hasNextPage: true,
+              hasPreviousPage: true,
+              items: [
+                {
+                  bestPractice: true,
+                  description: "Develop data plans",
+                  id: "10",
+                  name: "Data Curation Centre",
+                  visibility: "PUBLIC",
+                  ownerDisplayName: "UC Davis",
+                  ownerURI: "http://ucd.gov",
+                  modified: "2021-10-25 18:42:37",
+                  modifiedByName: 'John Doe',
+                  modifiedById: 14,
+                  ownerId: 122,
+                  version: "v2",
+                  templateId: 10,
+                  ownerSearchName: "UC Davis"
+                },
+                {
+                  id: "12",
+                  templateId: 11,
+                  name: "Best Practice Template",
+                  description: "Best Practice Template",
+                  visibility: "PUBLIC",
+                  bestPractice: true,
+                  version: "v2",
+                  modified: "2021-10-25 18:42:37",
+                  modifiedById: 14,
+                  modifiedByName: 'John Doe',
+                  ownerId: 122,
+                  ownerURI: "http://bestPractice.gov",
+                  ownerDisplayName: 'NIH',
+                  ownerSearchName: "DMP Best Practice",
+                }
+
+              ]
+            },
+          },
+        },
+      },
+      {
+        request: {
+          query: PublishedTemplatesDocument,
+          variables: {
+            paginationOptions: {
+              offset: 0,
+              limit: 5,
+              type: "OFFSET",
+              sortDir: "DESC",
+              selectOwnerURIs: [],
+              bestPractice: true
+            },
+            "term": ""
+          },
+        },
+        result: {
+          data: {
+            publishedTemplates: {
+              limit: 10,
+              nextCursor: null,
+              totalCount: 4,
+              availableSortFields: ['vt.bestPractice'],
+              currentOffset: 1,
+              hasNextPage: true,
+              hasPreviousPage: true,
+              items: [
+                {
+                  bestPractice: true,
+                  description: "Develop data plans",
+                  id: "10",
+                  name: "Data Curation Centre",
+                  visibility: "PUBLIC",
+                  ownerDisplayName: "UC Davis",
+                  ownerURI: "http://ucd.gov",
+                  modified: "2021-10-25 18:42:37",
+                  modifiedByName: 'John Doe',
+                  modifiedById: 14,
+                  ownerId: 122,
+                  version: "v2",
+                  templateId: 10,
+                  ownerSearchName: "UC Davis"
+                },
+                {
+                  id: "12",
+                  templateId: 11,
+                  name: "Best Practice Template",
+                  description: "Best Practice Template",
+                  visibility: "PUBLIC",
+                  bestPractice: true,
+                  version: "v2",
+                  modified: "2021-10-25 18:42:37",
+                  modifiedById: 14,
+                  modifiedByName: 'John Doe',
+                  ownerId: 122,
+                  ownerURI: "http://bestPractice.gov",
+                  ownerDisplayName: 'NIH',
+                  ownerSearchName: "DMP Best Practice",
+                }
+
+              ]
+            },
+          },
+        },
+      },
+      {
+        request: {
+          query: ProjectFundingsDocument,
+          variables: {
+            projectId: 1
+          },
+        },
+        result: {
+          data: {
+            projectFundings: []
+          },
+        },
+      },
+      // AddPlan mutation
+      {
+        request: {
+          query: AddPlanDocument,
+          variables: {
+            projectId: 1,
+            versionedTemplateId: 1
+          },
+        },
+        result: {
+          data: {
+            addPlan: {
+              id: 7,
+              "__typename": "Plan"
+            }
+          },
+        },
+      },
+    ]
     await act(async () => {
       render(
-        <PlanCreate />
+        <MockedProvider mocks={mocksWithOnlyBestPractice} addTypename={false}>
+          <PlanCreate />
+        </MockedProvider>
       );
     });
 
-    const funderCheckboxes = screen.queryAllByRole('checkbox');
-    expect(funderCheckboxes).toHaveLength(1);
-    const listItems = screen.getAllByRole('listitem').filter(item => item.classList.contains('templateItem'));
-    expect(listItems).toHaveLength(1);
-    expect(listItems[0]).toHaveTextContent(/Best Practice Template/);
-  });
 
-  it('should display best practices template when there are no matching templates', async () => {
-    const mockPublishedTemplates2 = {
-      items: [
-        {
-          bestPractice: false,
-          description: "Template 1",
-          id: "1",
-          name: "Agency for Healthcare Research and Quality",
-          visibility: "PUBLIC",
-          ownerDisplayName: "National Science Foundation (nsf.gov)",
-          ownerURI: "http://random.gove"
-        },
-        {
-          bestPractice: true,
-          description: "Best Practice Template",
-          id: "12",
-          name: "Best Practice Template",
-          visibility: "PUBLIC",
-          ownerDisplayName: 'NIH',
-          ownerURI: null
-        },
-      ]
-    }
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: [] }, loading: false, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates2 }, loading: false, error: null });
-    await act(async () => {
-      render(
-        <PlanCreate />
-      );
-    });
+    await waitFor(() => {
+      const checkBoxes = screen.getByRole('checkbox', { name: "best practices" });
+      expect(checkBoxes).toBeInTheDocument();
+      expect(screen.getByText('checkbox.filterByBestPracticesLabel')).toBeInTheDocument();
+      expect(screen.getByText('checkbox.filterByBestPracticesDescription')).toBeInTheDocument();
+      expect(screen.getByText("labels.dmpBestPractice")).toBeInTheDocument();
+      const listItems = screen.getAllByRole('listitem').filter(item => item.classList.contains('templateItem'));
+      expect(listItems).toHaveLength(2);
+      expect(screen.getByRole('heading', { level: 3, name: "Data Curation Centre" })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: "Best Practice Template" })).toBeInTheDocument();
 
-    const funderCheckboxes = screen.queryAllByRole('checkbox');
-    expect(funderCheckboxes).toHaveLength(1);
-    const listItems = screen.getAllByRole('listitem').filter(item => item.classList.contains('templateItem'));
-    expect(listItems).toHaveLength(1);
-    expect(listItems[0]).toHaveTextContent(/Best Practice Template/);
+    })
   });
 
 
   it('should display loading state', async () => {
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: null }, loading: true, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: null }, loading: true, error: null });
-
+    const mocksLoading = [
+      // PublishedTemplatesMetaData query
+      {
+        request: {
+          query: PublishedTemplatesMetaDataDocument,
+          variables: {
+            paginationOptions: {
+              offset: 0,
+              limit: 5,
+              type: "OFFSET",
+              sortDir: "DESC",
+              selectOwnerURIs: [],
+              bestPractice: false
+            },
+            "term": ""
+          },
+        },
+        result: {
+          data: null,
+          loading: true,
+          error: null
+        },
+      },
+      {
+        request: {
+          query: PublishedTemplatesDocument,
+          variables: {
+            paginationOptions: {
+              offset: 0,
+              limit: 5,
+              type: "OFFSET",
+              sortDir: "DESC",
+              selectOwnerURIs: [],
+              bestPractice: false
+            },
+            "term": ""
+          },
+        },
+        result: {
+          data: null,
+          loading: true,
+          error: null
+        },
+      },
+      {
+        request: {
+          query: ProjectFundingsDocument,
+          variables: {
+            projectId: 1
+          },
+        },
+        result: {
+          data: {
+            projectFundings: []
+          },
+        },
+      },
+      // AddPlan mutation
+      {
+        request: {
+          query: AddPlanDocument,
+          variables: {
+            projectId: 1,
+            versionedTemplateId: 1
+          },
+        },
+        result: {
+          data: {
+            addPlan: {
+              id: 7,
+              "__typename": "Plan"
+            }
+          },
+        },
+      },
+    ];
     await act(async () => {
       render(
-        <PlanCreate />
+        <MockedProvider mocks={mocksLoading} addTypename={false}>
+          <PlanCreate />
+        </MockedProvider>
       );
     });
-    expect(screen.getByText('messaging.loading...')).toBeInTheDocument();
+    expect(screen.getByText(/...messaging.loading/i)).toBeInTheDocument();
   });
 
   it('should display error state', async () => {
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: null }, loading: false, error: new Error('Error') });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: [] }, loading: false, error: null });
+    const mocksError = [
+      // PublishedTemplatesMetaData query
+      {
+        request: {
+          query: PublishedTemplatesMetaDataDocument,
+          variables: {
+            paginationOptions: {
+              offset: 0,
+              limit: 5,
+              type: "OFFSET",
+              sortDir: "DESC",
+              selectOwnerURIs: [],
+              bestPractice: false
+            },
+            "term": ""
+          },
+        },
+        error: new Error("There was an error"),
+      },
+      {
+        request: {
+          query: PublishedTemplatesDocument,
+          variables: {
+            paginationOptions: {
+              offset: 0,
+              limit: 5,
+              type: "OFFSET",
+              sortDir: "DESC",
+              selectOwnerURIs: [],
+              bestPractice: false
+            },
+            "term": ""
+          },
+        },
+        error: new Error("There was an error"),
+      },
+      {
+        request: {
+          query: PublishedTemplatesDocument,
+          variables: {
+            paginationOptions: {
+              offset: 0,
+              limit: 5,
+              type: "OFFSET",
+              sortDir: "DESC",
+              selectOwnerURIs: [],
+              bestPractice: false
+            },
+            "term": ""
+          },
+        },
+        error: new Error("There was an error"),
+      },
+      {
+        request: {
+          query: ProjectFundingsDocument,
+          variables: {
+            projectId: 1
+          },
+        },
+        result: {
+          data: {
+            projectFundings: []
+          },
+        },
+      },
+    ];
 
     await act(async () => {
       render(
-        <PlanCreate />
+        <MockedProvider mocks={mocksError} addTypename={false}>
+          <PlanCreate />
+        </MockedProvider>
       );
     });
-    expect(screen.getByText('messaging.error')).toBeInTheDocument();
-  });
 
-  it('should handle no items found in search', async () => {
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
-    await act(async () => {
-      render(
-        <PlanCreate />
-      );
-    });
-    const searchInput = screen.getByLabelText('Template search');
-    // Enter search term
-    fireEvent.change(searchInput, { target: { value: 'test' } });
-    // Click search button
-    const searchButton = screen.getByText('buttons.search');
-    fireEvent.click(searchButton);
-
-    expect(searchInput).toHaveValue('test');
-
-    // There should be no matches to the search for 'test'
     await waitFor(() => {
-      const heading3 = screen.queryAllByRole('heading', { level: 3 });
-      expect(heading3).toHaveLength(0);
-      expect(screen.getByText('messaging.noItemsFound')).toBeInTheDocument();
-    })
-
-  });
-
-  it('should return matching templates on search item', async () => {
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
-    await act(async () => {
-      render(
-        <PlanCreate />
-      );
-    });
-
-    const searchInput = screen.getByLabelText('Template search');
-    // Enter matching search term
-    fireEvent.change(searchInput, { target: { value: 'Arctic' } });
-
-    // Click search button
-    const searchButton = screen.getByText('buttons.search');
-    fireEvent.click(searchButton);
-
-
-    await waitFor(() => {
-      // Should bring up this matching template
-      expect(screen.getByRole('heading', { level: 3, name: /Arctic Data Center: NSF Polar Programs/i })).toBeInTheDocument();
+      expect(logECS).toHaveBeenCalledWith(
+        'error',
+        'Plan Create queries',
+        expect.objectContaining({
+          error: expect.anything(),
+          url: { path: '/en-US/projects/1/dmp/create' },
+        })
+      )
+      expect(mockToast.add).toHaveBeenCalledWith('messaging.somethingWentWrong', { type: 'error' });
+      expect(mockRouter.push).toHaveBeenCalledWith('/en-US/projects/1');
     });
   });
 
-  it('should handle Load More functionality', async () => {
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
-    await act(async () => {
-      render(
-        <PlanCreate />
-      );
-    });
+  // it('should handle no items found in search', async () => {
+  //   mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
+  //   mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
+  //   await act(async () => {
+  //     render(
+  //       <PlanCreate />
+  //     );
+  //   });
+  //   const searchInput = screen.getByLabelText('Template search');
+  //   // Enter search term
+  //   fireEvent.change(searchInput, { target: { value: 'test' } });
+  //   // Click search button
+  //   const searchButton = screen.getByText('buttons.search');
+  //   fireEvent.click(searchButton);
 
-    // Get all checkboxes with name="funders"
-    const funderCheckboxes = screen.getAllByRole('checkbox').filter(
-      (checkbox) => checkbox.getAttribute('name') === 'funders'
-    );
+  //   expect(searchInput).toHaveValue('test');
 
-    // Uncheck each one if it's checked
-    for (const checkbox of funderCheckboxes) {
-      if ((checkbox as HTMLInputElement).checked) {
-        await act(async () => {
-          fireEvent.click(checkbox);
-        });
-        expect((checkbox as HTMLInputElement).checked).toBe(false); // Confirm it's unchecked
-      }
-    }
+  //   // There should be no matches to the search for 'test'
+  //   await waitFor(() => {
+  //     const heading3 = screen.queryAllByRole('heading', { level: 3 });
+  //     expect(heading3).toHaveLength(0);
+  //     expect(screen.getByText('messaging.noItemsFound')).toBeInTheDocument();
+  //   })
 
-    const loadMoreButton = screen.getByRole('button', { name: /buttons.loadMore/i });
-    await waitFor(() => {
-      // Should bring up this matching template
-      expect(loadMoreButton).toBeInTheDocument();
-      fireEvent.click(loadMoreButton);
-    });
+  // });
 
-    const listItems = screen.getAllByRole('listitem').filter(item => item.classList.contains('templateItem'));
-    expect(listItems).toHaveLength(6);
-  });
+  // it('should return matching templates on search item', async () => {
+  //   mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
+  //   mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
+  //   await act(async () => {
+  //     render(
+  //       <PlanCreate />
+  //     );
+  //   });
+
+  //   const searchInput = screen.getByLabelText('Template search');
+  //   // Enter matching search term
+  //   fireEvent.change(searchInput, { target: { value: 'Arctic' } });
+
+  //   // Click search button
+  //   const searchButton = screen.getByText('buttons.search');
+  //   fireEvent.click(searchButton);
 
 
-  it('should pass axe accessibility test', async () => {
-    mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
-    mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
+  //   await waitFor(() => {
+  //     // Should bring up this matching template
+  //     expect(screen.getByRole('heading', { level: 3, name: /Arctic Data Center: NSF Polar Programs/i })).toBeInTheDocument();
+  //   });
+  // });
 
-    const { container } = render(
-      <PlanCreate />
-    );
-    await act(async () => {
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
-    });
-  });
+  // it('should handle Load More functionality', async () => {
+  //   mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
+  //   mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
+  //   await act(async () => {
+  //     render(
+  //       <PlanCreate />
+  //     );
+  //   });
+
+  //   // Get all checkboxes with name="funders"
+  //   const funderCheckboxes = screen.getAllByRole('checkbox').filter(
+  //     (checkbox) => checkbox.getAttribute('name') === 'funders'
+  //   );
+
+  //   // Uncheck each one if it's checked
+  //   for (const checkbox of funderCheckboxes) {
+  //     if ((checkbox as HTMLInputElement).checked) {
+  //       await act(async () => {
+  //         fireEvent.click(checkbox);
+  //       });
+  //       expect((checkbox as HTMLInputElement).checked).toBe(false); // Confirm it's unchecked
+  //     }
+  //   }
+
+  //   const loadMoreButton = screen.getByRole('button', { name: /buttons.loadMore/i });
+  //   await waitFor(() => {
+  //     // Should bring up this matching template
+  //     expect(loadMoreButton).toBeInTheDocument();
+  //     fireEvent.click(loadMoreButton);
+  //   });
+
+  //   const listItems = screen.getAllByRole('listitem').filter(item => item.classList.contains('templateItem'));
+  //   expect(listItems).toHaveLength(6);
+  // });
+
+
+  // it('should pass axe accessibility test', async () => {
+  //   mockUseProjectFundingsQuery.mockReturnValue({ data: { projectFundings: mockProjectFundings }, loading: false, error: null });
+  //   mockUsePublishedTemplatesQuery.mockReturnValue({ data: { publishedTemplates: mockPublishedTemplates }, loading: false, error: null });
+
+  //   const { container } = render(
+  //     <PlanCreate />
+  //   );
+  //   await act(async () => {
+  //     const results = await axe(container);
+  //     expect(results).toHaveNoViolations();
+  //   });
+  // });
 });

--- a/app/[locale]/projects/[projectId]/dmp/create/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/create/page.tsx
@@ -180,14 +180,13 @@ const PlanCreate: React.FC = () => {
     // Mark that user has interacted with checkboxes
     setUserHasInteracted(true);
 
-    setSelectedFilterItems(value);
-    let filteredList: TemplateItemProps[] | null = null;
-
     // Determine which templates to show based on selected filters
 
     if (value.length === 0) {
       setSelectedOwnerURIs([]);
       setBestPractice(false);
+      setSelectedFunders([]);
+      setSelectedFilterItems([]);
       // Default to all templates when no criteria selected
       await fetchTemplates({ page: currentPage });
 
@@ -199,6 +198,7 @@ const PlanCreate: React.FC = () => {
       // Fetch templates for selected funders
       await fetchTemplates({ selectedOwnerURIs: value });
     } else if (type === 'bestPractice') {
+      setSelectedFilterItems(value);
       setSelectedOwnerURIs([]);
       setBestPractice(true);
       // Fetch best practice templates
@@ -356,7 +356,6 @@ const PlanCreate: React.FC = () => {
         setSelectedFilterItems(["DMP Best Practice"]); // Set to best practice value
         setBestPractice(true);
         setSelectedOwnerURIs([]);
-        await fetchTemplates({ bestPractice: true });
 
       } else {
         // Set selected funders by their uri

--- a/app/[locale]/projects/[projectId]/dmp/create/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/create/page.tsx
@@ -482,17 +482,6 @@ const PlanCreate: React.FC = () => {
 
           {(publicTemplatesList?.length > 0) ? (
             <>
-              {/**Only display pagination if there is more than one page */}
-              {publicTemplatesList?.length && (
-                <Pagination
-                  currentPage={currentPage}
-                  totalPages={totalPages}
-                  hasPreviousPage={hasPreviousPage}
-                  hasNextPage={hasNextPage}
-                  handlePageClick={handlePageClick}
-                />
-              )}
-
               {/**Display list of published templates */}
               <section className="mb-8" aria-labelledby="public-templates">
                 <div className="template-list" role="list" aria-label="Public templates">

--- a/app/[locale]/projects/[projectId]/dmp/create/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/create/page.tsx
@@ -39,6 +39,7 @@ import { useToast } from '@/context/ToastContext';
 import { useFormatDate } from '@/hooks/useFormatDate';
 import { TemplateItemProps } from '@/app/types';
 
+// # of templates displayed per page
 const LIMIT = 5;
 
 interface ProjectFundersInterface {

--- a/app/[locale]/projects/[projectId]/fundings/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/page.tsx
@@ -40,8 +40,6 @@ const ProjectsProjectFunding = () => {
     fetchPolicy: 'network-only'
   });
 
-  console.log("Project Fundings", funders);
-
   const handleAddFunding = () => {
     router.push(routePath('projects.fundings.search', {
       projectId: projectId as string,

--- a/app/[locale]/projects/[projectId]/fundings/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/page.tsx
@@ -40,6 +40,8 @@ const ProjectsProjectFunding = () => {
     fetchPolicy: 'network-only'
   });
 
+  console.log("Project Fundings", funders);
+
   const handleAddFunding = () => {
     router.push(routePath('projects.fundings.search', {
       projectId: projectId as string,

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -304,6 +304,7 @@ export interface CheckboxGroupProps {
   errorMessage?: string;
   onChange?: ((value: string[]) => void),
   isRequired?: boolean;
+  ariaLabel?: string;
 }
 
 export interface ProjectMemberErrorInterface {

--- a/components/Form/CheckboxGroup/index.tsx
+++ b/components/Form/CheckboxGroup/index.tsx
@@ -19,6 +19,7 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
   errorMessage,
   onChange,
   isRequired = false,
+  ariaLabel
 }) => {
   return (
     <>
@@ -27,6 +28,7 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
         value={value}
         className="checkbox-group"
         data-testid="checkbox-group"
+        aria-label={ariaLabel}
         onChange={onChange}
         isRequired={isRequired}
       >
@@ -40,7 +42,7 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
         )}
         {checkboxData.map((checkbox, index) => (
           <div key={index}>
-            <Checkbox value={checkbox.value}>
+            <Checkbox value={checkbox.value} aria-label={ariaLabel}>
               <div className="checkbox">
                 <svg viewBox="0 0 18 18" aria-hidden="true">
                   <polyline points="1 9 7 14 15 4" />

--- a/components/Form/CheckboxGroup/index.tsx
+++ b/components/Form/CheckboxGroup/index.tsx
@@ -28,7 +28,6 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
         value={value}
         className="checkbox-group"
         data-testid="checkbox-group"
-        aria-label={ariaLabel}
         onChange={onChange}
         isRequired={isRequired}
       >

--- a/components/Pagination/__tests__/index.spec.tsx
+++ b/components/Pagination/__tests__/index.spec.tsx
@@ -1,0 +1,255 @@
+import React from 'react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import Pagination from '../index';
+expect.extend(toHaveNoViolations);
+// Mock translations
+jest.mock('next-intl', () => ({
+  useTranslations: jest.fn(() => jest.fn((key) => key)), // Mock `useTranslations`,
+}));
+
+// Mock the CSS module
+jest.mock('./pagination.module.scss', () => ({
+  pagination: 'pagination',
+  current: 'current',
+  ellipsis: 'ellipsis'
+}));
+
+describe('Pagination Component', () => {
+  const mockHandlePageClick = jest.fn();
+
+  beforeEach(() => {
+    mockHandlePageClick.mockClear();
+  });
+
+  const defaultProps = {
+    currentPage: 1,
+    totalPages: 10,
+    hasPreviousPage: false,
+    hasNextPage: true,
+    handlePageClick: mockHandlePageClick
+  };
+
+  describe('Basic Rendering', () => {
+    it('should render pagination navigation', () => {
+      render(<Pagination {...defaultProps} />);
+
+      const nav = screen.getByRole('navigation', { name: /pagination/i });
+      expect(nav).toBeInTheDocument();
+    });
+
+    it('should render previous and next buttons', () => {
+      render(<Pagination {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: "labels.previousPage" })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: "labels.nextPage" })).toBeInTheDocument();
+    });
+
+    it('should render page numbers as links', () => {
+      render(<Pagination {...defaultProps} />);
+      const page1 = screen.getAllByRole('link', { name: /page 1/i });
+      expect(page1).toHaveLength(2);
+    });
+  });
+
+  describe('Button States', () => {
+    it('should disable previous button when hasPreviousPage is false', () => {
+      render(<Pagination {...defaultProps} hasPreviousPage={false} />);
+
+      const prevButton = screen.getByRole('button', { name: "labels.previousPage" });
+      expect(prevButton).toBeDisabled();
+    });
+
+    it('should enable previous button when hasPreviousPage is true', () => {
+      render(<Pagination {...defaultProps} currentPage={2} hasPreviousPage={true} />);
+
+      const prevButton = screen.getByRole('button', { name: "labels.previousPage" });
+      expect(prevButton).not.toBeDisabled();
+    });
+
+    it('should disable next button when hasNextPage is false', () => {
+      render(<Pagination {...defaultProps} currentPage={10} hasNextPage={false} />);
+
+      const nextButton = screen.getByRole('button', { name: "labels.nextPage" });
+      expect(nextButton).toBeDisabled();
+    });
+
+    it('should enable next button when hasNextPage is true', () => {
+      render(<Pagination {...defaultProps} hasNextPage={true} />);
+
+      const nextButton = screen.getByRole('button', { name: "labels.nextPage" });
+      expect(nextButton).not.toBeDisabled();
+    });
+  });
+
+  describe('Current Page Highlighting', () => {
+    it('should apply current class to active page', () => {
+      render(<Pagination {...defaultProps} currentPage={3} />);
+
+      const currentPageLink = screen.getByRole('link', { name: /page 3/i });
+      expect(currentPageLink).toHaveClass('current');
+    });
+
+    it('should not apply current class to non-active pages', () => {
+      render(<Pagination {...defaultProps} currentPage={3} />);
+
+      const otherPageLink = screen.getAllByRole('link', { name: /page 1/i });
+      expect(otherPageLink[0]).not.toHaveClass('current');
+    });
+  });
+
+  describe('Click Handlers', () => {
+    it('should call handlePageClick with previous page when previous button is clicked', () => {
+      render(<Pagination {...defaultProps} currentPage={5} hasPreviousPage={true} />);
+
+      const prevButton = screen.getByRole('button', { name: "labels.previousPage" });
+      fireEvent.click(prevButton);
+
+      expect(mockHandlePageClick).toHaveBeenCalledWith(4);
+    });
+
+    it('should call handlePageClick with next page when next button is clicked', () => {
+      render(<Pagination {...defaultProps} currentPage={5} hasNextPage={true} />);
+
+      const nextButton = screen.getByRole('button', { name: "labels.nextPage" });
+      fireEvent.click(nextButton);
+
+      expect(mockHandlePageClick).toHaveBeenCalledWith(6);
+    });
+
+    it('should call handlePageClick with correct page number when page link is clicked', () => {
+      render(<Pagination {...defaultProps} />);
+
+      const pageLink = screen.getByRole('link', { name: /page 2/i });
+      fireEvent.click(pageLink);
+
+      expect(mockHandlePageClick).toHaveBeenCalledWith(2);
+    });
+
+    it('should not navigate when page link is clicked (preventDefault behavior)', () => {
+      render(<Pagination {...defaultProps} />);
+
+      const pageLink = screen.getByRole('link', { name: /page 2/i });
+
+      // The link should have href="#" but clicking it should not cause navigation
+      expect(pageLink).toHaveAttribute('href', '#');
+
+      // After clicking, the handlePageClick should be called instead of navigating
+      fireEvent.click(pageLink);
+      expect(mockHandlePageClick).toHaveBeenCalledWith(2);
+
+      // The URL should not have changed (no navigation occurred)
+      expect(window.location.hash).toBe('');
+    });
+  });
+
+  describe('Page Range Logic', () => {
+    it('should show ellipsis when there are many pages', () => {
+      render(<Pagination {...defaultProps} currentPage={5} totalPages={20} />);
+
+      const ellipsis = screen.getAllByText('…');
+      expect(ellipsis.length).toBeGreaterThan(0);
+    });
+
+    it('should show all pages when total pages is small', () => {
+      render(<Pagination {...defaultProps} currentPage={2} totalPages={5} />);
+
+      for (let i = 1; i <= 5; i++) {
+        expect(screen.getByRole('link', { name: `Page ${i}` })).toBeInTheDocument();
+      }
+    });
+
+    it('should always shows first and last page', () => {
+      render(<Pagination {...defaultProps} currentPage={10} totalPages={20} />);
+
+      const page1 = screen.getByRole('link', { name: "Page 1" });
+      const page20 = screen.getByRole('link', { name: "Page 20" });
+      expect(page1).toBeInTheDocument();
+      expect(page20).toBeInTheDocument();
+    });
+
+    it('should show pages around current page', () => {
+      render(<Pagination {...defaultProps} currentPage={10} totalPages={20} />);
+
+      // Should show pages around current page (delta = 2)
+      expect(screen.getByRole('link', { name: /page 8/i })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /page 9/i })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /page 10/i })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /page 11/i })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /page 12/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle single page correctly', () => {
+      render(<Pagination {...defaultProps} currentPage={1} totalPages={1} hasPreviousPage={false} hasNextPage={false} />);
+
+      expect(screen.getByRole('button', { name: "labels.previousPage" })).toBeDisabled();
+      expect(screen.getByRole('button', { name: "labels.nextPage" })).toBeDisabled();
+      expect(screen.getByRole('link', { name: /page 1/i })).toBeInTheDocument();
+    });
+
+    it('should handle first page correctly', () => {
+      render(<Pagination {...defaultProps} currentPage={1} totalPages={10} />);
+
+      expect(screen.getByRole('button', { name: "labels.previousPage" })).toBeDisabled();
+      expect(screen.getByRole('button', { name: "labels.nextPage" })).not.toBeDisabled();
+    });
+
+    it('should handle last page correctly', () => {
+      render(<Pagination {...defaultProps} currentPage={10} totalPages={10} hasPreviousPage={true} hasNextPage={false} />);
+
+      expect(screen.getByRole('button', { name: "labels.previousPage" })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: "labels.nextPage" })).toBeDisabled();
+    });
+
+    it('should handle null hasPreviousPage and hasNextPage', () => {
+      render(<Pagination {...defaultProps} hasPreviousPage={null} hasNextPage={null} />);
+
+      expect(screen.getByRole('button', { name: "labels.previousPage" })).toBeDisabled();
+      expect(screen.getByRole('button', { name: "labels.nextPage" })).toBeDisabled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper ARIA labels', () => {
+      render(<Pagination {...defaultProps} />);
+
+      expect(screen.getByRole('navigation', { name: /pagination/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: "labels.previousPage" })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: "labels.nextPage" })).toBeInTheDocument();
+    });
+
+    it('should have proper aria-setsize and aria-posinset attributes', () => {
+      render(<Pagination {...defaultProps} totalPages={5} />);
+
+      const listItems = screen.getAllByRole('listitem');
+      const pageItems = listItems.filter(item => !item.hasAttribute('aria-hidden'));
+
+      pageItems.forEach((item) => {
+        expect(item).toHaveAttribute('aria-setsize', '5');
+        expect(item).toHaveAttribute('aria-posinset');
+      });
+    });
+
+    it('should hide ellipsis from screen readers', () => {
+      render(<Pagination {...defaultProps} currentPage={10} totalPages={20} />);
+
+      const ellipsisElements = screen.getAllByText('…');
+      ellipsisElements.forEach(ellipsis => {
+        expect(ellipsis.closest('li')).toHaveAttribute('aria-hidden', 'true');
+      });
+    });
+
+
+    it('should pass axe accessibility test', async () => {
+      const { container } = render(<Pagination {...defaultProps} currentPage={10} totalPages={20} />);
+
+      await act(async () => {
+        const results = await axe(container);
+        expect(results).toHaveNoViolations();
+      });
+    });
+  });
+});

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -1,0 +1,39 @@
+'use client';
+import React from 'react';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  hasPreviousPage: boolean | null;
+  hasNextPage: boolean | null;
+  fetchTemplates: (page: number) => Promise<void>
+}
+
+export default function Pagination({ currentPage, totalPages, hasPreviousPage, hasNextPage, fetchTemplates }: PaginationProps) {
+  return (
+    <div>
+      <button onClick={() => fetchTemplates(currentPage - 1)} disabled={!hasPreviousPage}>
+        Prev
+      </button>
+
+      {[...Array(totalPages)].map((_, index) => {
+        const page = index + 1;
+        return (
+          <button
+            key={page}
+            data-page={page}
+            data-current={currentPage}
+            onClick={() => fetchTemplates(page)}
+            disabled={page === currentPage}
+          >
+            {page}
+          </button>
+        );
+      })}
+
+      <button onClick={() => fetchTemplates(currentPage + 1)} disabled={!hasNextPage}>
+        Next
+      </button>
+    </div>
+  );
+}

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -6,41 +6,36 @@ interface PaginationProps {
   totalPages: number;
   hasPreviousPage: boolean | null;
   hasNextPage: boolean | null;
-  bestPractice?: boolean;
-  selectedOwnerURIs?: string[];
-  fetchTemplates: (args: {
-    page?: number;
-    bestPractice?: boolean;
-    selectedOwnerURIs?: string[]
-  }) => Promise<void>;
-
+  handlePageClick: (page: number) => void;
 }
 
-export default function Pagination({ currentPage, totalPages, hasPreviousPage, hasNextPage, bestPractice, selectedOwnerURIs, fetchTemplates }: PaginationProps) {
+export default function Pagination({ currentPage, totalPages, hasPreviousPage, hasNextPage, handlePageClick }: PaginationProps) {
   return (
     <div>
-      <button onClick={async () => await fetchTemplates({ page: currentPage - 1, bestPractice, selectedOwnerURIs })} disabled={!hasPreviousPage}>
+      <button onClick={async () => handlePageClick(currentPage - 1)} disabled={!hasPreviousPage}>
         Prev
       </button>
 
-      {[...Array(totalPages)].map((_, index) => {
-        const page = index + 1;
-        return (
-          <button
-            key={page}
-            data-page={page}
-            data-current={currentPage}
-            onClick={async () => await fetchTemplates({ page, bestPractice, selectedOwnerURIs })}
-            disabled={page === currentPage}
-          >
-            {page}
-          </button>
-        );
-      })}
+      {
+        [...Array(totalPages)].map((_, index) => {
+          const page = index + 1;
+          return (
+            <button
+              key={page}
+              data-page={page}
+              data-current={currentPage}
+              onClick={async () => handlePageClick(page)}
+              disabled={page === currentPage}
+            >
+              {page}
+            </button>
+          );
+        })
+      }
 
-      <button onClick={async () => await fetchTemplates({ page: currentPage + 1 })} disabled={!hasNextPage}>
+      <button onClick={async () => handlePageClick(currentPage - 1)} disabled={!hasNextPage}>
         Next
       </button>
-    </div>
+    </div >
   );
 }

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -33,7 +33,7 @@ export default function Pagination({ currentPage, totalPages, hasPreviousPage, h
         })
       }
 
-      <button onClick={async () => handlePageClick(currentPage - 1)} disabled={!hasNextPage}>
+      <button onClick={async () => handlePageClick(currentPage + 1)} disabled={!hasNextPage}>
         Next
       </button>
     </div >

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -6,13 +6,20 @@ interface PaginationProps {
   totalPages: number;
   hasPreviousPage: boolean | null;
   hasNextPage: boolean | null;
-  fetchTemplates: (page: number) => Promise<void>
+  bestPractice?: boolean;
+  selectedOwnerURIs?: string[];
+  fetchTemplates: (args: {
+    page?: number;
+    bestPractice?: boolean;
+    selectedOwnerURIs?: string[]
+  }) => Promise<void>;
+
 }
 
-export default function Pagination({ currentPage, totalPages, hasPreviousPage, hasNextPage, fetchTemplates }: PaginationProps) {
+export default function Pagination({ currentPage, totalPages, hasPreviousPage, hasNextPage, bestPractice, selectedOwnerURIs, fetchTemplates }: PaginationProps) {
   return (
     <div>
-      <button onClick={() => fetchTemplates(currentPage - 1)} disabled={!hasPreviousPage}>
+      <button onClick={async () => await fetchTemplates({ page: currentPage - 1, bestPractice, selectedOwnerURIs })} disabled={!hasPreviousPage}>
         Prev
       </button>
 
@@ -23,7 +30,7 @@ export default function Pagination({ currentPage, totalPages, hasPreviousPage, h
             key={page}
             data-page={page}
             data-current={currentPage}
-            onClick={() => fetchTemplates(page)}
+            onClick={async () => await fetchTemplates({ page, bestPractice, selectedOwnerURIs })}
             disabled={page === currentPage}
           >
             {page}
@@ -31,7 +38,7 @@ export default function Pagination({ currentPage, totalPages, hasPreviousPage, h
         );
       })}
 
-      <button onClick={() => fetchTemplates(currentPage + 1)} disabled={!hasNextPage}>
+      <button onClick={async () => await fetchTemplates({ page: currentPage + 1 })} disabled={!hasNextPage}>
         Next
       </button>
     </div>

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 import React from 'react';
+import { useTranslations } from 'next-intl';
+
 
 interface PaginationProps {
   currentPage: number;
@@ -10,14 +12,16 @@ interface PaginationProps {
 }
 
 export default function Pagination({ currentPage, totalPages, hasPreviousPage, hasNextPage, handlePageClick }: PaginationProps) {
+  // Localization keys
+  const Global = useTranslations('Global');
   return (
-    <div>
+    <nav aria-label="pagination" id="pagination">
       <button onClick={async () => handlePageClick(currentPage - 1)} disabled={!hasPreviousPage}>
-        Prev
+        {Global('links.prev')}
       </button>
 
       {
-        [...Array(totalPages)].map((_, index) => {
+        [...Array(totalPages)].map((_, index: number) => {
           const page = index + 1;
           return (
             <button
@@ -34,8 +38,8 @@ export default function Pagination({ currentPage, totalPages, hasPreviousPage, h
       }
 
       <button onClick={async () => handlePageClick(currentPage + 1)} disabled={!hasNextPage}>
-        Next
+        {Global('links.next')}
       </button>
-    </div >
+    </nav>
   );
 }

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 import React from 'react';
 import { useTranslations } from 'next-intl';
-
+import { Button, Link } from "react-aria-components";
+import styles from './pagination.module.scss';
 
 interface PaginationProps {
   currentPage: number;
@@ -11,35 +12,93 @@ interface PaginationProps {
   handlePageClick: (page: number) => void;
 }
 
-export default function Pagination({ currentPage, totalPages, hasPreviousPage, hasNextPage, handlePageClick }: PaginationProps) {
-  // Localization keys
+export default function Pagination({
+  currentPage,
+  totalPages,
+  hasPreviousPage,
+  hasNextPage,
+  handlePageClick
+}: PaginationProps) {
   const Global = useTranslations('Global');
+
+  const getPages = () => {
+    const pages: (number | string)[] = [];
+    const delta = 2; // pages around the current page
+
+    // Always show first page
+    pages.push(1);
+
+    // Show leading ellipsis if needed
+    if (currentPage - delta > 2) {
+      pages.push('ellipsis-start');
+    }
+
+    // Pages around current page
+    for (let i = Math.max(2, currentPage - delta); i <= Math.min(totalPages - 1, currentPage + delta); i++) {
+      pages.push(i);
+    }
+
+    // Show trailing ellipsis if needed
+    if (currentPage + delta < totalPages - 1) {
+      pages.push('ellipsis-end');
+    }
+
+    // Always show last page if not already shown
+    if (totalPages > 1) {
+      pages.push(totalPages);
+    }
+
+    return pages;
+  };
+
+  const pagesToRender = getPages();
+
   return (
-    <nav aria-label="pagination" id="pagination">
-      <button onClick={async () => handlePageClick(currentPage - 1)} disabled={!hasPreviousPage}>
+    <nav aria-label="pagination" className={styles.pagination}>
+      <Button
+        aria-label={Global('labels.previousPage')}
+        onClick={() => handlePageClick(currentPage - 1)}
+        isDisabled={!hasPreviousPage}
+      >
         {Global('links.prev')}
-      </button>
+      </Button>
 
-      {
-        [...Array(totalPages)].map((_, index: number) => {
-          const page = index + 1;
-          return (
-            <button
-              key={page}
-              data-page={page}
-              data-current={currentPage}
-              onClick={async () => handlePageClick(page)}
-              disabled={page === currentPage}
-            >
-              {page}
-            </button>
-          );
-        })
-      }
+      <ol>
+        {pagesToRender.map((page, index) => (
+          page === 'ellipsis-start' || page === 'ellipsis-end' ? (
+            <li key={page + index} aria-hidden="true" className={styles.ellipsis}>
+              &hellip;
+            </li>
+          ) : (
+            <li aria-setsize={totalPages} aria-posinset={Number(page)} key={page}>
+              <Link
+                className={(page === currentPage) ? styles.current : ""}
+                href="#"
+                aria-label={`Page ${page}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  handlePageClick(Number(page));
+                }}
+              >
+                {page}
+              </Link>
+            </li>
+          )
+        ))}
+      </ol>
 
-      <button onClick={async () => handlePageClick(currentPage + 1)} disabled={!hasNextPage}>
+      <Button
+        aria-label={Global('labels.nextPage')}
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          handlePageClick(currentPage + 1)
+        }
+        }
+        isDisabled={!hasNextPage}
+      >
         {Global('links.next')}
-      </button>
+      </Button>
     </nav>
   );
 }

--- a/components/Pagination/pagination.module.scss
+++ b/components/Pagination/pagination.module.scss
@@ -1,0 +1,84 @@
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-size: var(--fs-small);
+
+  // Navigation buttons
+  button {
+    margin: 0 0.3rem;
+    padding: 0.1rem 0.5rem;
+    background-color: var(--slate-500);
+    color: var(--slate-100);
+    border: none;
+    border-radius: 0.4rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.1s ease;
+
+    &:hover:not([disabled]),
+    &:focus-visible {
+      background-color: #333;
+      color: var(--slate-100);
+      outline: 2px solid #fff;
+      outline-offset: 2px;
+    }
+
+    &:active:not([disabled]) {
+      transform: scale(0.97);
+    }
+
+    &[disabled] {
+      background-color: #ccc;
+      color: #666;
+      cursor: not-allowed;
+    }
+  }
+
+  // Numbered page links
+  a {
+    border-radius: 0.4rem;
+    color: var(--slate-900);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+        font-weight: 700;
+    padding: 0.1rem 0.5rem;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+
+    &:hover,
+    &:focus-visible {
+      background-color: var(--slate-200);
+      outline: 2px solid var(--slate-900);
+      outline-offset: 2px;
+    }
+  }
+
+  // Current page styling
+  .current {
+    background-color: var(--highlight-background);
+    color: #fff;
+
+    &:hover,
+    &:focus-visible {
+      background-color: var(--slate-200);
+            color: var(--slate-900);
+      outline: 2px solid #fff;
+      outline-offset: 2px;
+    }
+  }
+
+  // Page list layout
+  ol {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    gap: 0.7rem;
+
+    li {
+      display: inline-block;
+    }
+  }
+}

--- a/components/Pagination/pagination.module.scss
+++ b/components/Pagination/pagination.module.scss
@@ -20,7 +20,7 @@
     &:focus-visible {
       background-color: var(--slate-500);
       color: var(--slate-100);
-      outline: 2px solid #fff;
+      outline: 2px solid var(--slate-100);
       outline-offset: 2px;
     }
 

--- a/components/Pagination/pagination.module.scss
+++ b/components/Pagination/pagination.module.scss
@@ -18,7 +18,7 @@
 
     &:hover:not([disabled]),
     &:focus-visible {
-      background-color: #333;
+      background-color: var(--slate-500);
       color: var(--slate-100);
       outline: 2px solid #fff;
       outline-offset: 2px;
@@ -29,8 +29,8 @@
     }
 
     &[disabled] {
-      background-color: #ccc;
-      color: #666;
+      background-color: var(--slate-200);
+      color: var(--slate-900);
       cursor: not-allowed;
     }
   }
@@ -64,7 +64,7 @@
     &:focus-visible {
       background-color: var(--slate-200);
             color: var(--slate-900);
-      outline: 2px solid #fff;
+      outline: 2px solid var(--slate-100);
       outline-offset: 2px;
     }
   }

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -1444,6 +1444,8 @@ export type PaginatedQueryResults = {
 export type PaginationOptions = {
   /** The cursor to start the pagination from (used for cursor infinite scroll/load more only!) */
   cursor?: InputMaybe<Scalars['String']['input']>;
+  /** Specify that you want additional metadata, like whether the result set includes bestPractice options */
+  includeMetadata?: InputMaybe<Scalars['Boolean']['input']>;
   /** The number of items to return */
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** The number of items to skip before starting the pagination (used for standard offset pagination only!) */
@@ -2137,10 +2139,14 @@ export type ProjectSearchResults = PaginatedQueryResults & {
 
 export type PublishedTemplateSearchResults = PaginatedQueryResults & {
   __typename?: 'PublishedTemplateSearchResults';
+  /** The available affiliations in the result set */
+  availableAffiliations?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The sortFields that are available for this query (for standard offset pagination only!) */
   availableSortFields?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The current offset of the results (for standard offset pagination) */
   currentOffset?: Maybe<Scalars['Int']['output']>;
+  /** Whether the result set includes bestPractice templates */
+  hasBestPracticeTemplates?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a next page */
   hasNextPage?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a previous page */
@@ -4240,10 +4246,13 @@ export type MyVersionedTemplatesQueryVariables = Exact<{ [key: string]: never; }
 
 export type MyVersionedTemplatesQuery = { __typename?: 'Query', myVersionedTemplates?: Array<{ __typename?: 'VersionedTemplateSearchResult', id?: number | null, templateId?: number | null, name?: string | null, description?: string | null, visibility?: TemplateVisibility | null, bestPractice?: boolean | null, version?: string | null, modified?: string | null, modifiedById?: number | null, modifiedByName?: string | null, ownerId?: number | null, ownerURI?: string | null, ownerDisplayName?: string | null, ownerSearchName?: string | null } | null> | null };
 
-export type PublishedTemplatesQueryVariables = Exact<{ [key: string]: never; }>;
+export type PublishedTemplatesQueryVariables = Exact<{
+  paginationOptions?: InputMaybe<PaginationOptions>;
+  term?: InputMaybe<Scalars['String']['input']>;
+}>;
 
 
-export type PublishedTemplatesQuery = { __typename?: 'Query', publishedTemplates?: { __typename?: 'PublishedTemplateSearchResults', totalCount?: number | null, nextCursor?: string | null, items?: Array<{ __typename?: 'VersionedTemplateSearchResult', id?: number | null, templateId?: number | null, name?: string | null, description?: string | null, visibility?: TemplateVisibility | null, bestPractice?: boolean | null, version?: string | null, modified?: string | null, modifiedById?: number | null, modifiedByName?: string | null, ownerId?: number | null, ownerURI?: string | null, ownerDisplayName?: string | null, ownerSearchName?: string | null } | null> | null } | null };
+export type PublishedTemplatesQuery = { __typename?: 'Query', publishedTemplates?: { __typename?: 'PublishedTemplateSearchResults', limit?: number | null, nextCursor?: string | null, totalCount?: number | null, availableSortFields?: Array<string | null> | null, currentOffset?: number | null, hasNextPage?: boolean | null, hasPreviousPage?: boolean | null, hasBestPracticeTemplates?: boolean | null, availableAffiliations?: Array<string | null> | null, items?: Array<{ __typename?: 'VersionedTemplateSearchResult', id?: number | null, templateId?: number | null, name?: string | null, description?: string | null, visibility?: TemplateVisibility | null, bestPractice?: boolean | null, version?: string | null, modified?: string | null, modifiedById?: number | null, modifiedByName?: string | null, ownerId?: number | null, ownerURI?: string | null, ownerDisplayName?: string | null, ownerSearchName?: string | null } | null> | null } | null };
 
 export type TemplatesQueryVariables = Exact<{
   term?: InputMaybe<Scalars['String']['input']>;
@@ -7429,10 +7438,17 @@ export type MyVersionedTemplatesLazyQueryHookResult = ReturnType<typeof useMyVer
 export type MyVersionedTemplatesSuspenseQueryHookResult = ReturnType<typeof useMyVersionedTemplatesSuspenseQuery>;
 export type MyVersionedTemplatesQueryResult = Apollo.QueryResult<MyVersionedTemplatesQuery, MyVersionedTemplatesQueryVariables>;
 export const PublishedTemplatesDocument = gql`
-    query PublishedTemplates {
-  publishedTemplates {
-    totalCount
+    query PublishedTemplates($paginationOptions: PaginationOptions, $term: String) {
+  publishedTemplates(paginationOptions: $paginationOptions, term: $term) {
+    limit
     nextCursor
+    totalCount
+    availableSortFields
+    currentOffset
+    hasNextPage
+    hasPreviousPage
+    hasBestPracticeTemplates
+    availableAffiliations
     items {
       id
       templateId
@@ -7465,6 +7481,8 @@ export const PublishedTemplatesDocument = gql`
  * @example
  * const { data, loading, error } = usePublishedTemplatesQuery({
  *   variables: {
+ *      paginationOptions: // value for 'paginationOptions'
+ *      term: // value for 'term'
  *   },
  * });
  */

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -1442,6 +1442,8 @@ export type PaginatedQueryResults = {
 
 /** Pagination options, either cursor-based (inifite-scroll) or offset-based pagination (standard first, next, etc.) */
 export type PaginationOptions = {
+  /** Request just the bestPractice templates */
+  bestPractice?: InputMaybe<Scalars['Boolean']['input']>;
   /** The cursor to start the pagination from (used for cursor infinite scroll/load more only!) */
   cursor?: InputMaybe<Scalars['String']['input']>;
   /** Specify that you want additional metadata, like whether the result set includes bestPractice options */
@@ -1450,6 +1452,8 @@ export type PaginationOptions = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** The number of items to skip before starting the pagination (used for standard offset pagination only!) */
   offset?: InputMaybe<Scalars['Int']['input']>;
+  /** Request templates whose ownerIds match the provided array of ownerURIs */
+  selectOwnerURIs?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** The sort order (used for standard offset pagination only!) */
   sortDir?: InputMaybe<Scalars['String']['input']>;
   /** The sort field (used for standard offset pagination only!) */

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -1446,8 +1446,6 @@ export type PaginationOptions = {
   bestPractice?: InputMaybe<Scalars['Boolean']['input']>;
   /** The cursor to start the pagination from (used for cursor infinite scroll/load more only!) */
   cursor?: InputMaybe<Scalars['String']['input']>;
-  /** Specify that you want additional metadata, like whether the result set includes bestPractice options */
-  includeMetadata?: InputMaybe<Scalars['Boolean']['input']>;
   /** The number of items to return */
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** The number of items to skip before starting the pagination (used for standard offset pagination only!) */
@@ -2141,16 +2139,20 @@ export type ProjectSearchResults = PaginatedQueryResults & {
   totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
-export type PublishedTemplateSearchResults = PaginatedQueryResults & {
-  __typename?: 'PublishedTemplateSearchResults';
+export type PublishedTemplateMetaDataResults = {
+  __typename?: 'PublishedTemplateMetaDataResults';
   /** The available affiliations in the result set */
   availableAffiliations?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  /** Whether the result set includes bestPractice templates */
+  hasBestPracticeTemplates?: Maybe<Scalars['Boolean']['output']>;
+};
+
+export type PublishedTemplateSearchResults = PaginatedQueryResults & {
+  __typename?: 'PublishedTemplateSearchResults';
   /** The sortFields that are available for this query (for standard offset pagination only!) */
   availableSortFields?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The current offset of the results (for standard offset pagination) */
   currentOffset?: Maybe<Scalars['Int']['output']>;
-  /** Whether the result set includes bestPractice templates */
-  hasBestPracticeTemplates?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a next page */
   hasNextPage?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a previous page */
@@ -2258,6 +2260,8 @@ export type Query = {
   publishedSections?: Maybe<VersionedSectionSearchResults>;
   /** Search for VersionedTemplate whose name or owning Org's name contains the search term */
   publishedTemplates?: Maybe<PublishedTemplateSearchResults>;
+  /** Search for templates for lightweight info on what unique affiliations are in the data set, and whether any of them have best practice */
+  publishedTemplatesMetaData?: Maybe<PublishedTemplateMetaDataResults>;
   /** Get the specific Question based on questionId */
   question?: Maybe<Question>;
   /** Get the QuestionConditions that belong to a specific question */
@@ -2492,6 +2496,12 @@ export type QueryPublishedSectionsArgs = {
 
 
 export type QueryPublishedTemplatesArgs = {
+  paginationOptions?: InputMaybe<PaginationOptions>;
+  term?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPublishedTemplatesMetaDataArgs = {
   paginationOptions?: InputMaybe<PaginationOptions>;
   term?: InputMaybe<Scalars['String']['input']>;
 };
@@ -4256,7 +4266,15 @@ export type PublishedTemplatesQueryVariables = Exact<{
 }>;
 
 
-export type PublishedTemplatesQuery = { __typename?: 'Query', publishedTemplates?: { __typename?: 'PublishedTemplateSearchResults', limit?: number | null, nextCursor?: string | null, totalCount?: number | null, availableSortFields?: Array<string | null> | null, currentOffset?: number | null, hasNextPage?: boolean | null, hasPreviousPage?: boolean | null, hasBestPracticeTemplates?: boolean | null, availableAffiliations?: Array<string | null> | null, items?: Array<{ __typename?: 'VersionedTemplateSearchResult', id?: number | null, templateId?: number | null, name?: string | null, description?: string | null, visibility?: TemplateVisibility | null, bestPractice?: boolean | null, version?: string | null, modified?: string | null, modifiedById?: number | null, modifiedByName?: string | null, ownerId?: number | null, ownerURI?: string | null, ownerDisplayName?: string | null, ownerSearchName?: string | null } | null> | null } | null };
+export type PublishedTemplatesQuery = { __typename?: 'Query', publishedTemplates?: { __typename?: 'PublishedTemplateSearchResults', limit?: number | null, nextCursor?: string | null, totalCount?: number | null, availableSortFields?: Array<string | null> | null, currentOffset?: number | null, hasNextPage?: boolean | null, hasPreviousPage?: boolean | null, items?: Array<{ __typename?: 'VersionedTemplateSearchResult', id?: number | null, templateId?: number | null, name?: string | null, description?: string | null, visibility?: TemplateVisibility | null, bestPractice?: boolean | null, version?: string | null, modified?: string | null, modifiedById?: number | null, modifiedByName?: string | null, ownerId?: number | null, ownerURI?: string | null, ownerDisplayName?: string | null, ownerSearchName?: string | null } | null> | null } | null };
+
+export type PublishedTemplatesMetaDataQueryVariables = Exact<{
+  paginationOptions?: InputMaybe<PaginationOptions>;
+  term?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type PublishedTemplatesMetaDataQuery = { __typename?: 'Query', publishedTemplatesMetaData?: { __typename?: 'PublishedTemplateMetaDataResults', hasBestPracticeTemplates?: boolean | null, availableAffiliations?: Array<string | null> | null } | null };
 
 export type TemplatesQueryVariables = Exact<{
   term?: InputMaybe<Scalars['String']['input']>;
@@ -7451,8 +7469,6 @@ export const PublishedTemplatesDocument = gql`
     currentOffset
     hasNextPage
     hasPreviousPage
-    hasBestPracticeTemplates
-    availableAffiliations
     items {
       id
       templateId
@@ -7506,6 +7522,48 @@ export type PublishedTemplatesQueryHookResult = ReturnType<typeof usePublishedTe
 export type PublishedTemplatesLazyQueryHookResult = ReturnType<typeof usePublishedTemplatesLazyQuery>;
 export type PublishedTemplatesSuspenseQueryHookResult = ReturnType<typeof usePublishedTemplatesSuspenseQuery>;
 export type PublishedTemplatesQueryResult = Apollo.QueryResult<PublishedTemplatesQuery, PublishedTemplatesQueryVariables>;
+export const PublishedTemplatesMetaDataDocument = gql`
+    query PublishedTemplatesMetaData($paginationOptions: PaginationOptions, $term: String) {
+  publishedTemplatesMetaData(paginationOptions: $paginationOptions, term: $term) {
+    hasBestPracticeTemplates
+    availableAffiliations
+  }
+}
+    `;
+
+/**
+ * __usePublishedTemplatesMetaDataQuery__
+ *
+ * To run a query within a React component, call `usePublishedTemplatesMetaDataQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePublishedTemplatesMetaDataQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePublishedTemplatesMetaDataQuery({
+ *   variables: {
+ *      paginationOptions: // value for 'paginationOptions'
+ *      term: // value for 'term'
+ *   },
+ * });
+ */
+export function usePublishedTemplatesMetaDataQuery(baseOptions?: Apollo.QueryHookOptions<PublishedTemplatesMetaDataQuery, PublishedTemplatesMetaDataQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PublishedTemplatesMetaDataQuery, PublishedTemplatesMetaDataQueryVariables>(PublishedTemplatesMetaDataDocument, options);
+      }
+export function usePublishedTemplatesMetaDataLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PublishedTemplatesMetaDataQuery, PublishedTemplatesMetaDataQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PublishedTemplatesMetaDataQuery, PublishedTemplatesMetaDataQueryVariables>(PublishedTemplatesMetaDataDocument, options);
+        }
+export function usePublishedTemplatesMetaDataSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<PublishedTemplatesMetaDataQuery, PublishedTemplatesMetaDataQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<PublishedTemplatesMetaDataQuery, PublishedTemplatesMetaDataQueryVariables>(PublishedTemplatesMetaDataDocument, options);
+        }
+export type PublishedTemplatesMetaDataQueryHookResult = ReturnType<typeof usePublishedTemplatesMetaDataQuery>;
+export type PublishedTemplatesMetaDataLazyQueryHookResult = ReturnType<typeof usePublishedTemplatesMetaDataLazyQuery>;
+export type PublishedTemplatesMetaDataSuspenseQueryHookResult = ReturnType<typeof usePublishedTemplatesMetaDataSuspenseQuery>;
+export type PublishedTemplatesMetaDataQueryResult = Apollo.QueryResult<PublishedTemplatesMetaDataQuery, PublishedTemplatesMetaDataQueryVariables>;
 export const TemplatesDocument = gql`
     query Templates($term: String, $paginationOptions: PaginationOptions) {
   myTemplates(term: $term, paginationOptions: $paginationOptions) {

--- a/graphql/queries/templateVersions.query.graphql
+++ b/graphql/queries/templateVersions.query.graphql
@@ -37,10 +37,17 @@ query MyVersionedTemplates {
   }
 }
 
-query PublishedTemplates {
-  publishedTemplates {
-    totalCount
+query PublishedTemplates($paginationOptions: PaginationOptions, $term: String) {
+  publishedTemplates(paginationOptions: $paginationOptions, term: $term) {
+    limit
     nextCursor
+    totalCount
+    availableSortFields
+    currentOffset
+    hasNextPage
+    hasPreviousPage
+    hasBestPracticeTemplates
+    availableAffiliations
     items {
       id
       templateId

--- a/graphql/queries/templateVersions.query.graphql
+++ b/graphql/queries/templateVersions.query.graphql
@@ -46,8 +46,6 @@ query PublishedTemplates($paginationOptions: PaginationOptions, $term: String) {
     currentOffset
     hasNextPage
     hasPreviousPage
-    hasBestPracticeTemplates
-    availableAffiliations
     items {
       id
       templateId
@@ -64,5 +62,12 @@ query PublishedTemplates($paginationOptions: PaginationOptions, $term: String) {
       ownerDisplayName
       ownerSearchName
     }
+  }
+}
+
+query PublishedTemplatesMetaData($paginationOptions: PaginationOptions, $term: String) {
+  publishedTemplatesMetaData(paginationOptions: $paginationOptions, term: $term) {
+    hasBestPracticeTemplates
+    availableAffiliations
   }
 }

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -225,7 +225,9 @@
       "startDate": "Start date",
       "endDate": "End date",
       "funderSearch": "Search by funder name",
-      "requiredField": "Mark as required?"
+      "requiredField": "Mark as required?",
+      "previousPage": "Previous page",
+      "nextPage": "Next page"
     },
     "helpText": {
       "searchHelpText": "Search by research organization, field station or lab, template description, etc.",
@@ -245,7 +247,7 @@
       "expand": "Expand",
       "collapse": "Collapse",
       "editTitle": "Edit title",
-      "prev": "Prev",
+      "prev": "Previous",
       "next": "Next"
     },
     "messaging": {

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -244,7 +244,9 @@
       "update": "Update",
       "expand": "Expand",
       "collapse": "Collapse",
-      "editTitle": "Edit title"
+      "editTitle": "Edit title",
+      "prev": "Prev",
+      "next": "Next"
     },
     "messaging": {
       "loading": "Loading",

--- a/messages/en-US/planBuilderProjectOverview.json
+++ b/messages/en-US/planBuilderProjectOverview.json
@@ -260,7 +260,7 @@
     "para1": "When you click <strong>Grant access</strong> we'll send an email to this person inviting them to view your plan.",
     "para2": "If they aren't already a member of we'll invite them to join.",
     "para3": "We have sent an invite to <strong>{email}</strong>. They will have access to this project.",
-    "para4": "To also add them as a Project Member, <projectmember> go to the Project Members page </projectmember>.",
+    "para4": "To also add them as a Project Member, &lt;projectmember&gt; go to the Project Members page &lt;/projectmember&gt;.",
     "para5": "They will have access to {access} DMPs in this project.",
     "messaging": {
       "errors": {

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -126,7 +126,7 @@
     "addManuallyLabel": "Adicionar professor manualmente",
     "messages": {
       "success": {
-        "addProjectFunding": "Adicionou o financiador ao projeto com sucesso."
+        "addProjectFunding": "O financiador foi adicionado ao projeto com sucesso."
       }
     }
   },
@@ -177,7 +177,7 @@
       "projects": "Projetos",
       "projectOverview": "Visão geral do projeto",
       "projectFunding": "Orçamento do projeto",
-      "projectFundingSearch": "Pesquisa de financiamento de projetos",
+      "projectFundingSearch": "Pesquisa de financiamento de projeto",
       "planOverview": "Resumo do plano",
       "planFunding": "Financiamento do plano",
       "feedback": "Registrar",
@@ -195,8 +195,8 @@
     "editTitle": "Editar título",
     "bestPractice": "Melhores práticas por",
     "dataDescription": "Descrição dos dados",
-    "dataFormat": "Formato de dados",
-    "dataVolume": "Volume de dados",
+    "dataFormat": "Formato de dados:",
+    "dataVolume": "Volume dos dados",
     "buttons": {
       "search": "Buscar",
       "select": "Select",
@@ -218,14 +218,16 @@
       "preview": "Pré-visualizar",
       "publish": "Publicar",
       "close": "Fechar",
-      "loadMore": "Carregar mais..."
+      "loadMore": "Carregar mais"
     },
     "labels": {
       "searchByKeyword": "Pesquisar por palavra-chave",
       "startDate": "Data de início",
       "endDate": "Data final",
       "funderSearch": "Pesquisar por nome do financiador",
-      "requiredField": "Marcar como obrigatório?"
+      "requiredField": "Marcar como obrigatório?",
+      "previousPage": "Página anterior",
+      "nextPage": "Próxima página"
     },
     "helpText": {
       "searchHelpText": "Pesquisar por organização de pesquisa, estação de campo ou laboratório, descrição de modelo, etc.",
@@ -244,7 +246,9 @@
       "update": "Atualização",
       "expand": "Expandir",
       "collapse": "Recolher",
-      "editTitle": "Editar título"
+      "editTitle": "Editar título",
+      "prev": "Voltar",
+      "next": "Seguinte"
     },
     "messaging": {
       "loading": "Baixar",
@@ -260,7 +264,8 @@
         "invalidQuestionType": "Tipo de questão inválido encontrado.",
         "questionUnexpectedFormat": "Formato inesperado para question.json.",
         "questionJSONFParseFailed": "JSON.parse falhou."
-      }
+      },
+      "numDisplaying": "Mostrando {num} de {total}"
     },
     "tabs": {
       "editQuestion": "Editar pergunta",
@@ -276,8 +281,8 @@
       "textArea": "Área de texto",
       "radioButtons": "Botão de opção",
       "checkBoxes": "Caixa de verificação",
-      "selectBox": "Selecione",
-      "multiselectBox": "Seleção múltipla",
+      "selectBox": "Select",
+      "multiselectBox": "Caixa multi-seleção",
       "boolean": "Boleano",
       "number": "Número",
       "numberRange": "Intervalo de números",
@@ -288,7 +293,7 @@
       "dateRange": "Intervalo de datas",
       "filteredSearch": "Pesquisa com filtros",
       "table": "Tabela",
-      "affiliationSearch": "Pesquisa de Afiliação"
+      "affiliationSearch": "Affiliation search"
     }
   }
 }

--- a/messages/pt-BR/planBuilderPlanOverview.json
+++ b/messages/pt-BR/planBuilderPlanOverview.json
@@ -58,7 +58,7 @@
       "updateSection": "Editar: {title}"
     },
     "errors": {
-      "invalidDmpId": "ID DMP inválido: O ID DMP fornecido não é válido.",
+      "invalidDmpId": "ID DMP inválido: O ID de DMP fornecido não é válido.",
       "sectionNotFound": "Seção não encontrada: Esta seção não pertence ao plano atual."
     },
     "status": {

--- a/messages/pt-BR/planBuilderProjectOverview.json
+++ b/messages/pt-BR/planBuilderProjectOverview.json
@@ -156,6 +156,28 @@
       }
     }
   },
+  "ProjectsProjectFundingAdd": {
+    "title": "Adicionar detalhes de financiamento",
+    "description": "Adicionar manualmente uma nova fonte de financiamento",
+    "labels": {
+      "funderName": "Nome da planta",
+      "fundingStatus": "Status do financiamento",
+      "grantNumber": "Conceder número/url",
+      "projectNumber": "Número ou ID do projeto",
+      "opportunity": "No. de Prêmio Oportunidade/Federal"
+    },
+    "messages": {
+      "errors": {
+        "projectFundingUpdateFailed": "Erro ao atualizar detalhes do financiador do projeto",
+        "fundingGrantId": "Valor de ID do financiador inválido",
+        "fundingProjectNumber": "Valor inválido do número do projeto financiador",
+        "fundingName": "Valor do nome do financiador inválido"
+      },
+      "success": {
+        "projectFundingUpdated": "Detalhes do financiador do projeto atualizados com sucesso"
+      }
+    }
+  },
   "ProjectsProjectMembers": {
     "title": "Membros do Projeto",
     "description": "Defina contribuidores e membros da equipe e seu papel neste projeto.",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -248,3 +248,17 @@ body {
     top: 0;
   }
 }
+
+.clear-filter {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+
+.search-match-text {
+  font-size: var(--fs-small);
+  margin-top: var(--space-2);
+  margin-bottom: var(--space-2);
+}


### PR DESCRIPTION
## Description

This ticket was filed because the page never loaded more than the default 20 results that the backend started to return when it updated to use pagination queries.

- I updated the `Plan Create` page to use the new `pagination queries`, moving off of the manual `Load more` functionality we had in place
- Added use of `routePath` on page
- Added a new, accessible `Pagination` component, which is used in the updated `Plan Create` page. When adding the pagination, I tried to comply with the WCAG 2.5.5 `AA` tap size requirements of `24px x 24px`
- Updated unit test for `Plan Create` to use the `MockedProvider` and added some new unit tests
- Added translation keys

Fixes # ([686](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/686))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
This was tested manually, and with unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules

*** NOTE**: Since we switched to paginated data, the frontend only gets data in increments, but it needed to know whether the full set of data contained a `bestPractice` template, and also it needed the list of all the unique affiliations that would be in the total response, so that it would know whether to show the `affiliation/funder` checkboxes or `bestPractice` checkbox when the page was rendered.

The PR for the backend change is here: https://github.com/CDLUC3/dmsp_backend_prototype/pull/379

The backend branch that I updated is `feature/JS-paginationOptions-update-to-include-additionalData-378`
 
## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 


## Business requirements
- Expected functionality is that if the project has funder, and there are published templates that match those funders, then the page will render with `funder checkboxes` initially checked, and the list of templates filtered to only show those funder templates
- If there are no funders, but the list of templates returned contain a `best practice` template, then a `Best practice` checkbox will be display when the page first renders, and the list of templates will be filtered to display only the `best practice` templates.
- If the project has no funders and no best practice templates, then no checkboxes will be displayed.
### Pagination
- Pagination can be tested on the page by clicking either the "Next" or "Previous" buttons to advance or reverse the pages, or users can click directly on a page. Ellipsis were used to prevent too many pages from showing at once.


## To Test
- Make sure you use the backend branch `feature/JS-paginationOptions-update-to-include-additionalData-378` with this branch
- You can add funders to your projects by clicking on the "Funders" link on the `Projects Overview` page and then clicking on `Add funders`
- To remove funders, you can go into the `projectFundings` db table and remove it from there
- To set templates as `bestPractice`, you can set the `bestPractice` field to `1` in the `versionedTemplates` table

- [ ] Test with projects that have funders
- [ ] Test with projects without funders
- [ ] Test with and without best practice templates
- [ ] Verify pagination works with different result set sizes
- [ ] Confirm filter combinations work as expected

## Screen recordings
### When project has `funders`


https://github.com/user-attachments/assets/512a9f69-67c9-425c-8e07-6473b03cac0b


### When project has no `funders` but has `best practice` templates

https://github.com/user-attachments/assets/349272da-b6a2-49ac-b91e-3d5023fb42c0

### When project has no `funders` and no `best practice` templates

https://github.com/user-attachments/assets/59c7f60b-3bf3-4d93-aa6b-8ef3f1ebe317

