### PR TITLE
[Bug fix] Fixed issue with saved data not loading on the Funding Detail 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Updated the funding-search page on the create project step to link to the new page to add the funder manually [#497]
 
 ### Fixed
+- Fixed issue with saved data not loading on the `Funding Detail` page after saving [#659]
 - Added `Load more` functionality for `/projects` page, using the new pagination [#647]
 - Addressed issue where templates on `/projects/7/dmp/create` were showing `Not published`. They are all `versionedTemplates` so they are `published` [#646] d
 - Fixed bug when hovering over the `Back` button turns text white (essentially invisible) [#651]

--- a/app/[locale]/projects/[projectId]/fundings/[projectFundingId]/edit/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/[projectFundingId]/edit/page.tsx
@@ -92,6 +92,11 @@ const ProjectsProjectFundingEdit = () => {
   const { data, loading, error: queryError, refetch } = useProjectFundingQuery(
     {
       variables: { projectFundingId: Number(projectFundingId) },
+      /*Needed to add this fetchPolicy so that users get fresh data when coming back to this page after editing because it was
+      previously showing stale data. I believe that it's ok to use this here because:
+      - Edit pages typically are low traffic
+      - Data accuracy is critical on form pages and we don't want users overwriting their changes*/
+      fetchPolicy: 'network-only',
       notifyOnNetworkStatusChange: true
     }
   );


### PR DESCRIPTION
## Description

When on the `Funding Detail` page for a funding source, data appeared to not be updated when a user made changes and saved. However, when we refreshed the page, we saw the new data. The problem was that we were seeing stale, cached data.

- Added `fetchPolicy: 'network-only'` to the funding query, so that it always loads fresh data.

I believe this is ok because edit pages are low traffic pages, and we need to make sure that users always see the latest data so that they don't overwrite existing data.

Fixes # ([659](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/659))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## To Test
1) Go to the Projects Overview page: `/projects/1`
2) Click on `Edit funding details` link
3) Click on the `Edit` button to edit the National Science Foundation funding source
4) Change some data and click `Save changes` button
5) You will be redirected to the `/projects/1/fundings` page. From there, click on the `Edit` button again for "National Science Foundation"
6) You should see your changes
