### PR TITLE
[Bug fix] - Stripped HTML tags from question text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Updated the funding-search page on the create project step to link to the new page to add the funder manually [#497]
 
 ### Fixed
+- Updated the `stripHtmlTags` function to include an option to strip only specific tags [#662]
+- Updated the `Question details` page to strip the `questionText` of `HTML` tags [#662]
 - Added `Load more` functionality for `/projects` page, using the new pagination [#647]
 - Addressed issue where templates on `/projects/7/dmp/create` were showing `Not published`. They are all `versionedTemplates` so they are `published` [#646] d
 - Fixed bug when hovering over the `Back` button turns text white (essentially invisible) [#651]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 ### Added
+- Added `.js` extension to `import nextJest from "next/jest.js";` in `jest.config.ts` to remove errors when running `npm test`[#662]
 - Added JSON mocks to `__mocks__` for all types of versioned questions (for use with the project/plan pages)
 - Hooked up the Project Funding Search page at `/projects/[projectId]/fundings/search` [#606]
 - Added auto-save to the `Question Answer` page [#585]

--- a/__mocks__/common/mockPublishedQuestionDataForTextArea.json
+++ b/__mocks__/common/mockPublishedQuestionDataForTextArea.json
@@ -15,7 +15,7 @@
       "versionedTemplateId": null
     },
     "displayOrder": 3,
-    "questionText": "Text area question",
+    "questionText": "<p>Text area question</p>",
     "json": "{\"meta\":{\"asRichText\":true,\"schemaVersion\":\"1.0\"},\"type\":\"textArea\",\"attributes\":{\"cols\":20,\"rows\":20,\"maxLength\":1000,\"minLength\":0}}",
     "requirementText": "<p><strong>Requirements - Lorem Ipsum</strong>&nbsp;is simply dummy requirements text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>",
     "sampleText": "<p>Sample text <strong>Lorem Ipsum</strong>&nbsp;is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>",

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/__tests__/page.spec.tsx
@@ -124,20 +124,27 @@ const MOCKS = [
       data: {
         updatePlanFunding: [
           {
+            __typename: "PlanFunding",
             errors: {
+              __typename: "PlanFundingErrors",
               ProjectFundingId: null,
               general: null,
+              planId: null, 
             },
             projectFunding: {
+              __typename: "ProjectFunding",
               id: 111,
             }
           },
           {
             errors: {
+              __typename: "PlanFundingErrors",
               ProjectFundingId: null,
               general: null,
+              planId: null
             },
             projectFunding: {
+              __typename: "ProjectFunding",
               id: 222,
             }
           },
@@ -160,11 +167,15 @@ const MOCKS = [
       data: {
         updatePlanFunding: [
           {
+            __typename: "PlanFunding",
             errors: {
+              __typename: "PlanFundingErrors",
               ProjectFundingId: null,
               general: "This should throw an error",
+              planId: null, 
             },
             projectFunding: {
+              __typename: "ProjectFunding",
               id: 222,
             }
 
@@ -198,11 +209,15 @@ const MOCKS = [
       data: {
         updatePlanFunding: [
           {
+            __typename: "PlanFunding",
             errors: {
+              __typename: "PlanFundingErrors",
               ProjectFundingId: null,
               general: "This should throw an error",
+              planId: null, 
             },
             projectFunding: {
+              __typename: "ProjectFunding",
               id: null,
             }
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
@@ -213,6 +213,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
 
     // Check that question card is in the page with correct question details
     expect(screen.getByTestId('question-card')).toBeInTheDocument();
+    // Should strip out HTML tags for the Question Text
     expect(screen.getByRole('heading', { level: 2, name: 'Text area question' })).toBeInTheDocument();
     const requirementsByFunder = screen.getByText('page.requiredByFunder');
     expect(requirementsByFunder).toBeInTheDocument();

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
@@ -51,6 +51,7 @@ import { useToast } from '@/context/ToastContext';
 // Utils
 import logECS from '@/utils/clientLogger';
 import { routePath } from '@/utils/routes';
+import { stripHtmlTags } from '@/utils/general';
 import { QuestionTypeMap } from '@dmptool/types';
 
 import {
@@ -311,7 +312,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
     if (htmlString) {
       const sanitizedHTML = DOMPurify.sanitize(htmlString);
       return (
-          <div dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />
+        <div dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />
       );
     }
     return null;
@@ -419,7 +420,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
 
   // Handler for date change
   const handleDateChange = (
-      value: string | DateValue | CalendarDate | null
+    value: string | DateValue | CalendarDate | null
   ) => {
     setFormData(prev => ({
       ...prev,
@@ -430,8 +431,8 @@ const PlanOverviewQuestionPage: React.FC = () => {
 
   // Handler for date range changes
   const handleDateRangeChange = (
-      key: string,
-      value: string | DateValue | CalendarDate | null
+    key: string,
+    value: string | DateValue | CalendarDate | null
   ) => {
     setFormData(prev => ({
       ...prev,
@@ -517,8 +518,8 @@ const PlanOverviewQuestionPage: React.FC = () => {
         break;
       case 'multiselectBox':
         setFormData(prev => ({
-        ...prev,
-        selectedMultiSelectValues: new Set(answer)
+          ...prev,
+          selectedMultiSelectValues: new Set(answer)
         }));
         break;
       case 'boolean':
@@ -710,14 +711,14 @@ const PlanOverviewQuestionPage: React.FC = () => {
   // GraphQL mutation returns errors
   const hasFieldLevelErrors = (mutationErrors: MutationErrorsInterface): boolean => {
     return Object.values(mutationErrors).some(
-        value => value !== null && value !== undefined
+      value => value !== null && value !== undefined
     );
   };
 
   // Extract the errors from the graphql mutation result
   const getExtractedErrorValues = (mutationErrors: MutationErrorsInterface): string[] => {
     return Object.values(mutationErrors).filter(
-        (value) => value !== null && value !== undefined
+      (value) => value !== null && value !== undefined
     );
   };
 
@@ -735,16 +736,16 @@ const PlanOverviewQuestionPage: React.FC = () => {
     if (selectedQuestion) {
       try {
         const response = isUpdate
-            ? await updateAnswerAction({
-              answerId: Number(answerData?.answerByVersionedQuestionId?.id),
-              json: JSON.stringify(jsonPayload),
-            })
-            : await addAnswerAction({
-              planId: Number(dmpId),
-              versionedSectionId: Number(versionedSectionId),
-              versionedQuestionId: Number(versionedQuestionId),
-              json: JSON.stringify(jsonPayload),
-            });
+          ? await updateAnswerAction({
+            answerId: Number(answerData?.answerByVersionedQuestionId?.id),
+            json: JSON.stringify(jsonPayload),
+          })
+          : await addAnswerAction({
+            planId: Number(dmpId),
+            versionedSectionId: Number(versionedSectionId),
+            versionedQuestionId: Number(versionedQuestionId),
+            json: JSON.stringify(jsonPayload),
+          });
 
         if (response.redirect) {
           router.push(response.redirect);
@@ -1050,297 +1051,295 @@ const PlanOverviewQuestionPage: React.FC = () => {
   }
 
   return (
-      <>
-        <PageHeader
-            title={plan?.title ?? ''}
-            description=""
-            showBackButton={true}
-            breadcrumbs={
-              <Breadcrumbs aria-label={PlanOverview('navigation.navigation')}>
-                <Breadcrumb><Link
-                    href="/en-US">{PlanOverview('navigation.home')}</Link></Breadcrumb>
-                <Breadcrumb><Link
-                    href="/en-US/projects">{PlanOverview('navigation.projects')}</Link></Breadcrumb>
-                <Breadcrumb><Link href={`/en-US/projects/${projectId}/`}>{Global('breadcrumbs.projectOverview')}</Link></Breadcrumb>
-                <Breadcrumb><Link
-                    href={`/en-US/projects/${projectId}/dmp/${dmpId}/`}>{plan?.title}</Link></Breadcrumb>
-                <Breadcrumb>{Global('breadcrumbs.questionDetails')}</Breadcrumb>
-              </Breadcrumbs>
-            }
-            actions={null}
-            className="page-project-list"
-        />
+    <>
+      <PageHeader
+        title={plan?.title ?? ''}
+        description=""
+        showBackButton={true}
+        breadcrumbs={
+          <Breadcrumbs aria-label={PlanOverview('navigation.navigation')}>
+            <Breadcrumb><Link href={routePath('app.home')}>{Global('breadcrumbs.home')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.index')}>{Global('breadcrumbs.projects')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.show', { projectId })}>{Global('breadcrumbs.projectOverview')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.dmp.show', { projectId, dmpId })}>{Global('breadcrumbs.planOverview')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('projects.dmp.versionedSection', { projectId, dmpId, versionedSectionId })}>{Global('breadcrumbs.sectionOverview')}</Link></Breadcrumb>
+            <Breadcrumb>{Global('breadcrumbs.questionDetails')}</Breadcrumb>
+          </Breadcrumbs>
+        }
+        actions={null}
+        className="page-project-list"
+      />
 
-        <ErrorMessages errors={errors} ref={errorRef} />
+      <ErrorMessages errors={errors} ref={errorRef} />
 
-        <LayoutWithPanel
-            onClick={e => closeDrawers(e)}
-            className={classNames('layout-mask', { 'drawer-open': isSampleTextDrawerOpen || isCommentsDrawerOpen })}
-        >
-          <ContentContainer>
-            <div className="container">
-              {/**Requirements by funder */}
-              {question?.requirementText && (
-                  <section aria-label={PlanOverview('page.requirementsBy', { funder: plan?.funder ?? '' })}>
-                    <h3 className={"h4"}>{PlanOverview('page.requirementsBy', { funder: plan?.funder ?? '' })}</h3>
-                    {convertToHTML(question?.requirementText)}
-                  </section>
-              )}
-
-              {/**Requirements by organization */}
-              <section aria-label={"Requirements"}>
-                <h3 className={"h4"}>Requirements by University of California</h3>
-                <p>
-                  The university requires data and metadata to be cleared by the ethics
-                  committee before being submitted to funder.
-                </p>
+      <LayoutWithPanel
+        onClick={e => closeDrawers(e)}
+        className={classNames('layout-mask', { 'drawer-open': isSampleTextDrawerOpen || isCommentsDrawerOpen })}
+      >
+        <ContentContainer>
+          <div className="container">
+            {/**Requirements by funder */}
+            {question?.requirementText && (
+              <section aria-label={PlanOverview('page.requirementsBy', { funder: plan?.funder ?? '' })}>
+                <h3 className={"h4"}>{PlanOverview('page.requirementsBy', { funder: plan?.funder ?? '' })}</h3>
+                {convertToHTML(question?.requirementText)}
               </section>
+            )}
 
-              <p className={styles.guidanceLinkWrapper}>
-                <DmpIcon icon="down_arrow" />
-                <Link href="#guidance" className={`${styles.guidanceLink} react-aria-Link`}>{PlanOverview('page.jumpToGuidance')}</Link>
+            {/**Requirements by organization */}
+            <section aria-label={"Requirements"}>
+              <h3 className={"h4"}>Requirements by University of California</h3>
+              <p>
+                The university requires data and metadata to be cleared by the ethics
+                committee before being submitted to funder.
               </p>
-              <Form onSubmit={handleSubmit}>
-                <Card data-testid='question-card'>
-                  <span>Question</span>
-                  <h2 id="question-title" className="h3">
-                    {question?.questionText}
-                  </h2>
-                  {question?.required && (
-                      <div className={styles.requiredWrapper}>
-                        <div><strong>{PlanOverview('page.requiredByFunder')}</strong></div>
-                        <DialogTrigger>
-                          <Button className={`${styles.popOverButton} react-aria-Button`} aria-label="Required by funder"><div className={styles.infoIcon}><DmpIcon icon="info" /></div></Button>
-                          <Popover>
-                            <OverlayArrow>
-                              <svg width={12} height={12} viewBox="0 0 12 12">
-                                <path d="M0 0 L6 6 L12 0" />
-                              </svg>
-                            </OverlayArrow>
-                            <Dialog>
-                              <div className="flex-col">
-                                {PlanOverview('page.requiredByFunderInfo')}
-                              </div>
-                            </Dialog>
-                          </Popover>
-                        </DialogTrigger>
-                      </div>
-                  )}
-                  <div>
-                    <div className={styles.buttonsRow}>
-                      {/**Only include sample text button for textArea question types */}
-                      {questionType === 'textArea' && (
-                          <div className="">
-                            <Button
-                                ref={openSampleTextButtonRef}
-                                className={`${styles.buttonSmall} tertiary`}
-                                data-secondary
-                                onPress={toggleSampleTextDrawer}
-                            >
-                              {PlanOverview('page.viewSampleAnswer')}
-                            </Button>
-                          </div>
-                      )}
+            </section>
 
+            <p className={styles.guidanceLinkWrapper}>
+              <DmpIcon icon="down_arrow" />
+              <Link href="#guidance" className={`${styles.guidanceLink} react-aria-Link`}>{PlanOverview('page.jumpToGuidance')}</Link>
+            </p>
+            <Form onSubmit={handleSubmit}>
+              <Card data-testid='question-card'>
+                <span>Question</span>
+                <h2 id="question-title" className="h3">
+                  {stripHtmlTags(question?.questionText)}
+                </h2>
+                {question?.required && (
+                  <div className={styles.requiredWrapper}>
+                    <div><strong>{PlanOverview('page.requiredByFunder')}</strong></div>
+                    <DialogTrigger>
+                      <Button className={`${styles.popOverButton} react-aria-Button`} aria-label="Required by funder"><div className={styles.infoIcon}><DmpIcon icon="info" /></div></Button>
+                      <Popover>
+                        <OverlayArrow>
+                          <svg width={12} height={12} viewBox="0 0 12 12">
+                            <path d="M0 0 L6 6 L12 0" />
+                          </svg>
+                        </OverlayArrow>
+                        <Dialog>
+                          <div className="flex-col">
+                            {PlanOverview('page.requiredByFunderInfo')}
+                          </div>
+                        </Dialog>
+                      </Popover>
+                    </DialogTrigger>
+                  </div>
+                )}
+                <div>
+                  <div className={styles.buttonsRow}>
+                    {/**Only include sample text button for textArea question types */}
+                    {questionType === 'textArea' && (
                       <div className="">
                         <Button
-                            ref={openCommentsButtonRef}
-                            className={`${styles.buttonSmall} ${styles.buttonWithComments}`}
-                            onPress={toggleCommentsDrawer}
+                          ref={openSampleTextButtonRef}
+                          className={`${styles.buttonSmall} tertiary`}
+                          data-secondary
+                          onPress={toggleSampleTextDrawer}
                         >
-                          4 Comments
+                          {PlanOverview('page.viewSampleAnswer')}
                         </Button>
                       </div>
-                    </div>
-                    {parsed && questionField}
+                    )}
 
-                  </div>
-                  <div className="lastSaved mt-5"
-                       aria-live="polite"
-                       role="status">
-                    {getLastSavedText()}
-                  </div>
-                </Card>
-
-                <section aria-label={"Guidance"} id="guidance">
-                  <h3 className={"h4"}>{PlanOverview('page.guidanceBy', { funder: plan?.funder ?? '' })}</h3>
-
-                  {convertToHTML(question?.guidanceText)}
-
-
-                  <h3 className={"h4"}>Guidance by University of California</h3>
-                  <p>
-                    This is the most detailed section of the data management plan.
-                    Describe the categories of data being collected and how they tie
-                    into the data associated with the methods used to collect that
-                    data.
-                  </p>
-                  <p>
-                    Expect this section to be the most detailed section, taking up a
-                    large portion of your data management plan document.
-                  </p>
-                </section>
-                <div className={styles.modalAction}>
-                  <div>
-                    <Button
-                        type="submit"
-                        data-secondary
-                        className="primary"
-                        aria-label={PlanOverview('labels.saveAnswer')}
-                        aria-disabled={isSubmitting}
-                    >
-                      {isSubmitting ? Global('buttons.saving') : Global('buttons.save')}
-                    </Button>
-                  </div>
-                  <div>
-                    <Button
-                        className="secondary"
-                        aria-label={PlanOverview('labels.returnToSection')}
-                        onPress={() => handleBackToSection()}
-                    >
-                      {PlanOverview('buttons.backToSection')}
-                    </Button>
-                  </div>
-
-                </div>
-              </Form>
-            </div>
-          </ContentContainer >
-
-          <SidebarPanel isOpen={isSideBarPanelOpen}>
-
-            <div className={styles.headerWithLogo}>
-              <h2 className="h4">{Global('bestPractice')}</h2>
-              <Image
-                  className={styles.Logo}
-                  src="/images/DMP-logo.svg"
-                  width="140"
-                  height="16"
-                  alt="DMP Tool"
-              />
-            </div>
-
-
-            <ExpandableContentSection
-                id="data-description"
-                heading={Global('dataDescription')}
-                expandLabel={Global('links.expand')}
-                summaryCharLimit={200}
-            >
-              <p>
-                Give a summary of the data you will collect or create, noting the content, coverage and data type, e.g., tabular data, survey data, experimental measurements, models, software, audiovisual data, physical samples, etc.
-              </p>
-              <p>
-                Consider how your data could complement and integrate with existing data, or whether there are any existing data or methods that you could reuse.
-              </p>
-              <p>
-                Indicate which data are of long-term value and should be shared and/or preserved.
-
-              </p>
-              <p>
-                If purchasing or reusing existing data, explain how issues such as copyright and IPR have been addressed. You should aim to minimize any restrictions on the reuse (and subsequent sharing) of third-party data.
-
-              </p>
-
-            </ExpandableContentSection>
-
-            <ExpandableContentSection
-                id="data-format"
-                heading={Global('dataFormat')}
-                expandLabel={Global('links.expand')}
-                summaryCharLimit={200}
-
-            >
-              <p>
-                Clearly note what format(s) your data will be in, e.g., plain text (.txt), comma-separated values (.csv), geo-referenced TIFF (.tif, .tfw).
-              </p>
-
-            </ExpandableContentSection>
-
-            <ExpandableContentSection
-                id="data-volume"
-                heading={Global('dataVolume')}
-                expandLabel={Global('links.expand')}
-                summaryCharLimit={200}
-            >
-              <p>
-                Note what volume of data you will create in MB/GB/TB. Indicate the proportions of raw data, processed data, and other secondary outputs (e.g., reports).
-              </p>
-              <p>
-                Consider the implications of data volumes in terms of storage, access, and preservation. Do you need to include additional costs?
-              </p>
-              <p>
-                Consider whether the scale of the data will pose challenges when sharing or transferring data between sites; if so, how will you address these challenges?
-              </p>
-            </ExpandableContentSection>
-          </SidebarPanel>
-
-          {/** Sample text drawer. Only include for question types = Text Area */}
-          {
-              questionType === 'textArea' && (
-                  <DrawerPanel
-                      isOpen={isSampleTextDrawerOpen}
-                      onClose={closeCurrentDrawer}
-                      returnFocusRef={openSampleTextButtonRef}
-                      className={styles.drawerPanelWrapper}
-                  >
-                    <h3>{question?.questionText}</h3>
-                    <h4 className={`${styles.deEmphasize} h5`}>{PlanOverview('page.funderSampleText', { funder: plan?.funderName ?? '' })}</h4>
-                    <div className={styles.sampleText}>
-                      {convertToHTML(question?.sampleText)}
-                    </div>
                     <div className="">
-                      <Button className={`${styles.buttonSmall}`} onPress={() => handleUseAnswer(question?.sampleText)}>{PlanOverview('buttons.useAnswer')}</Button>
+                      <Button
+                        ref={openCommentsButtonRef}
+                        className={`${styles.buttonSmall} ${styles.buttonWithComments}`}
+                        onPress={toggleCommentsDrawer}
+                      >
+                        4 Comments
+                      </Button>
                     </div>
-                  </DrawerPanel>
-              )
-          }
+                  </div>
+                  {parsed && questionField}
 
-
-          {/**Comments drawer */}
-          <DrawerPanel
-              isOpen={isCommentsDrawerOpen}
-              onClose={closeCurrentDrawer}
-              returnFocusRef={openCommentsButtonRef}
-              className={styles.drawerPanelWrapper}
-          >
-            <h2>{PlanOverview('headings.comments')}</h2>
-            <div className={styles.comment}>
-              <h4>John Smith</h4>
-              <p className={styles.deEmphasize}>2 days ago</p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-                ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                laboris nisi ut aliquip ex ea commodo consequat.
-              </p>
-            </div>
-
-            <div className={styles.comment}>
-              <h4>John Smith</h4>
-              <p className={styles.deEmphasize}>2 days ago</p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-                ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                laboris nisi ut aliquip ex ea commodo consequat.
-              </p>
-            </div>
-
-            <div className={styles.leaveComment}>
-              <h2>{PlanOverview('headings.leaveAComment')}</h2>
-              <Form onSubmit={(e) => handleAddComment(e)}>
-                <TextField>
-                  <Label>Frederick Cook (you)</Label>
-                  <TextArea />
-                </TextField>
-                <div>
-                  <Button type="submit" className={`${styles.buttonSmall}`}>{PlanOverview('buttons.comment')}</Button>
-                  <p>{PlanOverview('page.participantsWillBeNotified')}</p>
                 </div>
-              </Form>
-            </div>
-          </DrawerPanel>
-        </LayoutWithPanel >
-      </>
+                <div className="lastSaved mt-5"
+                  aria-live="polite"
+                  role="status">
+                  {getLastSavedText()}
+                </div>
+              </Card>
+
+              <section aria-label={"Guidance"} id="guidance">
+                <h3 className={"h4"}>{PlanOverview('page.guidanceBy', { funder: plan?.funder ?? '' })}</h3>
+
+                {convertToHTML(question?.guidanceText)}
+
+
+                <h3 className={"h4"}>Guidance by University of California</h3>
+                <p>
+                  This is the most detailed section of the data management plan.
+                  Describe the categories of data being collected and how they tie
+                  into the data associated with the methods used to collect that
+                  data.
+                </p>
+                <p>
+                  Expect this section to be the most detailed section, taking up a
+                  large portion of your data management plan document.
+                </p>
+              </section>
+              <div className={styles.modalAction}>
+                <div>
+                  <Button
+                    type="submit"
+                    data-secondary
+                    className="primary"
+                    aria-label={PlanOverview('labels.saveAnswer')}
+                    aria-disabled={isSubmitting}
+                  >
+                    {isSubmitting ? Global('buttons.saving') : Global('buttons.save')}
+                  </Button>
+                </div>
+                <div>
+                  <Button
+                    className="secondary"
+                    aria-label={PlanOverview('labels.returnToSection')}
+                    onPress={() => handleBackToSection()}
+                  >
+                    {PlanOverview('buttons.backToSection')}
+                  </Button>
+                </div>
+
+              </div>
+            </Form>
+          </div>
+        </ContentContainer >
+
+        <SidebarPanel isOpen={isSideBarPanelOpen}>
+
+          <div className={styles.headerWithLogo}>
+            <h2 className="h4">{Global('bestPractice')}</h2>
+            <Image
+              className={styles.Logo}
+              src="/images/DMP-logo.svg"
+              width="140"
+              height="16"
+              alt="DMP Tool"
+            />
+          </div>
+
+
+          <ExpandableContentSection
+            id="data-description"
+            heading={Global('dataDescription')}
+            expandLabel={Global('links.expand')}
+            summaryCharLimit={200}
+          >
+            <p>
+              Give a summary of the data you will collect or create, noting the content, coverage and data type, e.g., tabular data, survey data, experimental measurements, models, software, audiovisual data, physical samples, etc.
+            </p>
+            <p>
+              Consider how your data could complement and integrate with existing data, or whether there are any existing data or methods that you could reuse.
+            </p>
+            <p>
+              Indicate which data are of long-term value and should be shared and/or preserved.
+
+            </p>
+            <p>
+              If purchasing or reusing existing data, explain how issues such as copyright and IPR have been addressed. You should aim to minimize any restrictions on the reuse (and subsequent sharing) of third-party data.
+
+            </p>
+
+          </ExpandableContentSection>
+
+          <ExpandableContentSection
+            id="data-format"
+            heading={Global('dataFormat')}
+            expandLabel={Global('links.expand')}
+            summaryCharLimit={200}
+
+          >
+            <p>
+              Clearly note what format(s) your data will be in, e.g., plain text (.txt), comma-separated values (.csv), geo-referenced TIFF (.tif, .tfw).
+            </p>
+
+          </ExpandableContentSection>
+
+          <ExpandableContentSection
+            id="data-volume"
+            heading={Global('dataVolume')}
+            expandLabel={Global('links.expand')}
+            summaryCharLimit={200}
+          >
+            <p>
+              Note what volume of data you will create in MB/GB/TB. Indicate the proportions of raw data, processed data, and other secondary outputs (e.g., reports).
+            </p>
+            <p>
+              Consider the implications of data volumes in terms of storage, access, and preservation. Do you need to include additional costs?
+            </p>
+            <p>
+              Consider whether the scale of the data will pose challenges when sharing or transferring data between sites; if so, how will you address these challenges?
+            </p>
+          </ExpandableContentSection>
+        </SidebarPanel>
+
+        {/** Sample text drawer. Only include for question types = Text Area */}
+        {
+          questionType === 'textArea' && (
+            <DrawerPanel
+              isOpen={isSampleTextDrawerOpen}
+              onClose={closeCurrentDrawer}
+              returnFocusRef={openSampleTextButtonRef}
+              className={styles.drawerPanelWrapper}
+            >
+              <h3>{question?.questionText}</h3>
+              <h4 className={`${styles.deEmphasize} h5`}>{PlanOverview('page.funderSampleText', { funder: plan?.funderName ?? '' })}</h4>
+              <div className={styles.sampleText}>
+                {convertToHTML(question?.sampleText)}
+              </div>
+              <div className="">
+                <Button className={`${styles.buttonSmall}`} onPress={() => handleUseAnswer(question?.sampleText)}>{PlanOverview('buttons.useAnswer')}</Button>
+              </div>
+            </DrawerPanel>
+          )
+        }
+
+
+        {/**Comments drawer */}
+        <DrawerPanel
+          isOpen={isCommentsDrawerOpen}
+          onClose={closeCurrentDrawer}
+          returnFocusRef={openCommentsButtonRef}
+          className={styles.drawerPanelWrapper}
+        >
+          <h2>{PlanOverview('headings.comments')}</h2>
+          <div className={styles.comment}>
+            <h4>John Smith</h4>
+            <p className={styles.deEmphasize}>2 days ago</p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat.
+            </p>
+          </div>
+
+          <div className={styles.comment}>
+            <h4>John Smith</h4>
+            <p className={styles.deEmphasize}>2 days ago</p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat.
+            </p>
+          </div>
+
+          <div className={styles.leaveComment}>
+            <h2>{PlanOverview('headings.leaveAComment')}</h2>
+            <Form onSubmit={(e) => handleAddComment(e)}>
+              <TextField>
+                <Label>Frederick Cook (you)</Label>
+                <TextArea />
+              </TextField>
+              <div>
+                <Button type="submit" className={`${styles.buttonSmall}`}>{PlanOverview('buttons.comment')}</Button>
+                <p>{PlanOverview('page.participantsWillBeNotified')}</p>
+              </div>
+            </Form>
+          </div>
+        </DrawerPanel>
+      </LayoutWithPanel >
+    </>
   );
 }
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,4 @@
-import nextJest from "next/jest";
+import nextJest from "next/jest.js";
 import type { Config } from 'jest'
 
 const createJestConfig = nextJest({

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -180,6 +180,7 @@
       "projectFundingSearch": "Project funding search",
       "planOverview": "Plan overview",
       "planFunding": "Plan funding",
+      "sectionOverview": "Section overview",
       "feedback": "Feedback",
       "questionDetails": "Question details"
     },

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -179,6 +179,7 @@
       "projectFunding": "Orçamento do projeto",
       "projectFundingSearch": "Pesquisa de financiamento de projetos",
       "planOverview": "Resumo do plano",
+      "sectionOverview": "Visão geral da seção",
       "planFunding": "Financiamento do plano",
       "feedback": "Registrar",
       "questionDetails": "Detalhes da pergunta"

--- a/utils/general.ts
+++ b/utils/general.ts
@@ -34,13 +34,34 @@ export const stripHtml = (htmlString: string | null | undefined): string => {
 };
 
 /**
- * Removes all content enclosed in "<" and ">" brackets, including the brackets themselves.
- * @param input - The string to sanitize.
- * @returns The sanitized string.
+ * Strips HTML tags from a string.
+ * If `tagsToRemove` is provided, only those tags are stripped (inner text is preserved).
+ * If not provided, all HTML tags are stripped.
  */
-export const stripHtmlTags = (input: string): string => {
-  return input.replace(/<[^>]*>/g, '');
+export const stripHtmlTags = (input: string | null | undefined, tagsToRemove?: string[]): string => {
+  if (input && input.length > 0) {
+    if (tagsToRemove && tagsToRemove.length > 0) {
+      // Remove only the specified tags
+      const pattern = `<\\/?(?:${tagsToRemove.join('|')})\\b[^>]*>`;
+      const regex = new RegExp(pattern, 'gi');
+      return input.replace(regex, ' ');
+    } else {
+      // Remove all tags
+      return input.replace(/<[^>]*>/g, ' ');
+    }
+  }
+  return '';
 };
+
+// Examples:
+//console.log(stripHtmlTags('<p>Hello <b>world</b></p>')); 
+// "Hello world"
+
+//console.log(stripHtmlTags('<p>Hello <b>world</b></p>', ['p','b'])); 
+// "Hello world"
+
+
+
 
 export const toTitleCase = (str: string) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 


### PR DESCRIPTION
## Description

Although we previously added a function, `stripHtmlTags` to strip tags out of question and section text that was being added, we didn't implement that for question text that had been seeded. Since we will be migrating data from the current tool to the new rebuild, we will need to strip out HTML tags from the question text as well.

- Implemented `stripHtmlTags` on `question text` on the `Question Details` page
- Updated `stripHtmlTags` function to include an option to only remove specified tags
- Added `.js` extension to `next/jest.js` import in `jest.config.ts`, because it was causing errors related to ESM strict requirements when using node v22.18.0

Fixes # ([662](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/662))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested and unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
