### PR TITLE
(#489) Updated the CSS to allow wrapping tags

### DIFF
--- a/styles/form/_checkbox.scss
+++ b/styles/form/_checkbox.scss
@@ -23,7 +23,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-top: 0.3rem;
+    margin-top: 0.2rem;
   }
 
   svg {
@@ -77,7 +77,6 @@
 
   .react-aria-Checkbox {
     margin-bottom: 0.5rem;
-
   }
 
   label {
@@ -124,22 +123,31 @@
     }
   }
 
-
-  :global(.react-aria-Checkbox) {
-    margin-bottom: 0;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-
   .checkbox-wrapper {
     display: inline-flex;
     white-space: nowrap;
-    align-items: center;
+    align-items: start;
     gap: 0.25rem;
+
+    @media (max-width: 768px) {
+      white-space: wrap;
+    }
   }
 
+  @media (max-width: 460px) {
+    .checkbox-label {
+      display: flex;
+      flex: 1;
+    }
+
+    .checkbox-wrapper {
+      flex: 1;
+
+      > div {
+        flex: 1;
+      }
+    }
+  }
 }
 
 .react-aria-CheckboxGroup {
@@ -147,7 +155,7 @@
     .react-aria-Checkbox {
       margin-bottom: 0;
       display: inline-flex;
-      align-items: center;
+      align-items: start;
       gap: 0.5rem;
     }
   }


### PR DESCRIPTION
## Description

Allow for tags in the checkbox group to wrap when the screen size is small.
Also added a bit better alignment of the info buttons on the smaller sizes.

Fixes #489

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Only did manual testing in the browser, resizing the view to different widths
  to see the final result.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have completed manual or automated accessibility testing for my changes
- [ ] New and existing unit tests pass locally with my changes

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
