### PR TITLE
[Bug fix] - Changed 'question' text to the correct `section` text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Updated the funding-search page on the create project step to link to the new page to add the funder manually [#497]
 
 ### Fixed
+- Fixed a bug on `Section` page where `question` text was used, when we should be referring to `section` instead [#666]
 - Added `Load more` functionality for `/projects` page, using the new pagination [#647]
 - Addressed issue where templates on `/projects/7/dmp/create` were showing `Not published`. They are all `versionedTemplates` so they are `published` [#646] d
 - Fixed bug when hovering over the `Back` button turns text white (essentially invisible) [#651]

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -171,9 +171,9 @@
     },
     "helpText": {
       "bestPracticeTagsDesc": "Select one or more tags to associate global best practice guidance written by DMP Tool.",
-      "sectionIntroduction": "Enter a short, concise introduction to the question.",
+      "sectionIntroduction": "Enter a short, concise introduction to the section.",
       "sectionRequirements": "Outline the requirements that a user must consider in this section.",
-      "sectionGuidance": "Provide users with helpful guidance to help them answer the question."
+      "sectionGuidance": "Provide users with helpful guidance to help them answer the questions in the section."
     }
   },
   "CreateSectionPage": {

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -171,9 +171,9 @@
     },
     "helpText": {
       "bestPracticeTagsDesc": "Selecione uma ou mais tags para associar a orientação de boas práticas globais escrita pela Ferramenta DMP.",
-      "sectionIntroduction": "Introduza uma introdução breve e concisa à pergunta.",
-      "sectionRequirements": "Esboça os requisitos que um usuário deve considerar nesta seção.",
-      "sectionGuidance": "Forneça aos usuários orientações úteis para ajudá-los a responder a pergunta."
+      "sectionIntroduction": "Insira uma introdução curta e concisa para a seção.",
+      "sectionRequirements": "Descreva os requisitos que um usuário deve considerar nesta seção.",
+      "sectionGuidance": "Forneça aos usuários orientações úteis para ajudá-los a responder às perguntas da seção."
     }
   },
   "CreateSectionPage": {


### PR DESCRIPTION
## Description

Small PR to fix the erroneous use of `question` text in the help text on the `Section` pages.
- Updated translation values.

Fixes # ([666](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/666))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manual testing


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshot of updated page

<img width="617" height="919" alt="image" src="https://github.com/user-attachments/assets/91ea942b-0f8a-42c2-82b1-f85a1be1d583" />
