### PR TITLE
Added Comment functionality to the Question detail page to allow adding, editing and deleting comments

### DIFF
--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentList.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentList.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
-import { formatRelativeFromTimestamp } from '@/utils/dateUtils';
 import {
   Button,
   TextArea,
 } from "react-aria-components";
+import { useTranslations } from "next-intl";
 import { MergedComment } from '@/app/types';
+import { MeQuery } from '@/generated/graphql';
+import { formatRelativeFromTimestamp } from '@/utils/dateUtils';
+
 import styles from './PlanOverviewQuestionPage.module.scss';
 
 
 interface CommentListProps {
-  comments: any[];
+  comments: MergedComment[];
   editingCommentId: number | null | undefined;
   editingCommentText: string;
-  me: any;
+  me: MeQuery | null | undefined;
   planOwners: number[] | null | undefined;
-  t: any;
-  Global: any;
   handleEditComment: (comment: MergedComment) => void;
   handleUpdateComment: (comment: MergedComment) => void;
   handleCancelEdit: () => void;
@@ -31,8 +32,6 @@ const CommentList = React.memo(function CommentList(props: CommentListProps) {
     editingCommentText,
     me,
     planOwners,
-    t,
-    Global,
     handleEditComment,
     handleUpdateComment,
     handleCancelEdit,
@@ -40,6 +39,11 @@ const CommentList = React.memo(function CommentList(props: CommentListProps) {
     locale,
     setEditingCommentText,
   } = props;
+
+
+  // Localization
+  const Global = useTranslations('Global');
+  const t = useTranslations('PlanOverviewQuestionPage');
 
 
   const updateCommentHandler = (comment: MergedComment) => {

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentList.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentList.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { MergedComment } from '@/app/types';
 import { MeQuery } from '@/generated/graphql';
 import { formatRelativeFromTimestamp } from '@/utils/dateUtils';
+import ExpandableContentSection from '@/components/ExpandableContentSection';
 
 import styles from './PlanOverviewQuestionPage.module.scss';
 
@@ -85,7 +86,6 @@ const CommentList = React.memo(function CommentList(props: CommentListProps) {
               <TextArea
                 value={editingCommentText}
                 onChange={(e) => setEditingCommentText(e.target.value)}
-                className={styles.editTextarea}
                 rows={3}
                 ref={(el) => {
                   if (el) {
@@ -94,7 +94,18 @@ const CommentList = React.memo(function CommentList(props: CommentListProps) {
                 }}
               />
             ) : (
-              <p>{comment.commentText}</p>
+              <>
+                {/**When comments are lengthy, this is a way we can set a character limit, and show the Expand/Collapse links */}
+                <ExpandableContentSection
+                  id={`comment-text-${index}`}
+                  heading=""
+                  expandLabel={Global('links.expand')}
+                  summaryCharLimit={250}
+                >
+                  <p>{comment.commentText}</p>
+
+                </ExpandableContentSection>
+              </>
             )}
 
             <div>

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentList.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentList.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { formatRelativeFromTimestamp } from '@/utils/dateUtils';
+import {
+  Button,
+  TextArea,
+} from "react-aria-components";
+import { MergedComment } from '@/app/types';
+import styles from './PlanOverviewQuestionPage.module.scss';
+
+
+interface CommentListProps {
+  comments: any[];
+  editingCommentId: number | null | undefined;
+  editingCommentText: string;
+  me: any;
+  planOwners: number[] | null | undefined;
+  t: any;
+  Global: any;
+  handleEditComment: (comment: MergedComment) => void;
+  handleUpdateComment: (comment: MergedComment) => void;
+  handleCancelEdit: () => void;
+  handleDeleteComment: (comment: MergedComment) => void;
+  locale: string;
+  setEditingCommentText: (text: string) => void;
+}
+
+const CommentList = React.memo(function CommentList(props: CommentListProps) {
+  const {
+    comments,
+    editingCommentId,
+    editingCommentText,
+    me,
+    planOwners,
+    t,
+    Global,
+    handleEditComment,
+    handleUpdateComment,
+    handleCancelEdit,
+    handleDeleteComment,
+    locale,
+    setEditingCommentText,
+  } = props;
+
+
+  const updateCommentHandler = (comment: MergedComment) => {
+    if (!editingCommentText.trim()) {
+      return; // Prevent saving empty comments
+    }
+
+    handleUpdateComment({
+      ...comment,
+
+    });
+    setEditingCommentText(''); // Clear the editing text after saving
+  };
+  return (
+    <>
+      {comments?.map((comment, index) => {
+        // Replace useMemo with a simple variable
+        const formattedCreatedDate = comment.created
+          ? formatRelativeFromTimestamp(comment.created, locale)
+          : "";
+
+        const isEditing = editingCommentId === comment.id;
+
+        return (
+          <div key={`${comment.type}-${comment.id}-${index}`} className={styles.comment}>
+            <h4>
+              {comment?.user?.givenName}{' '}{comment?.user?.surName}{' '}
+              <span className={styles.deEmphasize}>
+                {comment?.isFeedbackComment ? `(${t('admin')})` : ''}
+              </span>
+            </h4>
+            <p className={`${styles.deEmphasize} ${styles.createdDate}`}>
+              {formattedCreatedDate}{' '}
+              {(comment.created !== comment.modified) ? `(${t('edited')})` : ''}
+            </p>
+
+            {/* Conditional rendering: textarea when editing, paragraph when not */}
+            {isEditing ? (
+              <TextArea
+                value={editingCommentText}
+                onChange={(e) => setEditingCommentText(e.target.value)}
+                className={styles.editTextarea}
+                rows={3}
+                ref={(el) => {
+                  if (el) {
+                    el.focus({ preventScroll: true }); {/**focus the text without scrolling. If we use autofocus, it will scroll the field behind the sticky Add Comment section */ }
+                  }
+                }}
+              />
+            ) : (
+              <p>{comment.commentText}</p>
+            )}
+
+            <div>
+              {isEditing ? (
+                <>
+                  <Button
+                    className={`${styles.deEmphasize} link`}
+                    type="button"
+                    onPress={() => updateCommentHandler(comment)}
+                  >
+                    {Global('buttons.save')}
+                  </Button>
+                  <Button
+                    className={`${styles.deEmphasize} link`}
+                    type="button"
+                    onPress={handleCancelEdit}
+                  >
+                    {Global('buttons.cancel')}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  {/**Only display edit button if it's the user's own comment */}
+                  {comment?.user?.id === me?.me?.id && (
+                    <Button
+                      className={`${styles.deEmphasize} link`}
+                      type="button"
+                      onPress={() => handleEditComment(comment)}
+                    >
+                      {Global('buttons.edit')}
+                    </Button>
+                  )}
+
+                  {/**Only display the delete button for the user who created the comment or a project collaborator with role 'OWN' */}
+                  {((comment?.user?.id === me?.me?.id) || planOwners?.includes(me?.me?.id as number)) && (
+                    <Button
+                      className={`${styles.deEmphasize} link`}
+                      type="button"
+                      onPress={() => handleDeleteComment(comment)}
+                    >
+                      {Global('buttons.delete')}
+                    </Button>
+                  )}
+
+                </>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+});
+
+export default CommentList;

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/Comments.md
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/Comments.md
@@ -1,0 +1,34 @@
+# Summary of Comment functionality
+
+There are a lot of rules around who can add, edit and delete comments on this page.
+
+The `Leave a comment` section is sticky at the bottom of the Drawer panel. The `Comments` header and `Close` button also remain at the top. The list of comments is scrollable, with lengthy comments having their own scroll
+
+## Initital page load
+When there are comments from either the `answerComments` or `feedbackComments` table for the given `answerId`, a user will see the `Comments` button showing the # of comments associated with the current `answerId`.
+
+## Displaying all comments
+When the user clicks on the `Comments` button, all available comments from the above tables will be displayed in chronological order. Comments from `ADMINS` and `SUPERADMINs` will be marked with `(ADMIN)` next to the admin name.
+
+## CommentsDrawer
+The Comments Drawer code was placed into its own `CommentsDrawer` component for cleaner code, and to make it easier to test.
+
+## Comments hook
+All comments handlers and associated states were consolidated into one hook at `hooks/useComment.tsx`.
+
+## Adding comments
+
+### ADMIN and SUPERADMIN
+If there are `feedback` rounds open for given `planId` in the `feedback` db table, and the user is an `ADMIN` or `SUPERADMIN` that belongs to the same org as the plan, then they can add comments.
+
+### Plan Owners
+If the user is the `creator` of the plan, or is a project collaborator with the `role="OWN"`, then they can add comments.
+
+### Project Collaborators
+If the user is a `project collaborator` they can also add comments.
+
+## Editing comments
+Only the user who added the comment can edit their own comment. An `edit` link will display under the user's comment, allowing them to edit it.
+
+## Deleting comments
+The creator of the plan can `delete` any comments. Users who added the comments can delete their own.

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentsDrawer.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentsDrawer.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import React from 'react';
+import {
+  Button,
+  Form,
+  Label,
+  TextArea,
+  TextField
+} from "react-aria-components";
+
+import {
+  MeQuery
+} from '@/generated/graphql';
+import styles from './PlanOverviewQuestionPage.module.scss';
+import { useTranslations } from "next-intl";
+import {
+
+  DrawerPanel
+} from "@/components/Container";
+
+// Utils
+import { formatRelativeFromTimestamp } from '@/utils/dateUtils';
+
+interface User {
+  __typename?: "User";
+  id?: number | null;
+  surName?: string | null;
+  givenName?: string | null;
+}
+
+// Simple merged comment interface - more flexible approach
+interface MergedComment {
+  __typename?: "AnswerComment" | "PlanFeedbackComment";
+  id?: number | null;
+  commentText?: string | null;
+  answerId?: number | null;
+  created?: string | null;
+  type: 'answer' | 'feedback';
+  isAnswerComment: boolean;
+  isFeedbackComment: boolean;
+
+  // Optional fields that may exist on either type
+  user?: User | null;
+  modified?: string | null;
+  PlanFeedback?: any | null;
+}
+
+interface CommentsDrawerProps {
+  isCommentsDrawerOpen: boolean;
+  closeCurrentDrawer: () => void;
+  openCommentsButtonRef: React.RefObject<HTMLButtonElement>;
+  mergedComments: MergedComment[];
+  editingCommentId: number | null | undefined;
+  editingCommentText: string;
+  setEditingCommentText: (text: string) => void;
+  handleUpdateComment: (comment: MergedComment) => void;
+  handleCancelEdit: () => void;
+  handleEditComment: (comment: MergedComment) => void;
+  handleDeleteComment: (comment: MergedComment) => void;
+  me: MeQuery | null | undefined;
+  planOwners: number[] | undefined | null;
+  locale: string;
+  commentsEndRef: React.RefObject<HTMLDivElement>;
+  canAddComments: boolean;
+  newCommentText: string;
+  setNewCommentText: (text: string) => void;
+  handleAddComment: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
+}
+
+
+const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
+  isCommentsDrawerOpen,
+  closeCurrentDrawer,
+  openCommentsButtonRef,
+  mergedComments,
+  editingCommentId,
+  editingCommentText,
+  setEditingCommentText,
+  handleUpdateComment,
+  handleCancelEdit,
+  handleEditComment,
+  handleDeleteComment,
+  me,
+  planOwners,
+  locale,
+  commentsEndRef,
+  canAddComments,
+  newCommentText,
+  setNewCommentText,
+  handleAddComment,
+}) => {
+
+  // Localization
+  const Global = useTranslations('Global');
+  const PlanOverview = useTranslations('PlanOverview');
+  const t = useTranslations('PlanOverviewQuestionPage');
+
+
+  return (
+    <>
+      {/**Comments drawer */}
+      <DrawerPanel
+        isOpen={isCommentsDrawerOpen}
+        onClose={closeCurrentDrawer}
+        returnFocusRef={openCommentsButtonRef}
+        className={styles.drawerPanelWrapper}
+        title={PlanOverview('headings.comments')}
+      >
+
+        <div className={styles.commentsWrapper}>
+          {mergedComments?.map((comment, index) => {
+            const formattedCreatedDate = comment.created ? formatRelativeFromTimestamp(comment.created, locale) : '';
+            const isEditing = editingCommentId === comment.id;
+
+            return (
+              <div key={`${comment.type}-${comment.id}-${index}`} className={styles.comment}>
+                <h4>
+                  {comment?.user?.givenName}{' '}{comment?.user?.surName}{' '}
+                  <span className={styles.deEmphasize}>
+                    {comment?.isFeedbackComment ? `(${t('admin')})` : ''}
+                  </span>
+                </h4>
+                <p className={`${styles.deEmphasize} ${styles.createdDate}`}>
+                  {formattedCreatedDate}{' '}
+                  {(comment.created !== comment.modified) ? `(${t('edited')})` : ''}
+                </p>
+
+                {/* Conditional rendering: textarea when editing, paragraph when not */}
+                {isEditing ? (
+                  <TextArea
+                    value={editingCommentText}
+                    onChange={(e) => setEditingCommentText(e.target.value)}
+                    className={styles.editTextarea}
+                    rows={3}
+                    ref={(el) => {
+                      if (el) {
+                        el.focus({ preventScroll: true }); {/**focus the text without scrolling. If we use autofocus, it will scroll the field behind the sticky Add Comment section */ }
+                      }
+                    }}
+                  />
+                ) : (
+                  <p>{comment.commentText}</p>
+                )}
+
+                <div>
+                  {isEditing ? (
+                    <>
+                      <Button
+                        className={`${styles.deEmphasize} link`}
+                        type="button"
+                        onPress={() => handleUpdateComment(comment)}
+                      >
+                        {Global('buttons.save')}
+                      </Button>
+                      <Button
+                        className={`${styles.deEmphasize} link`}
+                        type="button"
+                        onPress={handleCancelEdit}
+                      >
+                        {Global('buttons.cancel')}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      {/**Only display edit button if it's the user's own comment */}
+                      {comment?.user?.id === me?.me?.id && (
+                        <Button
+                          className={`${styles.deEmphasize} link`}
+                          type="button"
+                          onPress={() => handleEditComment(comment)}
+                        >
+                          {Global('buttons.edit')}
+                        </Button>
+                      )}
+
+                      {/**Only display the delete button for the user who created the comment or a project collaborator with role 'OWN' */}
+                      {((comment?.user?.id === me?.me?.id) || planOwners?.includes(me?.me?.id as number)) && (
+                        <Button
+                          className={`${styles.deEmphasize} link`}
+                          type="button"
+                          onPress={() => handleDeleteComment(comment)}
+                        >
+                          {Global('buttons.delete')}
+                        </Button>
+                      )}
+
+                    </>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+          <div ref={commentsEndRef} />
+        </div>
+
+
+        {/**Can only add comments if the user has the correct permissions */}
+        {canAddComments && (
+          <div className={styles.leaveComment}>
+            <h2>{PlanOverview('headings.leaveAComment')}</h2>
+            <Form onSubmit={(e) => handleAddComment(e)}>
+              <TextField className={styles.commentTextField}>
+                <Label>{me ? (`${me?.me?.givenName} ${me?.me?.surName}`) : ''}{' '}{`(${t('you')})`}</Label>
+                <TextArea
+                  onChange={e => setNewCommentText(e.target.value)}
+                  value={newCommentText}
+                  data-testid="new-comment-textarea"
+                />
+              </TextField>
+              <div className={styles.addCommentButton}>
+                <div>
+                  <Button type="submit" className={`${styles.buttonSmall}`}>{PlanOverview('buttons.comment')}</Button>
+                </div>
+                <p className="font-small">{PlanOverview('page.participantsWillBeNotified')}</p>
+              </div>
+            </Form>
+          </div>
+        )}
+
+      </DrawerPanel>
+    </>
+  );
+}
+
+export default CommentsDrawer;

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentsDrawer.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentsDrawer.tsx
@@ -19,7 +19,7 @@ import CommentList from './CommentList';
 import { MergedComment } from '@/app/types';
 
 
-interface CommentsDrawerProps {
+export interface CommentsDrawerProps {
   isCommentsDrawerOpen: boolean;
   closeCurrentDrawer: () => void;
   openCommentsButtonRef: React.RefObject<HTMLButtonElement>;
@@ -36,8 +36,6 @@ interface CommentsDrawerProps {
   locale: string;
   commentsEndRef: React.RefObject<HTMLDivElement>;
   canAddComments: boolean;
-  // newCommentText: string;
-  // setNewCommentText: (text: string) => void;
   handleAddComment: (e: React.FormEvent<HTMLFormElement>, newComment: string) => Promise<void>;
 }
 
@@ -97,8 +95,6 @@ const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
             editingCommentText={editingCommentText}
             me={me}
             planOwners={planOwners}
-            t={t}
-            Global={Global}
             handleEditComment={handleEditComment}
             handleUpdateComment={handleUpdateComment}
             handleCancelEdit={handleCancelEdit}
@@ -116,10 +112,11 @@ const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
             <h2>{PlanOverview('headings.leaveAComment')}</h2>
             <Form onSubmit={(e) => addCommentHandler(e)}>
               <TextField className={styles.commentTextField}>
-                <Label>{me ? (`${me?.me?.givenName} ${me?.me?.surName}`) : ''}{' '}{`(${t('you')})`}</Label>
+                <Label htmlFor="new-comment-textarea">{me ? (`${me?.me?.givenName} ${me?.me?.surName}`) : ''}{' '}{`(${t('you')})`}</Label>
                 <TextArea
                   onChange={e => setNewCommentText(e.target.value)}
                   value={newCommentText}
+                  id="new-comment-textarea"
                   data-testid="new-comment-textarea"
                 />
               </TextField>

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentsDrawer.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentsDrawer.tsx
@@ -63,7 +63,6 @@ const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
   const [newCommentText, setNewCommentText] = useState<string>('');
 
   // Localization
-  const Global = useTranslations('Global');
   const PlanOverview = useTranslations('PlanOverview');
   const t = useTranslations('PlanOverviewQuestionPage');
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
@@ -148,16 +148,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden; // Prevent outer scrolling
-  
-  // Override the DrawerPanel's default scrolling behavior
-  // Target the drawer-scrollable-content that wraps this component so that we can scroll comments list
-  // without seeing the scrollbar run alongside the sticky "Leave a comment" section
-  :global(.drawer-scrollable-content) {
-    overflow: hidden !important; // Disable the drawer's scrolling
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-  }
+
 }
 
 /* For link to jump down to Guidance section*/
@@ -229,11 +220,15 @@
   border-top: 1px solid var(--border-color, #e2e8f0); // Use a CSS variable or lighter color
   background-color: white;
   flex-shrink: 0; // Prevent shrinking
-  padding: 1rem;
+  padding: 0 1rem;
   position: sticky; // Keep this
   bottom: 0; // Stick to bottom
   z-index: 1; // Ensure it stays on top
   box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1); // Optional: add subtle shadow for separation
+
+  .commentTextField {
+  margin-bottom: 0.5rem;
+  }
 }
 
 .comment {
@@ -246,4 +241,10 @@
   .createdDate {
     margin: 0;
   }
+}
+
+.addCommentButton {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
@@ -241,19 +241,6 @@
   .createdDate {
     margin: 0;
   }
-
-  p {
-    max-height: 8rem; // so that users can scroll a long comment
-    overflow-y: auto;
-    white-space: pre-wrap; // preserve whitespace and line breaks
-    word-wrap: break-word; // break long words to fit within container
-    width: 90%; //to avoid overlap of scrollbars
-  }
-
-  .editTextarea {
-    max-height: 8rem;
-    overflow-y: auto;
-  }
 }
 
 .addCommentButton {

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
@@ -241,6 +241,19 @@
   .createdDate {
     margin: 0;
   }
+
+  p {
+    max-height: 8rem; // so that users can scroll a long comment
+    overflow-y: auto;
+    white-space: pre-wrap; // preserve whitespace and line breaks
+    word-wrap: break-word; // break long words to fit within container
+    width: 90%; //to avoid overlap of scrollbars
+  }
+
+  .editTextarea {
+    max-height: 8rem;
+    overflow-y: auto;
+  }
 }
 
 .addCommentButton {

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
@@ -195,7 +195,15 @@
 /*End 'Required by funder' info icon tooltip*/
 
 .comment {
-  margin-bottom: 3rem;
+  margin-bottom: var(--space-8);
+
+  h4 {
+    margin: 0;
+  }
+
+  .createdDate {
+    margin: 0;
+  }
 }
 
 .leaveComment {

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
@@ -55,7 +55,6 @@
   gap: 0.5rem;
 }
 
-
 /*Button styles*/
 // Wrapper for multiple buttons in a row
 .buttonsRow {
@@ -140,7 +139,7 @@
 // lighter font colors
 .deEmphasize {
   color: var(--text-color-placeholder);
-  font-weight: 300;
+  font-weight: 300 !important;
   font-size: var(--fs-small);
 }
 
@@ -194,3 +193,15 @@
   gap: 0.25rem;
 }
 /*End 'Required by funder' info icon tooltip*/
+
+.comment {
+  margin-bottom: 3rem;
+}
+
+.leaveComment {
+  border-top: 1px solid black;
+  margin-top: 2rem;
+  background-color: white;
+  position: sticky;
+  bottom: 0;
+}

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
@@ -144,9 +144,20 @@
 }
 
 .drawerPanelWrapper {
-  min-height: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: hidden; // Prevent outer scrolling
+  
+  // Override the DrawerPanel's default scrolling behavior
+  // Target the drawer-scrollable-content that wraps this component so that we can scroll comments list
+  // without seeing the scrollbar run alongside the sticky "Leave a comment" section
+  :global(.drawer-scrollable-content) {
+    overflow: hidden !important; // Disable the drawer's scrolling
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
 }
 
 /* For link to jump down to Guidance section*/
@@ -206,10 +217,33 @@
   }
 }
 
+.commentsWrapper {
+  flex: 1;
+  overflow-y: auto; // Only comments scroll
+  padding-right: 0.5rem; // To avoid scrollbar overlap
+  padding-bottom: 1rem; // Add some breathing room at bottom
+  min-height: 0; // Important: allows flex item to shrink below content size
+}
+
 .leaveComment {
-  border-top: 1px solid black;
-  margin-top: 2rem;
+  border-top: 1px solid var(--border-color, #e2e8f0); // Use a CSS variable or lighter color
   background-color: white;
-  position: sticky;
-  bottom: 0;
+  flex-shrink: 0; // Prevent shrinking
+  padding: 1rem;
+  position: sticky; // Keep this
+  bottom: 0; // Stick to bottom
+  z-index: 1; // Ensure it stays on top
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1); // Optional: add subtle shadow for separation
+}
+
+.comment {
+  margin-bottom: var(--space-8);
+
+  h4 {
+    margin: 0;
+  }
+
+  .createdDate {
+    margin: 0;
+  }
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__mocks__/mockMeQuery.json
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__mocks__/mockMeQuery.json
@@ -1,0 +1,35 @@
+{
+  "data": {
+    "me": {
+      "id": 1,
+      "givenName": "Super",
+      "surName": "Admin",
+      "languageId": "en-US",
+      "role": "SUPERADMIN",
+      "emails": [
+        {
+          "id": 16,
+          "email": "super@example.com",
+          "isPrimary": true,
+          "isConfirmed": true,
+          "__typename": "UserEmail"
+        }
+      ],
+      "errors": {
+        "general": null,
+        "email": null,
+        "password": null,
+        "role": null,
+        "__typename": "UserErrors"
+      },
+      "affiliation": {
+        "id": 1,
+        "name": "California Digital Library",
+        "searchName": "California Digital Library | cdlib.org | CDL ",
+        "uri": "https://ror.org/03yrm5c26",
+        "__typename": "Affiliation"
+      },
+      "__typename": "User"
+    }
+  }
+}

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__mocks__/mockMeQuery.json
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__mocks__/mockMeQuery.json
@@ -1,35 +1,33 @@
 {
-  "data": {
-    "me": {
+  "me": {
+    "id": 1,
+    "givenName": "Super",
+    "surName": "Admin",
+    "languageId": "en-US",
+    "role": "SUPERADMIN",
+    "emails": [
+      {
+        "id": 16,
+        "email": "super@example.com",
+        "isPrimary": true,
+        "isConfirmed": true,
+        "__typename": "UserEmail"
+      }
+    ],
+    "errors": {
+      "general": null,
+      "email": null,
+      "password": null,
+      "role": null,
+      "__typename": "UserErrors"
+    },
+    "affiliation": {
       "id": 1,
-      "givenName": "Super",
-      "surName": "Admin",
-      "languageId": "en-US",
-      "role": "SUPERADMIN",
-      "emails": [
-        {
-          "id": 16,
-          "email": "super@example.com",
-          "isPrimary": true,
-          "isConfirmed": true,
-          "__typename": "UserEmail"
-        }
-      ],
-      "errors": {
-        "general": null,
-        "email": null,
-        "password": null,
-        "role": null,
-        "__typename": "UserErrors"
-      },
-      "affiliation": {
-        "id": 1,
-        "name": "California Digital Library",
-        "searchName": "California Digital Library | cdlib.org | CDL ",
-        "uri": "https://ror.org/03yrm5c26",
-        "__typename": "Affiliation"
-      },
-      "__typename": "User"
-    }
+      "name": "California Digital Library",
+      "searchName": "California Digital Library | cdlib.org | CDL ",
+      "uri": "https://ror.org/03yrm5c26",
+      "__typename": "Affiliation"
+    },
+    "__typename": "User"
   }
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__mocks__/mockMergedComments.json
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__mocks__/mockMergedComments.json
@@ -1,0 +1,127 @@
+[
+  {
+    "__typename": "PlanFeedbackComment",
+    "id": 48,
+    "commentText": "Adding a new comment123",
+    "created": "1755557418000",
+    "answerId": 1,
+    "modified": "1755557423000",
+    "PlanFeedback": null,
+    "user": {
+      "__typename": "User",
+      "id": 1,
+      "surName": "Admin",
+      "givenName": "Super"
+    },
+    "type": "feedback",
+    "isAnswerComment": false,
+    "isFeedbackComment": true
+  },
+  {
+    "__typename": "PlanFeedbackComment",
+    "id": 49,
+    "commentText": "Adding an admin comment123",
+    "created": "1755562088000",
+    "answerId": 1,
+    "modified": "1755562092000",
+    "PlanFeedback": null,
+    "user": {
+      "__typename": "User",
+      "id": 1,
+      "surName": "Admin",
+      "givenName": "Super"
+    },
+    "type": "feedback",
+    "isAnswerComment": false,
+    "isFeedbackComment": true
+  },
+  {
+    "__typename": "PlanFeedbackComment",
+    "id": 50,
+    "commentText": "Leaving another admin comment",
+    "created": "1755562100000",
+    "answerId": 1,
+    "modified": "1755562100000",
+    "PlanFeedback": null,
+    "user": {
+      "__typename": "User",
+      "id": 1,
+      "surName": "Admin",
+      "givenName": "Super"
+    },
+    "type": "feedback",
+    "isAnswerComment": false,
+    "isFeedbackComment": true
+  },
+  {
+    "__typename": "AnswerComment",
+    "id": 13,
+    "commentText": "I want to add a comment by a researcher123",
+    "answerId": 1,
+    "created": "1755562145000",
+    "modified": "1755562155000",
+    "user": {
+      "__typename": "User",
+      "id": 7,
+      "surName": "Researcher",
+      "givenName": "UCD"
+    },
+    "type": "answer",
+    "isAnswerComment": true,
+    "isFeedbackComment": false
+  },
+  {
+    "__typename": "PlanFeedbackComment",
+    "id": 51,
+    "commentText": "New admin comment",
+    "created": "1755562431000",
+    "answerId": 1,
+    "modified": "1755562431000",
+    "PlanFeedback": null,
+    "user": {
+      "__typename": "User",
+      "id": 1,
+      "surName": "Admin",
+      "givenName": "Super"
+    },
+    "type": "feedback",
+    "isAnswerComment": false,
+    "isFeedbackComment": true
+  },
+  {
+    "__typename": "PlanFeedbackComment",
+    "id": 52,
+    "commentText": "Can the admin write another comment? Yes",
+    "created": "1755562673000",
+    "answerId": 1,
+    "modified": "1755562685000",
+    "PlanFeedback": null,
+    "user": {
+      "__typename": "User",
+      "id": 1,
+      "surName": "Admin",
+      "givenName": "Super"
+    },
+    "type": "feedback",
+    "isAnswerComment": false,
+    "isFeedbackComment": true
+  },
+  {
+    "__typename": "PlanFeedbackComment",
+    "id": 53,
+    "commentText": "Give a summary of the data you will collect or create, noting the content, coverage and data type, e.g., tabular data, survey data, experimental measurements, models, software, audiovisual data,...Give a summary of the data you will collect or create, noting the content, coverage and data type, e.g., tabular data, survey data, experimental measurements, models, software, audiovisual data,...",
+    "created": "1755615932000",
+    "answerId": 1,
+    "modified": "1755615932000",
+    "PlanFeedback": null,
+    "user": {
+      "__typename": "User",
+      "id": 1,
+      "surName": "Admin",
+      "givenName": "Super"
+    },
+    "type": "feedback",
+    "isAnswerComment": false,
+    "isFeedbackComment": true
+  }
+]

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentList.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentList.spec.tsx
@@ -16,24 +16,6 @@ jest.mock("@/utils/dateUtils", () => ({
   },
 }));
 
-// Mock react-aria-components
-jest.mock("react-aria-components", () => ({
-  Button: ({ children, onPress, className, type }: any) => (
-    <button onClick={onPress} className={className} type={type}>
-      {children}
-    </button>
-  ),
-  TextArea: React.forwardRef<HTMLTextAreaElement, any>(({ onChange, value, className, rows, ...props }, ref) => (
-    <textarea
-      onChange={onChange}
-      value={value}
-      className={className}
-      rows={rows}
-      ref={ref}
-      {...props}
-    />
-  )),
-}));
 
 const mockComments: MergedComment[] = [
   {
@@ -184,9 +166,20 @@ describe("CommentList", () => {
   });
 
   it("should not show edit/delete buttons for non-owned comments when user is not plan owner", () => {
+    const meResearcher = {
+      id: 99,
+      givenName: "Other",
+      surName: "User",
+      languageId: "en",
+      role: UserRole.Admin,
+      emails: [],
+      errors: {},
+      affiliation: { id: 1, name: "Test Org", searchName: "test-org", uri: "https://test.org" }
+    };
+
     const props = {
       ...defaultProps,
-      me: { me: { id: 99, givenName: "Other", surName: "User" } }, // Different user
+      me: { me: meResearcher }, // Correct shape
       planOwners: [1], // Not a plan owner
     };
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentList.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentList.spec.tsx
@@ -1,0 +1,385 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CommentList from "../CommentList";
+import type { MergedComment } from "@/app/types";
+import { UserRole } from '@/generated/graphql';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+expect.extend(toHaveNoViolations);
+
+
+// Mock the date utils
+jest.mock("@/utils/dateUtils", () => ({
+  formatRelativeFromTimestamp: (timestamp: string, locale: string) => {
+    return `${new Date(parseInt(timestamp)).toLocaleDateString()} (${locale})`;
+  },
+}));
+
+// Mock react-aria-components
+jest.mock("react-aria-components", () => ({
+  Button: ({ children, onPress, className, type }: any) => (
+    <button onClick={onPress} className={className} type={type}>
+      {children}
+    </button>
+  ),
+  TextArea: React.forwardRef<HTMLTextAreaElement, any>(({ onChange, value, className, rows, ...props }, ref) => (
+    <textarea
+      onChange={onChange}
+      value={value}
+      className={className}
+      rows={rows}
+      ref={ref}
+      {...props}
+    />
+  )),
+}));
+
+const mockComments: MergedComment[] = [
+  {
+    __typename: "AnswerComment",
+    id: 1,
+    commentText: "This is a regular comment",
+    answerId: 1,
+    created: "1672531200000", // Jan 1, 2023
+    modified: "1672531200000",
+    type: "answer",
+    isAnswerComment: true,
+    isFeedbackComment: false,
+    user: {
+      __typename: "User",
+      id: 7,
+      givenName: "John",
+      surName: "Doe"
+    },
+    PlanFeedback: null,
+  },
+  {
+    __typename: "PlanFeedbackComment",
+    id: 2,
+    commentText: "This is an admin feedback comment",
+    answerId: 1,
+    created: "1672617600000", // Jan 2, 2023
+    modified: "1672704000000", // Jan 3, 2023 (edited)
+    type: "feedback",
+    isAnswerComment: false,
+    isFeedbackComment: true,
+    user: {
+      __typename: "User",
+      id: 1,
+      givenName: "Admin",
+      surName: "User"
+    },
+    PlanFeedback: null,
+  },
+  {
+    __typename: "AnswerComment",
+    id: 3,
+    commentText: "Another user's comment",
+    answerId: 1,
+    created: "1672790400000", // Jan 4, 2023
+    modified: "1672790400000",
+    type: "answer",
+    isAnswerComment: true,
+    isFeedbackComment: false,
+    user: {
+      __typename: "User",
+      id: 8,
+      givenName: "Jane",
+      surName: "Smith"
+    },
+    PlanFeedback: null,
+  },
+];
+
+describe("CommentList", () => {
+  const defaultProps = {
+    comments: mockComments,
+    editingCommentId: null,
+    editingCommentText: "",
+    me: {
+      me: {
+        id: 7,
+        givenName: "John",
+        surName: "Doe",
+        languageId: "en",
+        role: UserRole.Admin,
+        emails: [],
+        errors: {},
+        affiliation: { id: 1, name: "Test Org", searchName: "test-org", uri: "https://test.org" }
+      }
+    },
+    planOwners: [1, 7], // Current user and admin are plan owners
+    handleEditComment: jest.fn(),
+    handleUpdateComment: jest.fn(),
+    handleCancelEdit: jest.fn(),
+    handleDeleteComment: jest.fn(),
+    locale: "en",
+    setEditingCommentText: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render all comments", () => {
+    render(<CommentList {...defaultProps} />);
+
+    expect(screen.getByText("This is a regular comment")).toBeInTheDocument();
+    expect(screen.getByText("This is an admin feedback comment")).toBeInTheDocument();
+    expect(screen.getByText("Another user's comment")).toBeInTheDocument();
+  });
+
+  it("should display user names correctly", () => {
+    render(<CommentList {...defaultProps} />);
+
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("Admin User")).toBeInTheDocument();
+    expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+  });
+
+  it("should show admin indicator for feedback comments", () => {
+    render(<CommentList {...defaultProps} />);
+
+    // Should show admin indicator for feedback comment
+    expect(screen.getByText("(admin)")).toBeInTheDocument();
+
+    // Should only appear once (only one feedback comment)
+    expect(screen.getAllByText("(admin)")).toHaveLength(1);
+  });
+
+  it("should display formatted creation dates", () => {
+    render(<CommentList {...defaultProps} />);
+
+    expect(screen.getByText(/1\/1\/2023 \(en\)/)).toBeInTheDocument();
+    expect(screen.getByText(/1\/3\/2023 \(en\)/)).toBeInTheDocument();
+    expect(screen.getByText(/12\/31\/2022 \(en\)/)).toBeInTheDocument();
+  });
+
+  it("should show edited indicator when comment was modified", () => {
+    render(<CommentList {...defaultProps} />);
+
+    // Only the second comment has different created/modified dates
+    expect(screen.getByText(/\(edited\)/)).toBeInTheDocument();
+    expect(screen.getAllByText(/\(edited\)/)).toHaveLength(1);
+  });
+
+  it("should show edit button only for user's own comments", () => {
+    render(<CommentList {...defaultProps} />);
+
+    const editButtons = screen.getAllByText("buttons.edit");
+    // Should only show edit button for the current user's comment (id: 7)
+    expect(editButtons).toHaveLength(1);
+  });
+
+  it("should show delete button for own comments and plan owners", () => {
+    render(<CommentList {...defaultProps} />);
+
+    const deleteButtons = screen.getAllByText("buttons.delete");
+    // Current user (id: 7) can delete their own comment
+    // Plan owners can delete any comment
+    // In our test case: user 7 is both comment owner and plan owner
+    // So we should see delete buttons for comments where user is owner or plan owner
+    expect(deleteButtons.length).toBeGreaterThan(0);
+  });
+
+  it("should not show edit/delete buttons for non-owned comments when user is not plan owner", () => {
+    const props = {
+      ...defaultProps,
+      me: { me: { id: 99, givenName: "Other", surName: "User" } }, // Different user
+      planOwners: [1], // Not a plan owner
+    };
+
+    render(<CommentList {...props} />);
+
+    // Should not show any edit buttons (user doesn't own any comments)
+    expect(screen.queryByText("buttons.edit")).not.toBeInTheDocument();
+
+    // Should not show any delete buttons (user doesn't own comments and isn't plan owner)
+    expect(screen.queryByText("buttons.delete")).not.toBeInTheDocument();
+  });
+
+  it("should call handleEditComment when edit button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CommentList {...defaultProps} />);
+
+    const editButton = screen.getByText("buttons.edit");
+    await user.click(editButton);
+
+    expect(defaultProps.handleEditComment).toHaveBeenCalledWith(mockComments[0]);
+  });
+
+  it("should call handleDeleteComment when delete button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CommentList {...defaultProps} />);
+
+    const deleteButtons = screen.getAllByText("buttons.delete");
+    await user.click(deleteButtons[0]);
+
+    expect(defaultProps.handleDeleteComment).toHaveBeenCalledWith(expect.any(Object));
+  });
+
+  describe("when editing a comment", () => {
+    const editingProps = {
+      ...defaultProps,
+      editingCommentId: 1,
+      editingCommentText: "Editing this comment",
+    };
+
+    it("should show textarea instead of comment text", () => {
+      render(<CommentList {...editingProps} />);
+
+      expect(screen.getByDisplayValue("Editing this comment")).toBeInTheDocument();
+      expect(screen.queryByText("This is a regular comment")).not.toBeInTheDocument();
+    });
+
+    it("should show save and cancel buttons", () => {
+      render(<CommentList {...editingProps} />);
+
+      expect(screen.getByText("buttons.save")).toBeInTheDocument();
+      expect(screen.getByText("buttons.cancel")).toBeInTheDocument();
+    });
+
+    it("should hide edit and delete buttons when editing", () => {
+      render(<CommentList {...editingProps} />);
+
+      // Should not show edit/delete buttons for the comment being edited
+      expect(screen.queryByText("buttons.edit")).not.toBeInTheDocument();
+    });
+
+    it("should call setEditingCommentText when textarea value changes", async () => {
+      render(<CommentList {...editingProps} />);
+
+      const textarea = screen.getByDisplayValue("Editing this comment");
+      fireEvent.change(textarea, { target: { value: "Updated comment text" } });
+
+      expect(defaultProps.setEditingCommentText).toHaveBeenCalledWith("Updated comment text");
+    });
+
+    it("should call handleUpdateComment when save button is clicked", async () => {
+      render(<CommentList {...editingProps} />);
+
+      const saveButton = screen.getByText("buttons.save");
+      fireEvent.click(saveButton);
+
+      expect(defaultProps.handleUpdateComment).toHaveBeenCalledWith(mockComments[0]);
+      expect(defaultProps.setEditingCommentText).toHaveBeenCalledWith('');
+    });
+
+    it("should call handleCancelEdit when cancel button is clicked", async () => {
+      const user = userEvent.setup();
+      render(<CommentList {...editingProps} />);
+
+      const cancelButton = screen.getByText("buttons.cancel");
+      await user.click(cancelButton);
+
+      expect(defaultProps.handleCancelEdit).toHaveBeenCalled();
+    });
+
+    it("should prevent saving empty comments", async () => {
+      const user = userEvent.setup();
+      const props = {
+        ...editingProps,
+        editingCommentText: "   ", // Whitespace only
+      };
+
+      render(<CommentList {...props} />);
+
+      const saveButton = screen.getByText("buttons.save");
+      await user.click(saveButton);
+
+      // Should not call handleUpdateComment for empty/whitespace-only text
+      expect(defaultProps.handleUpdateComment).not.toHaveBeenCalled();
+      expect(defaultProps.setEditingCommentText).not.toHaveBeenCalledWith('');
+    });
+
+    it("should focus the textarea when editing starts", () => {
+      render(<CommentList {...editingProps} />);
+
+      const textarea = screen.getByDisplayValue("Editing this comment");
+      expect(document.activeElement).toBe(textarea);
+    });
+  });
+
+  it("should handle comments with missing user data gracefully", () => {
+    const commentsWithMissingUser: MergedComment[] = [
+      {
+        ...mockComments[0],
+        user: null,
+      },
+    ];
+
+    const props = {
+      ...defaultProps,
+      comments: commentsWithMissingUser,
+    };
+
+    render(<CommentList {...props} />);
+
+    // Should still render the comment text
+    expect(screen.getByText("This is a regular comment")).toBeInTheDocument();
+    const h4 = screen.getByRole('heading', { level: 4 });
+    expect(h4).toBeInTheDocument();
+    // Should handle missing user gracefully (empty name)
+    expect(h4.textContent?.trim()).toBe('');
+  });
+
+  it("should handle comments with missing dates gracefully", () => {
+    const commentsWithMissingDates: MergedComment[] = [
+      {
+        ...mockComments[0],
+        created: null,
+        modified: null,
+      },
+    ];
+
+    const props = {
+      ...defaultProps,
+      comments: commentsWithMissingDates,
+    };
+
+    render(<CommentList {...props} />);
+
+    // Should still render the comment
+    expect(screen.getByText("This is a regular comment")).toBeInTheDocument();
+  });
+
+  it("should render empty list when no comments provided", () => {
+    const props = {
+      ...defaultProps,
+      comments: [],
+    };
+
+    const { container } = render(<CommentList {...props} />);
+
+    // Should render without crashing
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should handle plan owners being null", () => {
+    const props = {
+      ...defaultProps,
+      planOwners: null,
+    };
+
+    render(<CommentList {...props} />);
+
+    // Should still render comments
+    expect(screen.getByText("This is a regular comment")).toBeInTheDocument();
+
+    // Should show edit button for own comment
+    expect(screen.getByText("buttons.edit")).toBeInTheDocument();
+  });
+
+  it('should pass accessibility tests', async () => {
+    const { container } = render(<CommentList {...defaultProps} />);
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.queryByText('Loading questions...')).not.toBeInTheDocument();
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentsDrawer.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentsDrawer.spec.tsx
@@ -16,6 +16,7 @@ jest.mock("next-intl", () => ({
 
 // Mock DrawerPanel (to avoid focusing/portal complexity)
 jest.mock("@/components/Container", () => ({
+  /*eslint-disable @typescript-eslint/no-explicit-any */
   DrawerPanel: ({ children, title, isOpen }: any) =>
     isOpen ? (
       <div data-testid="drawer">
@@ -26,32 +27,18 @@ jest.mock("@/components/Container", () => ({
 }));
 
 // Mock CommentList to simplify
-jest.mock("../CommentList", () => (props: any) => (
-  <div data-testid="comment-list">
-    {props.comments.map((c: MergedComment) => (
-      <p key={c.id}>{c.commentText}</p>
-    ))}
-  </div>
-));
-
-// Mock react-aria-components
-jest.mock("react-aria-components", () => ({
-  Button: ({ children, onClick, type, className }: any) => (
-    <button onClick={onClick} type={type} className={className}>
-      {children}
-    </button>
-  ),
-  Form: ({ children, onSubmit }: any) => (
-    <form onSubmit={onSubmit}>{children}</form>
-  ),
-  Label: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
-  TextArea: ({ onChange, value, ...props }: any) => (
-    <textarea onChange={onChange} value={value} {...props} />
-  ),
-  TextField: ({ children, className }: any) => (
-    <div className={className}>{children}</div>
-  ),
-}));
+jest.mock("../CommentList", () => {
+  /*eslint-disable @typescript-eslint/no-explicit-any */
+  const MockCommentList = (props: any) => (
+    <div data-testid="comment-list">
+      {props.comments.map((c: MergedComment) => (
+        <p key={c.id}>{c.commentText}</p>
+      ))}
+    </div>
+  );
+  MockCommentList.displayName = "MockCommentList";
+  return MockCommentList;
+});
 
 const mergedComments: MergedComment[] = [
   {
@@ -82,7 +69,7 @@ const mergedComments: MergedComment[] = [
   },
 ];
 
-// Create a minimal mock that matches the MeQuery structure
+// MeQuery mock
 const createMockMeQuery = (overrides = {}) => ({
   me: {
     id: 1,
@@ -198,7 +185,6 @@ describe("CommentsDrawer", () => {
     const user = userEvent.setup();
     render(<CommentsDrawer {...defaultProps} />);
 
-    const textarea = screen.getByTestId("new-comment-textarea");
     const submitButton = screen.getByRole("button", { name: "buttons.comment" });
 
     // Try to submit with empty textarea

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentsDrawer.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentsDrawer.spec.tsx
@@ -1,0 +1,322 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CommentsDrawer from "../CommentsDrawer";
+import type { MergedComment } from "@/app/types";
+import type { CommentsDrawerProps } from "../CommentsDrawer"; // Import the props type
+import { UserRole } from '@/generated/graphql';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+expect.extend(toHaveNoViolations);
+
+// Mock translations so we don't have to set up next-intl
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key, // return key as translation
+}));
+
+// Mock DrawerPanel (to avoid focusing/portal complexity)
+jest.mock("@/components/Container", () => ({
+  DrawerPanel: ({ children, title, isOpen }: any) =>
+    isOpen ? (
+      <div data-testid="drawer">
+        <h1>{title}</h1>
+        {children}
+      </div>
+    ) : null,
+}));
+
+// Mock CommentList to simplify
+jest.mock("../CommentList", () => (props: any) => (
+  <div data-testid="comment-list">
+    {props.comments.map((c: MergedComment) => (
+      <p key={c.id}>{c.commentText}</p>
+    ))}
+  </div>
+));
+
+// Mock react-aria-components
+jest.mock("react-aria-components", () => ({
+  Button: ({ children, onClick, type, className }: any) => (
+    <button onClick={onClick} type={type} className={className}>
+      {children}
+    </button>
+  ),
+  Form: ({ children, onSubmit }: any) => (
+    <form onSubmit={onSubmit}>{children}</form>
+  ),
+  Label: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
+  TextArea: ({ onChange, value, ...props }: any) => (
+    <textarea onChange={onChange} value={value} {...props} />
+  ),
+  TextField: ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+const mergedComments: MergedComment[] = [
+  {
+    __typename: "AnswerComment",
+    id: 11,
+    commentText: "adding a comment",
+    answerId: 1,
+    created: "1755544243000",
+    modified: "1755544243000",
+    type: "answer",
+    isAnswerComment: true,
+    isFeedbackComment: false,
+    user: { __typename: "User", id: 7, givenName: "UCD", surName: "Researcher" },
+    PlanFeedback: null,
+  },
+  {
+    __typename: "PlanFeedbackComment",
+    id: 48,
+    commentText: "Adding a new comment123",
+    answerId: 1,
+    created: "1755557417905",
+    modified: "1755557423554",
+    type: "feedback",
+    isAnswerComment: false,
+    isFeedbackComment: true,
+    user: { __typename: "User", id: 1, givenName: "Super", surName: "Admin" },
+    PlanFeedback: null,
+  },
+];
+
+// Create a minimal mock that matches the MeQuery structure
+const createMockMeQuery = (overrides = {}) => ({
+  me: {
+    id: 1,
+    givenName: "Test",
+    surName: "User",
+    languageId: "en",
+    role: UserRole.Admin,
+    emails: [
+      {
+        id: 1,
+        email: "test@example.com",
+        isPrimary: true,
+        isConfirmed: true
+      }
+    ],
+    errors: {
+      general: null,
+      email: null,
+      password: null,
+      role: null
+    },
+    affiliation: {
+      id: 1,
+      name: "Test Organization",
+      searchName: "test-organization",
+      uri: "https://test.org"
+    },
+    ...overrides
+  }
+});
+
+describe("CommentsDrawer", () => {
+  const defaultProps: CommentsDrawerProps = {
+    isCommentsDrawerOpen: true,
+    closeCurrentDrawer: jest.fn(),
+    openCommentsButtonRef: { current: null },
+    mergedComments,
+    editingCommentId: null,
+    editingCommentText: "",
+    setEditingCommentText: jest.fn(),
+    handleUpdateComment: jest.fn(),
+    handleCancelEdit: jest.fn(),
+    handleEditComment: jest.fn(),
+    handleDeleteComment: jest.fn(),
+    me: createMockMeQuery(),
+    planOwners: [1],
+    locale: "en",
+    commentsEndRef: { current: null },
+    canAddComments: true,
+    handleAddComment: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render merged comments when drawer is open", () => {
+    render(<CommentsDrawer {...defaultProps} />);
+
+    expect(screen.getByTestId("drawer")).toBeInTheDocument();
+    expect(screen.getByTestId("comment-list")).toBeInTheDocument();
+
+    // Check that comment texts render
+    expect(screen.getByText("adding a comment")).toBeInTheDocument();
+    expect(screen.getByText("Adding a new comment123")).toBeInTheDocument();
+  });
+
+  it("should not render when drawer is closed", () => {
+    const props = { ...defaultProps, isCommentsDrawerOpen: false };
+    render(<CommentsDrawer {...props} />);
+
+    expect(screen.queryByTestId("drawer")).not.toBeInTheDocument();
+  });
+
+  it("should render comment form when canAddComments is true", () => {
+    render(<CommentsDrawer {...defaultProps} />);
+
+    expect(screen.getByTestId("new-comment-textarea")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "buttons.comment" })).toBeInTheDocument();
+    expect(screen.getByText("Test User (you)")).toBeInTheDocument();
+  });
+
+  it("should not render comment form when canAddComments is false", () => {
+    const props = { ...defaultProps, canAddComments: false };
+    render(<CommentsDrawer {...props} />);
+
+    expect(screen.queryByTestId("new-comment-textarea")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "buttons.comment" })).not.toBeInTheDocument();
+  });
+
+  it("should submit a new comment with valid text", async () => {
+    const user = userEvent.setup();
+    render(<CommentsDrawer {...defaultProps} />);
+
+    const textarea = screen.getByTestId("new-comment-textarea");
+    const submitButton = screen.getByRole("button", { name: "buttons.comment" });
+
+    await user.type(textarea, "New test comment");
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(defaultProps.handleAddComment).toHaveBeenCalledWith(
+        expect.any(Object), // form event
+        "New test comment"
+      );
+    });
+
+    // Check that textarea is cleared after submission
+    expect(textarea).toHaveValue("");
+  });
+
+  it("should prevent submitting empty comment", async () => {
+    const user = userEvent.setup();
+    render(<CommentsDrawer {...defaultProps} />);
+
+    const textarea = screen.getByTestId("new-comment-textarea");
+    const submitButton = screen.getByRole("button", { name: "buttons.comment" });
+
+    // Try to submit with empty textarea
+    await user.click(submitButton);
+
+    expect(defaultProps.handleAddComment).not.toHaveBeenCalled();
+  });
+
+  it("should prevent submitting whitespace-only comment", async () => {
+    const user = userEvent.setup();
+    render(<CommentsDrawer {...defaultProps} />);
+
+    const textarea = screen.getByTestId("new-comment-textarea");
+    const submitButton = screen.getByRole("button", { name: "buttons.comment" });
+
+    await user.type(textarea, "   \n\t  ");
+    await user.click(submitButton);
+
+    expect(defaultProps.handleAddComment).not.toHaveBeenCalled();
+  });
+
+  it("should update textarea value when typing", async () => {
+    const user = userEvent.setup();
+    render(<CommentsDrawer {...defaultProps} />);
+
+    const textarea = screen.getByTestId("new-comment-textarea");
+
+    await user.type(textarea, "Test comment text");
+
+    expect(textarea).toHaveValue("Test comment text");
+  });
+
+  it("should handle form submission via Enter key", async () => {
+    const user = userEvent.setup();
+    render(<CommentsDrawer {...defaultProps} />);
+
+    const textarea = screen.getByTestId("new-comment-textarea");
+
+    await user.type(textarea, "New comment via enter");
+
+    // Submit form by pressing Enter while focused on submit button
+    const form = textarea.closest("form");
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(defaultProps.handleAddComment).toHaveBeenCalledWith(
+        expect.any(Object),
+        "New comment via enter"
+      );
+    });
+  });
+
+  it("should render user name correctly when \'me\' is provided", () => {
+    render(<CommentsDrawer {...defaultProps} />);
+
+    expect(screen.getByText("Test User (you)")).toBeInTheDocument();
+  });
+
+  it("should render empty user name when \'me\' is null", () => {
+    const props = { ...defaultProps, me: null };
+    render(<CommentsDrawer {...props} />);
+
+    expect(screen.getByText(/(you)/i)).toBeInTheDocument();
+  });
+
+  it("should render empty user name when \'me.me\' is null", () => {
+    const props = { ...defaultProps, me: { me: null } };
+    render(<CommentsDrawer {...props} />);
+
+    expect(screen.getByText(/(you)/i)).toBeInTheDocument();
+  });
+
+  it("should pass correct props to CommentList", () => {
+    render(<CommentsDrawer {...defaultProps} />);
+
+    const commentList = screen.getByTestId("comment-list");
+    expect(commentList).toBeInTheDocument();
+
+    // Verify comments are passed through (our mock renders comment text)
+    expect(screen.getByText("adding a comment")).toBeInTheDocument();
+    expect(screen.getByText("Adding a new comment123")).toBeInTheDocument();
+  });
+
+  it("should call handleAddComment and clear textarea optimistically", async () => {
+    const user = userEvent.setup();
+    // Mock a successful response
+    const handleAddCommentMock = jest.fn().mockResolvedValue(undefined);
+    const props = { ...defaultProps, handleAddComment: handleAddCommentMock };
+
+    render(<CommentsDrawer {...props} />);
+
+    const textarea = screen.getByTestId("new-comment-textarea");
+    const submitButton = screen.getByRole("button", { name: "buttons.comment" });
+
+    await user.type(textarea, "Test comment");
+    await user.click(submitButton);
+
+    // Verify handleAddComment was called
+    await waitFor(() => {
+      expect(handleAddCommentMock).toHaveBeenCalledWith(
+        expect.any(Object),
+        "Test comment"
+      );
+    });
+
+    // Textarea should be cleared immediately (optimistic UX)
+    expect(textarea).toHaveValue("");
+  });
+
+  it('should pass accessibility tests', async () => {
+    const { container } = render(<CommentsDrawer {...defaultProps} />);
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.queryByText('Loading questions...')).not.toBeInTheDocument();
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
@@ -7,6 +7,7 @@ import {
   useAnswerByVersionedQuestionIdQuery,
   usePublishedQuestionQuery,
   usePlanQuery,
+  useMeQuery
 } from '@/generated/graphql';
 import {
   addAnswerAction,
@@ -18,7 +19,7 @@ import * as apolloClientModule from '@/lib/graphql/client/apollo-client';
 import mockAnswerData from '../__mocks__/mockAnswerData.json';
 import mockPlanData from '../__mocks__/mockPlanData.json';
 import mockPublishedQuestion from '../__mocks__/mockPublishedQuestion.json';
-
+import mockMeData from '../__mocks__/mockMeQuery.json';
 // Mocked question data
 import mockCheckboxQuestion from '../__mocks__/mockCheckboxQuestion.json';
 import mockQuestionDataForBoolean from '@/__mocks__/common/mockPublishedQuestionDataForBoolean.json';
@@ -106,6 +107,7 @@ expect.extend(toHaveNoViolations);
 
 // Mock the GraphQL query and mutation hooks
 jest.mock("@/generated/graphql", () => ({
+  useMeQuery: jest.fn(),
   usePlanQuery: jest.fn(),
   usePublishedQuestionQuery: jest.fn(),
   useAnswerByVersionedQuestionIdQuery: jest.fn(),
@@ -156,6 +158,11 @@ describe('PlanOverviewQuestionPage render of questions', () => {
 
 
     jest.useFakeTimers();
+
+    (useMeQuery as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce(mockMeData),
+      { loading: false, error: undefined },
+    ]);
 
     (usePlanQuery as jest.Mock).mockReturnValue([
       jest.fn().mockResolvedValueOnce(mockPlanData),

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
@@ -63,15 +63,15 @@ beforeEach(() => {
   // Cannot get the escaping to work in the mock JSON file, so doing it programmatically here
   const affiliationQuery = 'query Affiliations($name: String!){ ' +
     'affiliations(name: $name) { ' +
-      'totalCount ' +
-      'nextCursor ' +
-      'items { ' +
-        'id ' +
-        'displayName ' +
-        'uri ' +
-      '} ' +
+    'totalCount ' +
+    'nextCursor ' +
+    'items { ' +
+    'id ' +
+    'displayName ' +
+    'uri ' +
     '} ' +
-  '}';
+    '} ' +
+    '}';
 
   const json: AffiliationSearchQuestionType = {
     type: 'affiliationSearch',

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
@@ -60,6 +60,16 @@ import { mockScrollIntoView } from "@/__mocks__/common";
 import PlanOverviewQuestionPage from "../page";
 import { AffiliationSearchQuestionType } from "@dmptool/types";
 
+// Mock for useComments hook
+import { mockUseComments, defaultMockReturn } from '../hooks/__mocks__/useComments';
+
+jest.mock('../hooks/useComments', () => {
+  const { mockUseComments } = jest.requireActual('../hooks/__mocks__/useComments');
+  return {
+    useComments: mockUseComments,
+  };
+});
+
 beforeEach(() => {
   // Cannot get the escaping to work in the mock JSON file, so doing it programmatically here
   const affiliationQuery = 'query Affiliations($name: String!){ ' +
@@ -100,6 +110,9 @@ beforeEach(() => {
     },
   };
   mockQuestionDataForTypeAheadSearch.publishedQuestion.json = JSON.stringify(json);
+
+  // Mock the useComments hook
+  mockUseComments.mockReturnValue(defaultMockReturn);
 });
 
 expect.extend(toHaveNoViolations);
@@ -159,10 +172,13 @@ describe('PlanOverviewQuestionPage render of questions', () => {
 
     jest.useFakeTimers();
 
-    (useMeQuery as jest.Mock).mockReturnValue([
-      jest.fn().mockResolvedValueOnce(mockMeData),
-      { loading: false, error: undefined },
-    ]);
+    (useMeQuery as jest.Mock).mockReturnValue({
+      data: mockMeData,
+      loading: false,
+      error: undefined
+    });
+
+    mockUseComments.mockReturnValue(defaultMockReturn);
 
     (usePlanQuery as jest.Mock).mockReturnValue([
       jest.fn().mockResolvedValueOnce(mockPlanData),
@@ -180,6 +196,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
       loading: false,
       error: undefined,
     });
+
   })
 
   afterEach(() => {
@@ -206,7 +223,8 @@ describe('PlanOverviewQuestionPage render of questions', () => {
       );
     });
 
-    // Check for Requirements content
+
+    //Check for Requirements content
     expect(screen.getByRole('heading', { level: 3, name: 'page.requirementsBy' })).toBeInTheDocument();
     const boldedRequirements = screen.getByText('Requirements - Lorem Ipsum');
     expect(boldedRequirements).toBeInTheDocument();
@@ -229,7 +247,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('button', { name: 'Required by funder' })).toBeInTheDocument();
     // check for drawer panel trigger buttons
     expect(screen.getByRole('button', { name: 'page.viewSampleAnswer' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
     // Check that the textArea question field is in page
     expect(screen.getByLabelText('question-text-editor')).toBeInTheDocument();
 
@@ -273,7 +291,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Checkbox question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
     const checkboxGroup = screen.getByTestId('checkbox-group');
     expect(checkboxGroup).toBeInTheDocument();
     const checkboxes = within(checkboxGroup).getAllByRole('checkbox');
@@ -318,7 +336,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Radio button question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
 
     //Radio group
     const radioGroup = screen.getByRole('radiogroup');
@@ -357,7 +375,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: "Testing" })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
     const textFieldWrapper = screen.getByTestId('field-wrapper');
     expect(textFieldWrapper).toBeInTheDocument();
     expect(within(textFieldWrapper).getByLabelText('text')).toBeInTheDocument();
@@ -392,7 +410,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Affiliation search question' }))
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
     const typeAheadContainer = screen.getByTestId('typeaheadWithOther');
     expect(typeAheadContainer).toBeInTheDocument();
     expect(within(typeAheadContainer).getByText('Institution')).toBeInTheDocument();
@@ -423,7 +441,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Date range question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
     // Date range container
     const dateRangeContainer = screen.getByTestId('date-range-container');
     expect(dateRangeContainer).toBeInTheDocument();
@@ -474,7 +492,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Date field question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
     // Date picker container
     const datePicker = screen.getByTestId('date-picker');
     const date = within(datePicker);
@@ -512,7 +530,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Yes/No question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
 
     //Radio group
     const radioGroup = screen.getByRole('radiogroup');
@@ -546,7 +564,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Url question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
 
     const urlInput = screen.getByPlaceholderText('url');
     expect(urlInput).toBeInTheDocument();
@@ -575,7 +593,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Email field question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
 
     const emailInput = screen.getByPlaceholderText('email');
     expect(emailInput).toBeInTheDocument();
@@ -605,7 +623,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Currency Field question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
 
     // Should see increment and decrement buttons
     const decreaseButton = screen.getAllByLabelText('Decrease');
@@ -640,7 +658,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Number Range question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
 
     expect(screen.getByText('Starting')).toBeInTheDocument();
     expect(screen.getByText('Ending')).toBeInTheDocument();
@@ -679,7 +697,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Number Field question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
 
     expect(screen.getByText('number')).toBeInTheDocument();
     // Should see increment and decrement buttons
@@ -715,7 +733,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Multi select question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
 
     expect(screen.getByText('Select Items (Multiple)')).toBeInTheDocument();
     expect(screen.getByText('Apple')).toBeInTheDocument();
@@ -755,7 +773,7 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Select box question' })).toBeInTheDocument();
     // View sample text button should not display when the question is not a textArea question type
     expect(screen.queryByRole('button', { name: 'page.viewSampleAnswer' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '4 Comments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'buttons.commentWithNumber' })).toBeInTheDocument();
 
     const selectButton = screen.getByTestId('select-button');
     expect(within(selectButton).getByText('Oregon')).toBeInTheDocument();
@@ -871,6 +889,14 @@ describe('Call to updateAnswerAction', () => {
       loading: false,
       error: undefined,
     });
+
+    (useMeQuery as jest.Mock).mockReturnValue({
+      data: mockMeData,
+      loading: false,
+      error: undefined
+    });
+
+    mockUseComments.mockReturnValue(defaultMockReturn);
   })
 
   it('should call updateAnswerAction when data changes for typeaheadSearch field', async () => {
@@ -1759,7 +1785,7 @@ describe('Call to updateAnswerAction', () => {
           versionedQuestionId: 'versionedQuestionId already exists'
         },
         id: 27,
-        json: "{\"type\":\"textArea\",\"answer\":\"This is a test\"}",
+        json: "{\"type\":\"textArea123\",\"answer\":\"This is a test\"}",
         modified: "1751929006000",
         versionedQuestion: {
           versionedSectionId: 20
@@ -1901,6 +1927,15 @@ describe('DrawerPanel', () => {
       loading: false,
       error: undefined,
     });
+
+    (useMeQuery as jest.Mock).mockReturnValue({
+      data: mockMeData,
+      loading: false,
+      error: undefined
+    });
+
+    mockUseComments.mockReturnValue(defaultMockReturn);
+
   })
 
   it('should open Sample text DrawerPanel when user clicks on the \'View sample answer\' button', async () => {
@@ -2046,7 +2081,7 @@ describe('DrawerPanel', () => {
     const sidebarPanel = screen.queryByTestId('sidebar-panel');
 
     // check for drawer panel trigger buttons
-    const viewCommentsBtn = screen.getByRole('button', { name: '4 Comments' });
+    const viewCommentsBtn = screen.getByRole('button', { name: 'buttons.commentWithNumber' });
     expect(viewCommentsBtn).toBeInTheDocument();
     expect(sidebarPanel).toBeInTheDocument();
     expect(visibleDrawerPanel).toBeUndefined();
@@ -2109,7 +2144,7 @@ describe('DrawerPanel', () => {
     });
 
 
-    const viewCommentsBtn = screen.getByRole('button', { name: '4 Comments' });
+    const viewCommentsBtn = screen.getByRole('button', { name: 'buttons.commentWithNumber' });
     // Click on Comments button to reveal comments drawer panel
     await userEvent.click(viewCommentsBtn);
 
@@ -2121,93 +2156,9 @@ describe('DrawerPanel', () => {
     await userEvent.click(commentBtn);
 
     // Get new info on sidebar and drawer panel - drawer should be closed and sidebar panel should be displayed
-    const allDrawerPanels2 = screen.getAllByTestId('drawer-panel');
-    const visibleDrawerPanel2 = allDrawerPanels2.find(
-      panel => panel.getAttribute('aria-hidden') !== 'true'
-    )!; // Non-null assertion operator
+
     const sidebarPanel2 = screen.queryByTestId('sidebar-panel');
     expect(sidebarPanel2).toBeInTheDocument();
-    expect(visibleDrawerPanel2).toBeUndefined();
-  })
-
-  it('should close drawer panel when user clicks on the masked body while comments drawer panel is open', async () => {
-
-    (usePublishedQuestionQuery as jest.Mock).mockReturnValue({
-      data: mockQuestionDataForTextArea,
-      loading: false,
-      error: undefined,
-    });
-
-    (useAnswerByVersionedQuestionIdQuery as jest.Mock).mockReturnValue({
-      data: mockAnswerDataForTextArea,
-      loading: false,
-      error: undefined,
-    });
-
-    await act(async () => {
-      render(
-        <PlanOverviewQuestionPage />
-      );
-    });
-
-
-    const viewCommentsBtn = screen.getByRole('button', { name: '4 Comments' });
-    // Click on Comments button to reveal comments drawer panel
-    await userEvent.click(viewCommentsBtn);
-
-    const layoutWithPanel = screen.getByTestId('layout-with-panel');
-
-    // Click on the masked layoutWithPanel to close the drawer
-    await userEvent.click(layoutWithPanel);
-
-    // Drawer should be closed now and sidebar panel should be displayed
-    const allDrawerPanels = screen.getAllByTestId('drawer-panel');
-    const visibleDrawerPanel = allDrawerPanels.find(
-      panel => panel.getAttribute('aria-hidden') !== 'true'
-    )!; // Non-null assertion operator
-    const sidebarPanel = screen.queryByTestId('sidebar-panel');
-    expect(sidebarPanel).toBeInTheDocument();
-    expect(visibleDrawerPanel).toBeUndefined();
-  })
-
-  it('should close drawer panel when user clicks on the masked body when sample answer drawer panel is open', async () => {
-
-    (usePublishedQuestionQuery as jest.Mock).mockReturnValue({
-      data: mockQuestionDataForTextArea,
-      loading: false,
-      error: undefined,
-    });
-
-    (useAnswerByVersionedQuestionIdQuery as jest.Mock).mockReturnValue({
-      data: mockAnswerDataForTextArea,
-      loading: false,
-      error: undefined,
-    });
-
-    await act(async () => {
-      render(
-        <PlanOverviewQuestionPage />
-      );
-    });
-
-
-    const viewSampleTextBtn = screen.getByRole('button', { name: 'page.viewSampleAnswer' });
-    // Click on View Sample text button to reveal sample text drawer panel
-    await userEvent.click(viewSampleTextBtn);
-
-    const layoutWithPanel = screen.getByTestId('layout-with-panel');
-
-    // Click on the masked layoutWithPanel to close the drawer
-    await userEvent.click(layoutWithPanel);
-
-    // Drawer should be closed now and sidebar panel should be displayed
-    const allDrawerPanels = screen.getAllByTestId('drawer-panel');
-    const visibleDrawerPanel = allDrawerPanels.find(
-      panel => panel.getAttribute('aria-hidden') !== 'true'
-    )!; // Non-null assertion operator
-    const sidebarPanel = screen.queryByTestId('sidebar-panel');
-    expect(sidebarPanel).toBeInTheDocument();
-    expect(visibleDrawerPanel).toBeUndefined();
   })
 });
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addAnswerCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addAnswerCommentAction.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
+import logger from "@/utils/server/logger";
+import { ActionResponse } from "@/app/types";
+import { AddAnswerCommentDocument } from "@/generated/graphql";
+
+export async function addAnswerCommentAction({
+  answerId,
+  commentText
+}: {
+  answerId: number;
+  commentText: string;
+}): Promise<ActionResponse> {
+  try {
+    // Execute the mutation using the shared handler
+    return await executeGraphQLMutation({
+      document: AddAnswerCommentDocument,
+      variables: { answerId, commentText },
+      dataPath: "addAnswerComment"
+    });
+  } catch (error) {
+    logger.error(`[Add answerComment from answer]: ${error}`, { error });
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
+}

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addFeedbackCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addFeedbackCommentAction.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
+import logger from "@/utils/server/logger";
+import { ActionResponse } from "@/app/types";
+import { AddFeedbackCommentDocument } from "@/generated/graphql";
+
+export async function addFeedbackCommentAction({
+  planId,
+  planFeedbackId,
+  answerId,
+  commentText
+}: {
+  planId: number;
+  planFeedbackId: number;
+  answerId: number;
+  commentText: string;
+}): Promise<ActionResponse> {
+  try {
+    // Execute the mutation using the shared handler
+    return await executeGraphQLMutation({
+      document: AddFeedbackCommentDocument,
+      variables: { planId, planFeedbackId, answerId, commentText },
+      dataPath: "addFeedbackComment"
+    });
+  } catch (error) {
+    logger.error(`[Add feedbackComment from answer]: ${error}`, { error });
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
+}

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/index.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/index.tsx
@@ -1,2 +1,6 @@
 export { addAnswerAction } from './addAnswerAction';
 export { updateAnswerAction } from './updateAnswerAction';
+export { removeAnswerCommentAction } from './removeAnswerCommentAction';
+export { removeFeedbackCommentAction } from './removeFeedbackCommentAction';
+export { updateFeedbackCommentAction } from './updateFeedbackCommentAction';
+export { updateAnswerCommentAction } from './updateAnswerCommentAction';

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/index.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/index.tsx
@@ -4,3 +4,5 @@ export { removeAnswerCommentAction } from './removeAnswerCommentAction';
 export { removeFeedbackCommentAction } from './removeFeedbackCommentAction';
 export { updateFeedbackCommentAction } from './updateFeedbackCommentAction';
 export { updateAnswerCommentAction } from './updateAnswerCommentAction';
+export { addAnswerCommentAction } from './addAnswerCommentAction';
+export { addFeedbackCommentAction } from './addFeedbackCommentAction';

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeAnswerCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeAnswerCommentAction.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
+import logger from "@/utils/server/logger";
+import { ActionResponse } from "@/app/types";
+import { RemoveAnswerCommentDocument } from "@/generated/graphql";
+
+export async function removeAnswerCommentAction({
+  answerId,
+  answerCommentId
+}: {
+  answerId: number;
+  answerCommentId: number;
+}): Promise<ActionResponse> {
+  try {
+    // Execute the mutation using the shared handler
+    return await executeGraphQLMutation({
+      document: RemoveAnswerCommentDocument,
+      variables: { answerId, answerCommentId },
+      dataPath: "removeAnswerComment"
+    });
+  } catch (error) {
+    logger.error(`[Remove answerComment from answer]: ${error}`, { error });
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
+}

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeFeedbackCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeFeedbackCommentAction.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
+import logger from "@/utils/server/logger";
+import { ActionResponse } from "@/app/types";
+import { RemoveFeedbackCommentDocument } from "@/generated/graphql";
+
+export async function removeFeedbackCommentAction({
+  planId,
+  planFeedbackCommentId
+}: {
+  planId: number;
+  planFeedbackCommentId: number;
+}): Promise<ActionResponse> {
+  try {
+    // Execute the mutation using the shared handler
+    return await executeGraphQLMutation({
+      document: RemoveFeedbackCommentDocument,
+      variables: { planId, planFeedbackCommentId },
+      dataPath: "removeFeedbackComment"
+    });
+  } catch (error) {
+    logger.error(`[Remove feedbackComment from answer]: ${error}`, { error });
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
+}

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateAnswerCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateAnswerCommentAction.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
+import logger from "@/utils/server/logger";
+import { ActionResponse } from "@/app/types";
+import { UpdateAnswerCommentDocument } from "@/generated/graphql";
+
+export async function updateAnswerCommentAction({
+  answerId,
+  answerCommentId,
+  commentText
+}: {
+  answerId: number;
+  answerCommentId: number;
+  commentText: string;
+}): Promise<ActionResponse> {
+  try {
+    // Execute the mutation using the shared handler
+    return await executeGraphQLMutation({
+      document: UpdateAnswerCommentDocument,
+      variables: { answerId, answerCommentId, commentText },
+      dataPath: "updateAnswerComment"
+    });
+  } catch (error) {
+    logger.error(`[Update answerComment from answer]: ${error}`, { error });
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
+}

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateFeedbackCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateFeedbackCommentAction.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
+import logger from "@/utils/server/logger";
+import { ActionResponse } from "@/app/types";
+import { UpdateFeedbackCommentDocument } from "@/generated/graphql";
+
+export async function updateFeedbackCommentAction({
+  planId,
+  planFeedbackCommentId,
+  commentText
+}: {
+  planId: number;
+  planFeedbackCommentId: number;
+  commentText: string;
+}): Promise<ActionResponse> {
+  try {
+    // Execute the mutation using the shared handler
+    return await executeGraphQLMutation({
+      document: UpdateFeedbackCommentDocument,
+      variables: { planId, planFeedbackCommentId, commentText },
+      dataPath: "updateFeedbackComment"
+    });
+  } catch (error) {
+    logger.error(`[Update feedbackComment from answer]: ${error}`, { error });
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
+}

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/__mocks__/useComments.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/__mocks__/useComments.ts
@@ -1,0 +1,24 @@
+import mockMergedComments from '../../__mocks__/mockMergedComments.json'
+
+export const mockUseComments = jest.fn();
+
+export const defaultMockReturn = {
+  mergedComments: mockMergedComments,
+  editingCommentId: null,
+  editingCommentText: '',
+  canAddComments: true,
+  errors: [],
+  commentsEndRef: { current: null },
+  setEditingCommentText: jest.fn(),
+  setCommentsFromData: jest.fn(),
+  updateCanAddComments: jest.fn(),
+  handleAddComment: jest.fn(),
+  handleDeleteComment: jest.fn(),
+  handleEditComment: jest.fn(),
+  handleUpdateComment: jest.fn(),
+  handleCancelEdit: jest.fn(),
+};
+
+mockUseComments.mockReturnValue(defaultMockReturn);
+
+export const useComments = mockUseComments;

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/__tests__/useComments.spec.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/__tests__/useComments.spec.ts
@@ -1,0 +1,489 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useToast } from '@/context/ToastContext';
+import { useRouter } from 'next/navigation';
+import * as actions from '../../actions';
+import { useComments } from '../useComments';
+import { MergedComment } from '@/app/types';
+
+// Mocks
+// Mock the useRouter from next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+const mockToast = { add: jest.fn() };
+
+
+jest.mock('../../actions', () => ({
+  addAnswerCommentAction: jest.fn().mockResolvedValue({ success: true, errors: [], data: { id: 123 } }),
+  addFeedbackCommentAction: jest.fn().mockResolvedValue({ success: true, errors: [], data: { id: 456 } }),
+  removeAnswerCommentAction: jest.fn().mockResolvedValue({ success: true, errors: [], data: {} }),
+  removeFeedbackCommentAction: jest.fn().mockResolvedValue({ success: true, errors: [], data: {} }),
+  updateAnswerCommentAction: jest.fn().mockResolvedValue({ success: true, errors: [], data: {} }),
+  updateFeedbackCommentAction: jest.fn().mockResolvedValue({ success: true, errors: [], data: {} }),
+}));
+
+describe('useComments', () => {
+  let mockRouter;
+
+  beforeEach(() => {
+    jest.clearAllMocks();   // resets call history
+    jest.resetModules();    // resets module state if needed
+    (useToast as jest.Mock).mockReturnValue(mockToast);
+
+    mockRouter = { push: jest.fn() };
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+  });
+
+  const me = {
+    me: {
+      id: 1,
+      givenName: 'Test',
+      surName: 'User',
+      role: 'ADMIN',
+      affiliation: { uri: 'org1' }
+    }
+  };
+
+  it('should allow admin to add comments', async () => {
+    const { result } = renderHook(() =>
+      useComments({
+        dmpId: '1',
+        projectId: '1',
+        versionedSectionId: '1',
+        versionedQuestionId: '1',
+        planFeedbackId: 10,
+        me,
+        planOrgId: 'org1',
+        openFeedbackRounds: true,
+        planOwners: [1],
+        collaborators: [1]
+      })
+    );
+
+    // Simulate canAddComments logic
+    act(() => {
+      result.current.updateCanAddComments();
+    });
+    expect(result.current.canAddComments).toBe(true);
+
+    // Simulate adding a comment
+    await act(async () => {
+      await result.current.handleAddComment(
+        { preventDefault: () => { } } as any,
+        1,
+        'New comment'
+      );
+    });
+
+    expect(result.current.mergedComments.length).toBe(1);
+    expect(result.current.mergedComments[0].commentText).toBe('New comment');
+  });
+
+
+  it('should optimistically remove and restore comments on delete failure', async () => {
+    // Mock the delete action to fail
+    (actions.removeAnswerCommentAction as jest.Mock).mockResolvedValueOnce({
+      success: false,
+      errors: ['fail'],
+      data: {}
+    });
+
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    // First, add a comment so there's something to delete
+    await act(async () => {
+      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Comment to delete');
+    });
+
+    // Grab the comment that was just added
+    const commentToDelete = result.current.mergedComments[0];
+    expect(commentToDelete).toBeDefined();
+
+    // Call handleDeleteComment with the comment
+    await act(async () => {
+      await result.current.handleDeleteComment(commentToDelete);
+    });
+
+    // Check optimistic rollback happened
+    expect(result.current.mergedComments.length).toBe(1);
+    expect(result.current.errors).toContain('fail');
+  });
+
+  it('should redirect if remove response contains a redirect', async () => {
+    (actions.removeAnswerCommentAction as jest.Mock).mockResolvedValueOnce({
+      success: false,
+      errors: ['fail'],
+      data: {},
+      redirect: '/new-url'
+    });
+
+
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    // First, add a comment so there's something to delete
+    await act(async () => {
+      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Comment to delete');
+    });
+
+    // Grab the comment that was just added
+    const commentToDelete = result.current.mergedComments[0];
+    expect(commentToDelete).toBeDefined();
+
+    // Call handleDeleteComment with the comment
+    await act(async () => {
+      await result.current.handleDeleteComment(commentToDelete);
+    });
+    // Verify that router.push was called with "/new-url"
+    expect(mockRouter.push).toHaveBeenCalledWith('/new-url');
+  });
+
+  it('should call removeFeedbackCommentAction when planFeedbackId exists', async () => {
+    // Mock the feedback comment delete API
+    (actions.removeFeedbackCommentAction as jest.Mock).mockResolvedValueOnce({
+      success: true,
+      errors: [],
+      data: {}
+    });
+
+    const planFeedbackId = 42;
+    const { result } = renderHook(() =>
+      useComments({
+        dmpId: '1',
+        projectId: '1',
+        versionedSectionId: '1',
+        versionedQuestionId: '1',
+        me,
+        planFeedbackId
+      })
+    );
+    const feedbackComment: MergedComment = {
+      __typename: 'PlanFeedbackComment',
+      id: 456,
+      commentText: 'Feedback comment',
+      answerId: null,
+      type: 'feedback',
+      isAnswerComment: false,
+      isFeedbackComment: true,
+      PlanFeedback: {},       // any non-null value triggers the planFeedback path
+      created: Date.now().toString(),
+      modified: Date.now().toString(),
+      user: { id: 1, givenName: 'Test', surName: 'User', __typename: 'User' }
+    };
+    await act(async () => {
+      await result.current.handleDeleteComment(feedbackComment);
+    });
+
+    // Assertions
+    expect(actions.removeFeedbackCommentAction).toHaveBeenCalledWith({
+      planId: Number(1),
+      planFeedbackCommentId: 456
+    });
+
+  });
+
+  it('should call updateAnswerCommentAction when planFeedbackId exists', async () => {
+    // Mock the feedback comment delete API
+    (actions.updateFeedbackCommentAction as jest.Mock).mockResolvedValueOnce({
+      success: true,
+      errors: [],
+      data: {},
+    });
+    const planFeedbackId = 42;
+    const { result } = renderHook(() =>
+      useComments({
+        dmpId: '1',
+        projectId: '1',
+        versionedSectionId: '1',
+        versionedQuestionId: '1',
+        me,
+        planFeedbackId,
+        planOrgId: 'org1',
+        openFeedbackRounds: true
+      })
+    );
+
+    await act(async () => {
+      result.current.setEditingCommentText('Feedback comment');
+    });
+
+    const feedbackComment: MergedComment = {
+      __typename: 'PlanFeedbackComment',
+      id: 456,
+      commentText: 'Feedback comment',
+      answerId: null,
+      type: 'feedback',
+      isAnswerComment: false,
+      isFeedbackComment: true,
+      PlanFeedback: {},       // any non-null value triggers the planFeedback path
+      created: Date.now().toString(),
+      modified: Date.now().toString(),
+      user: { id: 1, givenName: 'Test', surName: 'User', __typename: 'User' }
+    };
+    await act(async () => {
+      await result.current.handleUpdateComment(feedbackComment);
+    });
+    // Assertions
+    expect(actions.updateFeedbackCommentAction).toHaveBeenCalledWith({
+      planId: 1,
+      planFeedbackCommentId: 456,
+      commentText: "Feedback comment"
+    });
+
+  });
+
+  it('should roll back optimistic add when API fails', async () => {
+    (actions.addAnswerCommentAction as jest.Mock).mockResolvedValueOnce({
+      success: false,
+      errors: ['fail'],
+      data: {},
+    });
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    await act(async () => {
+      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Failing comment');
+    });
+
+    expect(result.current.mergedComments.length).toBe(0);
+    expect(result.current.errors).toEqual(["fail"]);
+  });
+
+  it('should redirect if response contains a redirect', async () => {
+    (actions.addAnswerCommentAction as jest.Mock).mockResolvedValueOnce({
+      success: false,
+      errors: ['fail'],
+      data: {},
+      redirect: '/new-url'
+    });
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    await act(async () => {
+      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Failing comment');
+    });
+
+    // Verify that router.push was called with "/new-url"
+    expect(mockRouter.push).toHaveBeenCalledWith('/new-url');
+  });
+
+  it('should roll back optimistic add when mutation returns field errors', async () => {
+    (actions.addAnswerCommentAction as jest.Mock).mockResolvedValueOnce({
+      success: true,
+      errors: [],
+      data: { errors: { general: 'field error' } }
+    });
+
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    await act(async () => {
+      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Bad comment');
+    });
+
+    expect(result.current.mergedComments.length).toBe(0);
+    expect(result.current.errors).toContain('field error');
+  });
+
+  it('should replace tempId with real id on successful add', async () => {
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    await act(async () => {
+      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Real id comment');
+    });
+
+    const saved = result.current.mergedComments[0];
+    expect(saved.id).toBe(123); // from your mock
+  });
+
+  it('should delete comment successfully and show toast', async () => {
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    await act(async () => {
+      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Delete me');
+    });
+
+    await waitFor(() => {
+      expect(result.current.mergedComments.length).toBe(1);
+    });
+
+    const comment = result.current.mergedComments[0];
+
+    await act(async () => {
+      await result.current.handleDeleteComment(comment);
+    });
+
+    // wait for the state update to complete
+    await waitFor(() => {
+      expect(result.current.mergedComments.length).toBe(0);
+    });
+
+    // check toast calls in order
+    expect(mockToast.add).toHaveBeenNthCalledWith(
+      1,
+      'messages.commentSent',
+      expect.objectContaining({ type: 'success' })
+    );
+    expect(mockToast.add).toHaveBeenNthCalledWith(
+      2,
+      'messages.commentDeleted',
+      expect.objectContaining({ type: 'success' })
+    );
+  });
+
+  it('should update comment successfully and clear edit state', async () => {
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    // Add a comment
+    await act(async () => {
+      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Old text');
+    });
+    const comment = result.current.mergedComments[0];
+
+    // Start editing
+    act(() => {
+      result.current.handleEditComment(comment);
+    });
+
+    await act(async () => {
+      result.current.setEditingCommentText('Updated text');
+    });
+
+    // Save
+    await act(async () => {
+      await result.current.handleUpdateComment(comment);
+    });
+
+    expect(result.current.mergedComments[0].commentText).toBe('Updated text');
+    expect(result.current.editingCommentId).toBe(null);
+  });
+
+  it('should roll back optimistic update on failure', async () => {
+    (actions.updateAnswerCommentAction as jest.Mock).mockResolvedValueOnce({
+      success: false,
+      errors: ['fail'],
+      data: {},
+    });
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    await act(async () => {
+      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Initial text');
+    });
+    const comment = result.current.mergedComments[0];
+
+    act(() => result.current.handleEditComment(comment));
+
+    await act(async () => {
+      // set the new text
+      result.current.setEditingCommentText('New text');
+      // then call update
+      await result.current.handleUpdateComment(comment);
+    });
+
+    await waitFor(() => {
+      expect(result.current.errors).toContain('fail');
+      expect(result.current.mergedComments[0].commentText).toBe('Initial text');
+    });
+
+  });
+
+  it('should redirect if update response includes a redirect', async () => {
+    (actions.updateAnswerCommentAction as jest.Mock).mockResolvedValueOnce({
+      success: false,
+      errors: ['fail'],
+      data: {},
+      redirect: '/new-url'
+    });
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    await act(async () => {
+      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Initial text');
+    });
+    const comment = result.current.mergedComments[0];
+
+    act(() => result.current.handleEditComment(comment));
+
+    await act(async () => {
+      // set the new text
+      result.current.setEditingCommentText('New text');
+      // then call update
+      await result.current.handleUpdateComment(comment);
+    });
+
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith('/new-url');
+    });
+
+  });
+
+  it('should enter and cancel edit mode', () => {
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    const fakeComment = { id: 99, commentText: 'test' } as any;
+
+    act(() => result.current.handleEditComment(fakeComment));
+    expect(result.current.editingCommentId).toBe(99);
+
+    act(() => result.current.handleCancelEdit());
+    expect(result.current.editingCommentId).toBe(null);
+    expect(result.current.editingCommentText).toBe('');
+  });
+
+  it('should merge and sort answer + feedback comments', () => {
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+    );
+
+    const answerComments = [{ id: 1, commentText: 'Answer', created: '10', answerId: 1 }] as any;
+    const feedbackComments = [{ id: 2, commentText: 'Feedback', created: '5' }] as any;
+
+    act(() => result.current.setCommentsFromData(answerComments, feedbackComments));
+
+    expect(result.current.mergedComments[0].commentText).toBe('Feedback'); // earlier created
+    expect(result.current.mergedComments[1].commentText).toBe('Answer');
+  });
+
+  it('should set canAddComments true for collaborator', () => {
+    const { result } = renderHook(() =>
+      useComments({
+        dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1',
+        me: { me: { id: 2, role: 'USER' } },
+        collaborators: [2]
+      })
+    );
+
+    act(() => result.current.updateCanAddComments());
+    expect(result.current.canAddComments).toBe(true);
+  });
+
+  it('should set canAddComments false when user not allowed', () => {
+    const { result } = renderHook(() =>
+      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me: { me: { id: 3, role: 'USER' } } })
+    );
+
+    act(() => result.current.updateCanAddComments());
+    expect(result.current.canAddComments).toBe(false);
+  });
+
+});

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/__tests__/useComments.spec.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/__tests__/useComments.spec.ts
@@ -2,7 +2,8 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { useToast } from '@/context/ToastContext';
 import { useRouter } from 'next/navigation';
 import * as actions from '../../actions';
-import { useComments } from '../useComments';
+import { UserRole } from '@/generated/graphql';
+import { useComments, AnswerComment, FeedbackComment } from '../useComments';
 import { MergedComment } from '@/app/types';
 
 // Mocks
@@ -42,8 +43,28 @@ describe('useComments', () => {
       id: 1,
       givenName: 'Test',
       surName: 'User',
-      role: 'ADMIN',
-      affiliation: { uri: 'org1' }
+      role: UserRole.Admin,
+      languageId: 'en',
+      emails: [
+        {
+          id: 1,
+          email: "test@example.com",
+          isPrimary: true,
+          isConfirmed: true
+        }
+      ],
+      errors: {
+        general: null,
+        email: null,
+        password: null,
+        role: null
+      },
+      affiliation: {
+        id: 1,
+        name: "Test Organization",
+        searchName: "test-organization",
+        uri: "https://test.org"
+      },
     }
   };
 
@@ -51,9 +72,6 @@ describe('useComments', () => {
     const { result } = renderHook(() =>
       useComments({
         dmpId: '1',
-        projectId: '1',
-        versionedSectionId: '1',
-        versionedQuestionId: '1',
         planFeedbackId: 10,
         me,
         planOrgId: 'org1',
@@ -71,8 +89,9 @@ describe('useComments', () => {
 
     // Simulate adding a comment
     await act(async () => {
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
       await result.current.handleAddComment(
-        { preventDefault: () => { } } as any,
+        fakeEvent,
         1,
         'New comment'
       );
@@ -92,14 +111,19 @@ describe('useComments', () => {
     });
 
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
     // First, add a comment so there's something to delete
     await act(async () => {
-      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Comment to delete');
-    });
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
 
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Comment to delete'
+      );
+    });
     // Grab the comment that was just added
     const commentToDelete = result.current.mergedComments[0];
     expect(commentToDelete).toBeDefined();
@@ -124,12 +148,18 @@ describe('useComments', () => {
 
 
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
     // First, add a comment so there's something to delete
     await act(async () => {
-      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Comment to delete');
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Comment to delete'
+      );
     });
 
     // Grab the comment that was just added
@@ -156,9 +186,6 @@ describe('useComments', () => {
     const { result } = renderHook(() =>
       useComments({
         dmpId: '1',
-        projectId: '1',
-        versionedSectionId: '1',
-        versionedQuestionId: '1',
         me,
         planFeedbackId
       })
@@ -199,9 +226,6 @@ describe('useComments', () => {
     const { result } = renderHook(() =>
       useComments({
         dmpId: '1',
-        projectId: '1',
-        versionedSectionId: '1',
-        versionedQuestionId: '1',
         me,
         planFeedbackId,
         planOrgId: 'org1',
@@ -245,11 +269,16 @@ describe('useComments', () => {
       data: {},
     });
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
     await act(async () => {
-      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Failing comment');
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Failing comment'
+      );
     });
 
     expect(result.current.mergedComments.length).toBe(0);
@@ -264,13 +293,17 @@ describe('useComments', () => {
       redirect: '/new-url'
     });
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
     await act(async () => {
-      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Failing comment');
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Failing comment'
+      );
     });
-
     // Verify that router.push was called with "/new-url"
     expect(mockRouter.push).toHaveBeenCalledWith('/new-url');
   });
@@ -283,11 +316,16 @@ describe('useComments', () => {
     });
 
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
     await act(async () => {
-      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Bad comment');
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Bad comment'
+      );
     });
 
     expect(result.current.mergedComments.length).toBe(0);
@@ -296,11 +334,16 @@ describe('useComments', () => {
 
   it('should replace tempId with real id on successful add', async () => {
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
     await act(async () => {
-      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Real id comment');
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Real id comment'
+      );
     });
 
     const saved = result.current.mergedComments[0];
@@ -309,11 +352,16 @@ describe('useComments', () => {
 
   it('should delete comment successfully and show toast', async () => {
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
     await act(async () => {
-      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Delete me');
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Delete me'
+      );
     });
 
     await waitFor(() => {
@@ -346,12 +394,17 @@ describe('useComments', () => {
 
   it('should update comment successfully and clear edit state', async () => {
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
     // Add a comment
     await act(async () => {
-      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Old text');
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Old text'
+      );
     });
     const comment = result.current.mergedComments[0];
 
@@ -380,11 +433,16 @@ describe('useComments', () => {
       data: {},
     });
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
     await act(async () => {
-      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Initial text');
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Initial text'
+      );
     });
     const comment = result.current.mergedComments[0];
 
@@ -412,11 +470,16 @@ describe('useComments', () => {
       redirect: '/new-url'
     });
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
     await act(async () => {
-      await result.current.handleAddComment({ preventDefault: () => { } } as any, 1, 'Initial text');
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Initial text'
+      );
     });
     const comment = result.current.mergedComments[0];
 
@@ -435,15 +498,24 @@ describe('useComments', () => {
 
   });
 
-  it('should enter and cancel edit mode', () => {
+  it('should enter and cancel edit mode', async () => {
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
-    const fakeComment = { id: 99, commentText: 'test' } as any;
+    await act(async () => {
+      const fakeEvent = { preventDefault: () => { } } as unknown as React.FormEvent<HTMLFormElement>;
 
-    act(() => result.current.handleEditComment(fakeComment));
-    expect(result.current.editingCommentId).toBe(99);
+      await result.current.handleAddComment(
+        fakeEvent,
+        1,
+        'Comment to delete'
+      );
+    });
+    // Grab the comment that was just added
+    const commentToEdit = result.current.mergedComments[0];
+    act(() => result.current.handleEditComment(commentToEdit));
+    expect(result.current.editingCommentId).toBe(123);
 
     act(() => result.current.handleCancelEdit());
     expect(result.current.editingCommentId).toBe(null);
@@ -452,11 +524,11 @@ describe('useComments', () => {
 
   it('should merge and sort answer + feedback comments', () => {
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me })
+      useComments({ dmpId: '1', me })
     );
 
-    const answerComments = [{ id: 1, commentText: 'Answer', created: '10', answerId: 1 }] as any;
-    const feedbackComments = [{ id: 2, commentText: 'Feedback', created: '5' }] as any;
+    const answerComments = [{ id: 1, commentText: 'Answer', created: '10', answerId: 1 }] as AnswerComment[];
+    const feedbackComments = [{ id: 2, commentText: 'Feedback', created: '5' }] as FeedbackComment[];
 
     act(() => result.current.setCommentsFromData(answerComments, feedbackComments));
 
@@ -465,10 +537,17 @@ describe('useComments', () => {
   });
 
   it('should set canAddComments true for collaborator', () => {
+    const meResearcher = {
+      me: {
+        ...me.me,
+        id: 2,
+        role: UserRole.Researcher
+      }
+    };
     const { result } = renderHook(() =>
       useComments({
-        dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1',
-        me: { me: { id: 2, role: 'USER' } },
+        dmpId: '1',
+        me: meResearcher,
         collaborators: [2]
       })
     );
@@ -478,8 +557,15 @@ describe('useComments', () => {
   });
 
   it('should set canAddComments false when user not allowed', () => {
+    const meResearcher = {
+      me: {
+        ...me.me,
+        id: 3,
+        role: UserRole.Researcher
+      }
+    };
     const { result } = renderHook(() =>
-      useComments({ dmpId: '1', projectId: '1', versionedSectionId: '1', versionedQuestionId: '1', me: { me: { id: 3, role: 'USER' } } })
+      useComments({ dmpId: '1', me: meResearcher })
     );
 
     act(() => result.current.updateCanAddComments());

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/useComments.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/useComments.tsx
@@ -3,8 +3,6 @@ import { useState, useRef, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useToast } from '@/context/ToastContext';
-import logECS from '@/utils/clientLogger';
-import { routePath } from '@/utils/routes';
 import {
   addAnswerCommentAction,
   addFeedbackCommentAction,
@@ -15,6 +13,7 @@ import {
 } from '../actions';
 
 import { MergedComment } from '@/app/types';
+import { MeQuery } from '@/generated/graphql';
 
 type AddCommentData = {
   id: number;
@@ -23,7 +22,7 @@ type AddCommentData = {
   errors?: { [key: string]: string | null } | null;
 };
 
-interface AnswerComment {
+export interface AnswerComment {
   __typename?: "AnswerComment";
   id?: number | null;
   commentText: string;
@@ -38,7 +37,7 @@ interface AnswerComment {
   } | null | undefined;
 }
 
-interface FeedbackComment {
+export interface FeedbackComment {
   __typename?: "PlanFeedbackComment";
   id?: number | null;
   commentText?: string | null;
@@ -59,11 +58,8 @@ interface FeedbackComment {
 
 interface UseCommentsProps {
   dmpId: string;
-  projectId: string;
-  versionedSectionId: string;
-  versionedQuestionId: string;
   planFeedbackId?: number | null;
-  me?: any;
+  me?: MeQuery | null | undefined;
   planOrgId?: string;
   openFeedbackRounds?: boolean;
   planOwners?: number[] | null;
@@ -76,9 +72,6 @@ interface MutationErrorsInterface {
 
 export const useComments = ({
   dmpId,
-  projectId,
-  versionedSectionId,
-  versionedQuestionId,
   planFeedbackId,
   me,
   planOrgId,
@@ -235,7 +228,7 @@ export const useComments = ({
         __typename: 'PlanFeedbackComment',
         id: tempId,
         commentText: newComment,
-        answerId: answerId,
+        answerId,
         created: new Date().getTime().toString(),
         modified: new Date().getTime().toString(),
         type: 'feedback',
@@ -254,7 +247,7 @@ export const useComments = ({
         __typename: 'AnswerComment',
         id: tempId,
         commentText: newComment,
-        answerId: answerId,
+        answerId,
         created: new Date().getTime().toString(),
         modified: new Date().getTime().toString(),
         type: 'answer',
@@ -424,7 +417,7 @@ export const useComments = ({
     editingCommentId,
     editingCommentText,
     canAddComments,
-    errors: errors,
+    errors,
     commentsEndRef,
 
     // Setters

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/useComments.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/useComments.tsx
@@ -1,0 +1,488 @@
+// hooks/useComments.ts
+import { useState, useRef, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { useToast } from '@/context/ToastContext';
+import logECS from '@/utils/clientLogger';
+import { routePath } from '@/utils/routes';
+import {
+  addAnswerCommentAction,
+  addFeedbackCommentAction,
+  removeAnswerCommentAction,
+  removeFeedbackCommentAction,
+  updateAnswerCommentAction,
+  updateFeedbackCommentAction
+} from '../actions';
+
+import { MergedComment } from '@/app/types';
+
+type AddCommentData = {
+  id: number;
+  answerId: number;
+  commenText: string;
+  errors?: { [key: string]: string | null } | null;
+};
+
+interface AnswerComment {
+  __typename?: "AnswerComment";
+  id?: number | null;
+  commentText: string;
+  answerId: number;
+  created?: string | null;
+  modified?: string | null;
+  user?: {
+    __typename?: "User";
+    id?: number | null;
+    surName?: string | null;
+    givenName?: string | null;
+  } | null | undefined;
+}
+
+interface FeedbackComment {
+  __typename?: "PlanFeedbackComment";
+  id?: number | null;
+  commentText?: string | null;
+  created?: string | null;
+  answerId?: number | null;
+  modified?: string | null;
+  PlanFeedback?: {
+    __typename?: "PlanFeedback";
+    id?: number | null;
+  } | null;
+  user?: {
+    __typename?: "User";
+    id?: number | null;
+    surName?: string | null;
+    givenName?: string | null;
+  } | null | undefined
+}
+
+interface UseCommentsProps {
+  dmpId: string;
+  projectId: string;
+  versionedSectionId: string;
+  versionedQuestionId: string;
+  planFeedbackId?: number | null;
+  me?: any;
+  planOrgId?: string;
+  openFeedbackRounds?: boolean;
+  planOwners?: number[] | null;
+  collaborators?: number[];
+}
+
+interface MutationErrorsInterface {
+  general: string | null;
+}
+
+export const useComments = ({
+  dmpId,
+  projectId,
+  versionedSectionId,
+  versionedQuestionId,
+  planFeedbackId,
+  me,
+  planOrgId,
+  openFeedbackRounds,
+  planOwners,
+  collaborators
+}: UseCommentsProps) => {
+  const router = useRouter();
+  const toastState = useToast();
+  const Global = useTranslations('Global');
+  const t = useTranslations('PlanOverviewQuestionPage');
+
+  // Comment states
+  const [mergedComments, setMergedComments] = useState<MergedComment[]>([]);
+  const [editingCommentId, setEditingCommentId] = useState<number | null | undefined>(null);
+  const [editingCommentText, setEditingCommentText] = useState<string>('');
+  const [newCommentText, setNewCommentText] = useState<string>('');
+  const [canAddComments, setCanAddComments] = useState<boolean>(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  // Ref for scrolling to bottom of comments
+  const commentsEndRef = useRef<HTMLDivElement | null>(null);
+
+  // Helper functions
+  const hasFieldLevelErrors = (mutationErrors: MutationErrorsInterface): boolean => {
+    return Object.values(mutationErrors).some(
+      value => value !== null && value !== undefined
+    );
+  };
+
+  const getExtractedErrorValues = (mutationErrors: MutationErrorsInterface): string[] => {
+    return Object.values(mutationErrors).filter(
+      (value) => value !== null && value !== undefined
+    );
+  };
+
+  // Determine if user can add comments
+  const updateCanAddComments = useCallback(() => {
+    if (!me) return;
+
+    // Is this user an admin?
+    if (['ADMIN', 'SUPERADMIN'].includes(me?.me?.role as string)) {
+      // Does this admin belong to the same org as plan, and are there any feedback rounds open?
+      const meURI = me?.me?.affiliation?.uri;
+      if ((meURI === planOrgId) && openFeedbackRounds) {
+        setCanAddComments(true);
+        return;
+      }
+    }
+
+    // If the current user is a project collaborator or plan owner
+    const userId = me?.me?.id as number;
+    if (collaborators?.includes(userId) || planOwners?.includes(userId)) {
+      setCanAddComments(true);
+      return;
+    }
+
+    setCanAddComments(false);
+  }, [me, planOrgId, openFeedbackRounds, collaborators, planOwners]);
+
+  // Add comment action
+  const addComment = async (comment: MergedComment) => {
+    let response;
+    try {
+      if (comment.isAnswerComment) {
+        response = await addAnswerCommentAction({
+          answerId: Number(comment?.answerId),
+          commentText: comment?.commentText ?? ''
+        });
+      } else if (planFeedbackId) {
+        response = await addFeedbackCommentAction({
+          planId: Number(dmpId),
+          planFeedbackId,
+          answerId: Number(comment?.answerId),
+          commentText: comment?.commentText ?? ''
+        });
+      }
+
+      if (response?.redirect) {
+        router.push(response.redirect);
+      }
+
+      if (response) {
+        return {
+          success: response.success,
+          errors: response.errors,
+          data: response.data
+        };
+      }
+      return {
+        success: false,
+        errors: [Global('messaging.somethingWentWrong')],
+        data: null
+      };
+    } catch (error) {
+      logECS('error', 'addComment', {
+        error,
+        url: {
+          path: routePath('projects.dmp.versionedQuestion.detail', {
+            projectId, dmpId, versionedSectionId, versionedQuestionId
+          })
+        }
+      });
+      return {
+        success: false,
+        errors: [Global('messaging.somethingWentWrong')],
+        data: null
+      };
+    }
+  };
+
+  // Delete comment action
+  const deleteComment = async (comment: MergedComment) => {
+    try {
+      const response = comment.isAnswerComment
+        ? await removeAnswerCommentAction({
+          answerId: Number(comment?.answerId),
+          answerCommentId: Number(comment?.id)
+        })
+        : await removeFeedbackCommentAction({
+          planId: Number(dmpId),
+          planFeedbackCommentId: Number(comment?.id)
+        });
+
+      if (response.redirect) {
+        router.push(response.redirect);
+      }
+
+      return {
+        success: response.success,
+        errors: response.errors,
+        data: response.data
+      };
+    } catch (error) {
+      logECS('error', 'deleteComment', {
+        error,
+        url: {
+          path: routePath('projects.dmp.versionedQuestion.detail', {
+            projectId, dmpId, versionedSectionId, versionedQuestionId
+          })
+        }
+      });
+      return {
+        success: false,
+        errors: [Global('messaging.somethingWentWrong')],
+        data: null
+      };
+    }
+  };
+
+  // Update comment action
+  const updateComment = async (comment: MergedComment) => {
+    try {
+      const response = comment.isAnswerComment
+        ? await updateAnswerCommentAction({
+          answerId: Number(comment?.answerId),
+          answerCommentId: Number(comment?.id),
+          commentText: editingCommentText
+        })
+        : await updateFeedbackCommentAction({
+          planId: Number(dmpId),
+          planFeedbackCommentId: Number(comment?.id),
+          commentText: editingCommentText
+        });
+
+      if (response.redirect) {
+        router.push(response.redirect);
+      }
+
+      return {
+        success: response.success,
+        errors: response.errors,
+        data: response.data
+      };
+    } catch (error) {
+      logECS('error', 'updateComment', {
+        error,
+        url: {
+          path: routePath('projects.dmp.versionedQuestion.detail', {
+            projectId, dmpId, versionedSectionId, versionedQuestionId
+          })
+        }
+      });
+      return {
+        success: false,
+        errors: [Global('messaging.somethingWentWrong')],
+        data: null
+      };
+    }
+  };
+
+  // Event handlers
+  const handleAddComment = async (e: React.FormEvent<HTMLFormElement>, answerId: number, newComment: string): Promise<void> => {
+    e.preventDefault();
+    let optimisticComment: MergedComment;
+    const tempId = Date.now() * -1;
+
+    // Determine comment type based on user role and feedback rounds
+    if ((['ADMIN', 'SUPERADMIN'].includes(me?.me?.role as string)) && planOrgId && openFeedbackRounds) {
+      optimisticComment = {
+        __typename: 'PlanFeedbackComment',
+        id: tempId,
+        commentText: newComment,
+        answerId: answerId,
+        created: new Date().getTime().toString(),
+        modified: new Date().getTime().toString(),
+        type: 'feedback',
+        isAnswerComment: false,
+        isFeedbackComment: true,
+        user: {
+          __typename: 'User',
+          id: me?.me?.id,
+          givenName: me?.me?.givenName,
+          surName: me?.me?.surName
+        },
+        PlanFeedback: null
+      };
+    } else {
+      optimisticComment = {
+        __typename: 'AnswerComment',
+        id: tempId,
+        commentText: newComment,
+        answerId: answerId,
+        created: new Date().getTime().toString(),
+        modified: new Date().getTime().toString(),
+        type: 'answer',
+        isAnswerComment: true,
+        isFeedbackComment: false,
+        user: {
+          __typename: 'User',
+          id: me?.me?.id,
+          givenName: me?.me?.givenName,
+          surName: me?.me?.surName
+        },
+        PlanFeedback: null
+      };
+    }
+
+    const originalComments = [...mergedComments];
+
+    // Optimistic update
+    setMergedComments(prev => [...prev, optimisticComment].sort((a, b) => {
+      return parseInt(a.created || '0', 10) - parseInt(b.created || '0', 10);
+    }));
+
+    setNewCommentText('');
+
+    // Call mutation
+    const result = await addComment(optimisticComment);
+
+    if (!result?.success) {
+      setMergedComments(originalComments);
+      const errors = result?.errors;
+      if (errors) {
+        setErrors(errors);
+      }
+    } else if (result.data?.errors && hasFieldLevelErrors(result.data.errors as unknown as MutationErrorsInterface)) {
+      const mutationErrors = result.data.errors as unknown as MutationErrorsInterface;
+      const extractedErrors = getExtractedErrorValues(mutationErrors);
+      setMergedComments(originalComments);
+      setErrors(extractedErrors);
+    } else {
+      toastState.add(t('messages.commentSent'), { type: 'success', timeout: 3000 });
+      // Scroll to bottom of comments list
+      if (commentsEndRef.current) {
+        commentsEndRef.current.scrollIntoView({ behavior: "smooth" });
+      }
+
+      // Take the optimistic comment and replace tempId with actual ID from server
+      const savedComment = result?.data as AddCommentData;
+
+      if (savedComment?.id) {
+        const newId = savedComment?.id;
+
+        setMergedComments(prev =>
+          prev.map(c =>
+            c.id === tempId ? { ...c, id: newId } : c
+          )
+        );
+      }
+    }
+  };
+
+  const handleDeleteComment = async (comment: MergedComment) => {
+    const originalComments = [...mergedComments];
+
+    // Optimistic update
+    setMergedComments(prev => prev.filter(c => c.id !== comment.id));
+
+    const result = await deleteComment(comment);
+
+    if (!result.success) {
+      setMergedComments(originalComments);
+      const errors = result.errors;
+      if (errors) {
+        setErrors(errors);
+      }
+    } else if (result.data?.errors && hasFieldLevelErrors(result.data.errors as unknown as MutationErrorsInterface)) {
+      const mutationErrors = result.data.errors as unknown as MutationErrorsInterface;
+      const extractedErrors = getExtractedErrorValues(mutationErrors);
+      setMergedComments(originalComments);
+      setErrors(extractedErrors);
+    } else {
+      toastState.add(t('messages.commentDeleted'), { type: 'success', timeout: 3000 });
+    }
+  };
+
+  const handleEditComment = (comment: MergedComment) => {
+    setEditingCommentId(comment?.id);
+    setEditingCommentText(comment?.commentText || '');
+  };
+
+  const handleUpdateComment = async (comment: MergedComment) => {
+    const originalComment = { ...comment };
+
+    // Optimistic update
+    setMergedComments(prev =>
+      prev.map(c =>
+        c.id === comment.id
+          ? {
+            ...c,
+            commentText: editingCommentText,
+            modified: new Date().getTime().toString()
+          }
+          : c
+      )
+    );
+
+    const result = await updateComment(comment);
+
+    if (!result.success) {
+      setMergedComments(prev =>
+        prev.map(c => c.id === comment.id ? originalComment : c)
+      );
+      const errors = result.errors;
+      if (errors) {
+        setErrors(errors);
+      }
+    } else if (result.data?.errors && hasFieldLevelErrors(result.data.errors as unknown as MutationErrorsInterface)) {
+      setMergedComments(prev =>
+        prev.map(c => c.id === comment.id ? originalComment : c)
+      );
+      const mutationErrors = result.data.errors as unknown as MutationErrorsInterface;
+      const extractedErrors = getExtractedErrorValues(mutationErrors);
+      setErrors(extractedErrors);
+    } else {
+      setEditingCommentId(null);
+      setEditingCommentText('');
+      toastState.add(t('messages.commentUpdated'), { type: 'success', timeout: 3000 });
+    }
+  };
+
+  const handleCancelEdit = () => {
+    setEditingCommentId(null);
+    setEditingCommentText('');
+  };
+
+  // Utility function to set merged comments (for external use)
+  const setCommentsFromData = (
+    answerComments: AnswerComment[] | undefined | null,
+    feedbackComments: FeedbackComment[] | undefined | null
+  ) => {
+    const merged: MergedComment[] = [
+      ...(answerComments || []).map(comment => ({
+        ...comment,
+        type: 'answer' as const,
+        isAnswerComment: true as const,
+        isFeedbackComment: false as const
+      })),
+      ...(feedbackComments || []).map(comment => ({
+        ...comment,
+        type: 'feedback' as const,
+        isAnswerComment: false as const,
+        isFeedbackComment: true as const
+      }))
+    ].sort((a, b) => {
+      if (!a.created && !b.created) return 0;
+      if (!a.created) return 1;
+      if (!b.created) return -1;
+      return parseInt(a.created, 10) - parseInt(b.created, 10);
+    });
+
+    setMergedComments(merged);
+  };
+
+  return {
+    // State
+    mergedComments,
+    editingCommentId,
+    editingCommentText,
+    canAddComments,
+    errors: errors,
+    commentsEndRef,
+
+    // Setters
+    setEditingCommentText,
+    setCommentsFromData,
+    updateCanAddComments,
+
+    // Handlers
+    handleAddComment,
+    handleDeleteComment,
+    handleEditComment,
+    handleUpdateComment,
+    handleCancelEdit
+  };
+};

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
@@ -255,9 +255,6 @@ const PlanOverviewQuestionPage: React.FC = () => {
     handleCancelEdit
   } = useComments({
     dmpId,
-    projectId,
-    versionedSectionId,
-    versionedQuestionId,
     planFeedbackId: plan?.feedbackId,
     me,
     planOrgId: plan?.orgId,

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
@@ -52,6 +52,7 @@ import { useToast } from '@/context/ToastContext';
 import logECS from '@/utils/clientLogger';
 import { routePath } from '@/utils/routes';
 import { stripHtmlTags } from '@/utils/general';
+import { formatRelativeFromTimestamp } from '@/utils/dateUtils';
 import { QuestionTypeMap } from '@dmptool/types';
 
 import {
@@ -122,6 +123,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
   const projectId = params.projectId as string;
   const versionedSectionId = params.sid as string;
   const versionedQuestionId = params.qid as string;
+  const locale = params.locale as string;
   const toastState = useToast(); // Access the toast state from context
   //For scrolling to error in page
   const errorRef = useRef<HTMLDivElement | null>(null);
@@ -194,6 +196,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
     }
   );
 
+
   // Get Plan using planId
   const { data: planData, loading: planQueryLoading, error: planQueryError } = usePlanQuery(
     {
@@ -202,7 +205,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
     }
   );
 
-  // Get loadAnswer to call later, after we set the versionedQuestionId
+  // Get answer data
   const { data: answerData, loading: answerLoading, error: answerError } = useAnswerByVersionedQuestionIdQuery(
     {
       variables: {
@@ -212,7 +215,6 @@ const PlanOverviewQuestionPage: React.FC = () => {
       }
     }
   );
-
 
   // Show Success Message
   const showSuccessToast = () => {
@@ -970,6 +972,12 @@ const PlanOverviewQuestionPage: React.FC = () => {
     return () => clearInterval(interval);
   }, []);
 
+
+  useEffect(() => {
+    console.log("ANSWER Data", answerData)
+  }, [answerData])
+
+
   // Render the question using the useRenderQuestionField helper
   const questionField = useRenderQuestionField({
     questionType,
@@ -1302,26 +1310,25 @@ const PlanOverviewQuestionPage: React.FC = () => {
           onClose={closeCurrentDrawer}
           returnFocusRef={openCommentsButtonRef}
           className={styles.drawerPanelWrapper}
+          title={PlanOverview('headings.comments')}
         >
-          <h2>{PlanOverview('headings.comments')}</h2>
           <div className={styles.comment}>
-            <h4>John Smith</h4>
-            <p className={styles.deEmphasize}>2 days ago</p>
-            <p>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-              laboris nisi ut aliquip ex ea commodo consequat.
-            </p>
-          </div>
-
-          <div className={styles.comment}>
-            <h4>John Smith</h4>
-            <p className={styles.deEmphasize}>2 days ago</p>
-            <p>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-              laboris nisi ut aliquip ex ea commodo consequat.
-            </p>
+            {answerData?.answerByVersionedQuestionId?.comments?.map((comment, index) => {
+              const formattedCreatedDate = comment.created ? formatRelativeFromTimestamp(comment.created, locale) : '';
+              return (
+                <div key={index}>
+                  <div>
+                    <h4>{comment?.user?.givenName}{' '}{comment?.user?.surName}</h4>
+                    <p className={styles.deEmphasize}>{formattedCreatedDate}{(comment.created !== comment.modified) ? `(edited)` : ''}</p>
+                    <p>{comment.commentText}</p>
+                    <div>
+                      <Button className={`${styles.deEmphasize} link`} type="button">Edit</Button>
+                      <Button className={`${styles.deEmphasize} link`} type="button">Delete</Button>
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
           </div>
 
           <div className={styles.leaveComment}>

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Image from 'next/image';
-import classNames from 'classnames';
 import {
   Breadcrumb,
   Breadcrumbs,
@@ -296,19 +295,6 @@ const PlanOverviewQuestionPage: React.FC = () => {
     setIsSideBarPanelOpen(true);
     setSampleTextDrawerOpen(false);
     setCommentsDrawerOpen(false);
-  }
-
-  // Close all drawer panels. One scenario is when the user clicks on the masked content.
-  const closeDrawers = (e?: React.MouseEvent<HTMLDivElement, MouseEvent> | React.MouseEvent<Element, MouseEvent>) => {
-    setIsSideBarPanelOpen(true);
-
-    // Only close if clicking on the mask/backdrop, not the drawer content
-    if (e && e.target === e.currentTarget) {
-      if (isCommentsDrawerOpen || isSampleTextDrawerOpen) {
-        setSampleTextDrawerOpen(false);
-        setCommentsDrawerOpen(false);
-      }
-    }
   }
 
   function buildSetContent<T extends keyof FormDataInterface>(
@@ -1055,14 +1041,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
 
   // Set errors from commentErrors state
   useEffect(() => {
-    setErrors((prevErrors) => {
-      // If there are no errors, return an empty array
-      if (!commentErrors || commentErrors.length === 0) {
-        return [];
-      }
-      // Otherwise, include the comment errors
-      return prevErrors.concat(commentErrors);
-    });
+    setErrors((prevErrors) => [...prevErrors, ...commentErrors]);
   }, [commentErrors])
 
   // Render the question using the useRenderQuestionField helper
@@ -1167,10 +1146,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
 
       <ErrorMessages errors={errors} ref={errorRef} />
 
-      <LayoutWithPanel
-        onClick={e => closeDrawers(e)}
-        className={classNames('layout-mask', { 'drawer-open': isSampleTextDrawerOpen || isCommentsDrawerOpen })}
-      >
+      <LayoutWithPanel>
         <ContentContainer>
           <div className="container">
             {/**Requirements by funder */}
@@ -1369,6 +1345,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
             </p>
           </ExpandableContentSection>
         </SidebarPanel>
+
 
         {/** Sample text drawer. Only include for question types = Text Area */}
         {

--- a/app/[locale]/styleguide/page.tsx
+++ b/app/[locale]/styleguide/page.tsx
@@ -741,6 +741,7 @@ function Page() {
                 <DmpIcon icon="check_circle" />
                 <DmpIcon icon="error_circle" />
                 <DmpIcon icon="close" />
+                <DmpIcon icon="right-panel_close" />
                 <DmpIcon icon="solid-left_arrow" />
                 <DmpIcon icon="solid-right_arrow" />
                 <DmpIcon icon="solid-down_arrow" />

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { PlanSectionProgress, TemplateVisibility } from "@/generated/graphql";
+import { PlanSectionProgress, TemplateVisibility, PlanFeedback } from "@/generated/graphql";
 import { AffiliationSearchQuestionType, AnyQuestionType } from '@dmptool/types';
 
 export interface EmailInterface {
@@ -462,5 +462,5 @@ export interface MergedComment {
   // Optional fields that may exist on either type
   user?: User | null;
   modified?: string | null;
-  PlanFeedback?: any | null;
+  PlanFeedback?: PlanFeedback | null;
 }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -441,3 +441,26 @@ export interface AffiliationSearchQuestionProps {
   handleAffiliationChange: (id: string, value: string) => Promise<void>
   handleOtherAffiliationChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
+
+interface User {
+  __typename?: "User";
+  id?: number | null;
+  surName?: string | null;
+  givenName?: string | null;
+}
+
+export interface MergedComment {
+  __typename?: "AnswerComment" | "PlanFeedbackComment";
+  id?: number | null;
+  commentText?: string | null;
+  answerId?: number | null;
+  created?: string | null;
+  type: 'answer' | 'feedback';
+  isAnswerComment: boolean;
+  isFeedbackComment: boolean;
+
+  // Optional fields that may exist on either type
+  user?: User | null;
+  modified?: string | null;
+  PlanFeedback?: any | null;
+}

--- a/components/Container/LayoutWithPanel.tsx
+++ b/components/Container/LayoutWithPanel.tsx
@@ -272,10 +272,7 @@ export const DrawerPanel: React.FC<DrawerPanelProps> = ({
               </Button>
             </div>
             <h2>{title}</h2>
-            {/* Add a scrollable wrapper for the desktop version, so that user can scroll the drawer panel */}
-            <div className="drawer-scrollable-content">
-              {children}
-            </div>
+            {children}
           </ContentContainer >
         </div >
       )}
@@ -303,10 +300,7 @@ export const DrawerPanel: React.FC<DrawerPanelProps> = ({
               </Button>
             </div>
             <h2>{title}</h2>
-            {/* Add a scrollable wrapper for the desktop version so that user can scroll the drawer panel*/}
-            <div className="drawer-scrollable-content">
-              {children}
-            </div>
+            {children}
           </div>
         )
       }

--- a/components/Container/LayoutWithPanel.tsx
+++ b/components/Container/LayoutWithPanel.tsx
@@ -143,6 +143,7 @@ export const SidebarPanel: React.FC<SidebarPanelProps> = ({
 interface DrawerPanelProps extends ContentContainerProps {
   isOpen?: boolean;
   onClose?: () => void;
+  title?: string;
   returnFocusRef?: React.RefObject<HTMLElement>;
 }
 
@@ -150,6 +151,7 @@ export const DrawerPanel: React.FC<DrawerPanelProps> = ({
   children,
   id = '',
   className = '',
+  title = '',
   isOpen = false,
   onClose,
   returnFocusRef
@@ -257,47 +259,57 @@ export const DrawerPanel: React.FC<DrawerPanelProps> = ({
           data-testid="drawer-panel"
         >
           <ContentContainer className="drawer-content">
-            <Button
-              ref={closeButtonRef}
-              className="close-action"
-              aria-label={Global('buttons.close')}
-              onPress={handleClose}
-              data-testid="close-action"
-            >
-              <DmpIcon icon="close" />
-            </Button>
+            <div className="close-action-container">
+              <Button
+                ref={closeButtonRef}
+                className="close-action"
+                aria-label={Global('buttons.close')}
+                onPress={handleClose}
+                data-testid="close-action"
+              >
+                <DmpIcon icon="right-panel_close" />
+                {' '}{Global('buttons.close')}
+              </Button>
+            </div>
+            <h2>{title}</h2>
             {/* Add a scrollable wrapper for the desktop version, so that user can scroll the drawer panel */}
             <div className="drawer-scrollable-content">
               {children}
             </div>
-          </ContentContainer>
-        </div>
+          </ContentContainer >
+        </div >
       )}
 
-      {!isMobile && (
-        <div
-          id={id}
-          ref={drawerRef}
-          className={`layout-drawer-panel ${className} ${stateOpen ? "state-open" : "state-closed"}`}
-          tabIndex={stateOpen ? 0 : -1}
-          aria-hidden={!stateOpen}
-          data-testid="drawer-panel"
-        >
-          <Button
-            ref={closeButtonRef}
-            className="close-action"
-            aria-label={Global('buttons.close')}
-            onPress={handleClose}
-            data-testid="close-action"
+      {
+        !isMobile && (
+          <div
+            id={id}
+            ref={drawerRef}
+            className={`layout-drawer-panel ${className} ${stateOpen ? "state-open" : "state-closed"}`}
+            tabIndex={stateOpen ? 0 : -1}
+            aria-hidden={!stateOpen}
+            data-testid="drawer-panel"
           >
-            <DmpIcon icon="close" />
-          </Button>
-          {/* Add a scrollable wrapper for the desktop version so that user can scroll the drawer panel*/}
-          <div className="drawer-scrollable-content">
-            {children}
+            <div className="close-action-container">
+              <Button
+                ref={closeButtonRef}
+                className="close-action"
+                aria-label={Global('buttons.close')}
+                onPress={handleClose}
+                data-testid="close-action"
+              >
+                <DmpIcon icon="right-panel_close" />
+                {' '}{Global('buttons.close')}
+              </Button>
+            </div>
+            <h2>{title}</h2>
+            {/* Add a scrollable wrapper for the desktop version so that user can scroll the drawer panel*/}
+            <div className="drawer-scrollable-content">
+              {children}
+            </div>
           </div>
-        </div>
-      )}
+        )
+      }
     </>
   );
 }

--- a/components/Container/containers.scss
+++ b/components/Container/containers.scss
@@ -149,6 +149,7 @@
   height: 100vh;
   z-index: 10;
   background-color: white;
+  padding: var(--space-5);
   transition: transform 0.3s ease-in-out;
   transform: translateX(100%); // hide offscreen
   display: flex;
@@ -168,8 +169,6 @@
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: var(--layout-content-padding, var(--brand-space2));
-  padding-top: 4rem; // Space for close button
   overscroll-behavior: contain;
   
   > :first-child { 
@@ -199,20 +198,13 @@
   
 // Close button in the drawer panel
 .close-action {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 50%;
   background: #fff;
-  border: 2px solid #000;
   color: #000;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  padding: 0;
+  padding: 0.25rem;
   z-index: 21;
   transition: background 0.2s ease-in-out;
 
@@ -240,12 +232,6 @@
     box-shadow: 0 0 0 3px var(--focus-ring, #3b82f6);
   }
 
-  svg {
-    width: 1.25rem;
-    height: 1.25rem;
-    fill: #000;
-  }
-
   .dmp-icon {
     // override existing styles for dmp-icon because the icon, in this case, 
     //is sharing same position as the circle around it
@@ -261,4 +247,12 @@
       }
   }
 
+}
+
+.close-action-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: right;
+  width: 100%;
 }

--- a/components/Container/containers.scss
+++ b/components/Container/containers.scss
@@ -164,18 +164,6 @@
   }
 }
 
-// Scrollable content for both mobile and desktop
-.drawer-scrollable-content {
-  flex: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
-  overscroll-behavior: contain;
-  
-  > :first-child { 
-    margin-top: 0; 
-  }
-}
-
 // Add mask to rest of content when drawer panel is open
 .layout-mask::before { 
   content: "";

--- a/components/ExpandableContentSection/index.tsx
+++ b/components/ExpandableContentSection/index.tsx
@@ -13,7 +13,7 @@ export default function ExpandableContentSection({
   children
 }: {
   id: string;
-  heading: string;
+  heading?: string;
   expandLabel?: string;
   collapseLabel?: string;
   summaryCharLimit?: number;
@@ -100,8 +100,9 @@ export default function ExpandableContentSection({
 
   return (
     <section className={styles.section}>
-      <h3 id={`${id}-heading`} className="h5">{heading}</h3>
-
+      {heading && (
+        <h3 id={`${id}-heading`} className="h5">{heading}</h3>
+      )}
       {/**Don't show the summaryElements if the content is expanded */}
       <div className={styles.summaryContent} id={contentId}>
         {isExpanded || !wasTruncated ? children : summaryElements}

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -39,8 +39,6 @@ function Header() {
 
 
   const handleLogout = async (e: MouseEvent<HTMLAnchorElement>) => {
-    console.log("handleLogout called")
-
     e.preventDefault();
 
 

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -429,6 +429,8 @@ export type Answer = {
   createdById?: Maybe<Scalars['Int']['output']>;
   /** Errors associated with the Object */
   errors?: Maybe<AffiliationErrors>;
+  /** The feedback comments associated with the answer */
+  feedbackComments?: Maybe<Array<PlanFeedbackComment>>;
   /** The unique identifer for the Object */
   id?: Maybe<Scalars['Int']['output']>;
   /** The answer to the question */
@@ -1614,8 +1616,8 @@ export type PlanFeedbackComment = {
   __typename?: 'PlanFeedbackComment';
   /** The round of plan feedback the comment belongs to */
   PlanFeedback?: Maybe<PlanFeedback>;
-  /** The answer the comment is related to */
-  answer?: Maybe<Answer>;
+  /** The answerId the comment is related to */
+  answerId?: Maybe<Scalars['Int']['output']>;
   /** The comment */
   commentText?: Maybe<Scalars['String']['output']>;
   /** The timestamp when the Object was created */
@@ -1630,6 +1632,8 @@ export type PlanFeedbackComment = {
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** User who made the comment */
+  user?: Maybe<User>;
 };
 
 /** A collection of errors related to the PlanFeedbackComment */
@@ -3843,6 +3847,40 @@ export type UpdateAnswerMutationVariables = Exact<{
 
 export type UpdateAnswerMutation = { __typename?: 'Mutation', updateAnswer?: { __typename?: 'Answer', id?: number | null, json?: string | null, modified?: string | null, errors?: { __typename?: 'AffiliationErrors', acronyms?: string | null, aliases?: string | null, contactEmail?: string | null, contactName?: string | null, displayName?: string | null, feedbackEmails?: string | null, feedbackMessage?: string | null, fundrefId?: string | null, general?: string | null, homepage?: string | null, json?: string | null, logoName?: string | null, logoURI?: string | null, name?: string | null, planId?: string | null, provenance?: string | null, searchName?: string | null, ssoEntityId?: string | null, subHeaderLinks?: string | null, types?: string | null, uri?: string | null, versionedQuestionId?: string | null, versionedSectionId?: string | null } | null, versionedQuestion?: { __typename?: 'VersionedQuestion', versionedSectionId: number } | null } | null };
 
+export type RemoveAnswerCommentMutationVariables = Exact<{
+  answerCommentId: Scalars['Int']['input'];
+  answerId: Scalars['Int']['input'];
+}>;
+
+
+export type RemoveAnswerCommentMutation = { __typename?: 'Mutation', removeAnswerComment?: { __typename?: 'AnswerComment', id?: number | null, answerId: number, commentText: string, errors?: { __typename?: 'AnswerCommentErrors', general?: string | null } | null } | null };
+
+export type UpdateAnswerCommentMutationVariables = Exact<{
+  answerCommentId: Scalars['Int']['input'];
+  answerId: Scalars['Int']['input'];
+  commentText: Scalars['String']['input'];
+}>;
+
+
+export type UpdateAnswerCommentMutation = { __typename?: 'Mutation', updateAnswerComment?: { __typename?: 'AnswerComment', commentText: string, answerId: number, id?: number | null, errors?: { __typename?: 'AnswerCommentErrors', general?: string | null, commentText?: string | null, answerId?: string | null } | null } | null };
+
+export type RemoveFeedbackCommentMutationVariables = Exact<{
+  planId: Scalars['Int']['input'];
+  planFeedbackCommentId: Scalars['Int']['input'];
+}>;
+
+
+export type RemoveFeedbackCommentMutation = { __typename?: 'Mutation', removeFeedbackComment?: { __typename?: 'PlanFeedbackComment', id?: number | null, answerId?: number | null, commentText?: string | null, errors?: { __typename?: 'PlanFeedbackCommentErrors', general?: string | null } | null } | null };
+
+export type UpdateFeedbackCommentMutationVariables = Exact<{
+  planId: Scalars['Int']['input'];
+  planFeedbackCommentId: Scalars['Int']['input'];
+  commentText: Scalars['String']['input'];
+}>;
+
+
+export type UpdateFeedbackCommentMutation = { __typename?: 'Mutation', updateFeedbackComment?: { __typename?: 'PlanFeedbackComment', answerId?: number | null, commentText?: string | null, id?: number | null, errors?: { __typename?: 'PlanFeedbackCommentErrors', general?: string | null } | null } | null };
+
 export type AddPlanMutationVariables = Exact<{
   projectId: Scalars['Int']['input'];
   versionedTemplateId: Scalars['Int']['input'];
@@ -4120,7 +4158,7 @@ export type AnswerByVersionedQuestionIdQueryVariables = Exact<{
 }>;
 
 
-export type AnswerByVersionedQuestionIdQuery = { __typename?: 'Query', answerByVersionedQuestionId?: { __typename?: 'Answer', id?: number | null, json?: string | null, modified?: string | null, created?: string | null, versionedQuestion?: { __typename?: 'VersionedQuestion', id?: number | null } | null, plan?: { __typename?: 'Plan', id?: number | null } | null, comments?: Array<{ __typename?: 'AnswerComment', id?: number | null, commentText: string, answerId: number, created?: string | null, modified?: string | null, user?: { __typename?: 'User', surName?: string | null, givenName?: string | null } | null }> | null, errors?: { __typename?: 'AffiliationErrors', general?: string | null, planId?: string | null, versionedSectionId?: string | null, versionedQuestionId?: string | null, json?: string | null } | null } | null };
+export type AnswerByVersionedQuestionIdQuery = { __typename?: 'Query', answerByVersionedQuestionId?: { __typename?: 'Answer', id?: number | null, json?: string | null, modified?: string | null, created?: string | null, versionedQuestion?: { __typename?: 'VersionedQuestion', id?: number | null } | null, plan?: { __typename?: 'Plan', id?: number | null } | null, comments?: Array<{ __typename?: 'AnswerComment', id?: number | null, commentText: string, answerId: number, created?: string | null, modified?: string | null, user?: { __typename?: 'User', surName?: string | null, givenName?: string | null } | null }> | null, feedbackComments?: Array<{ __typename?: 'PlanFeedbackComment', id?: number | null, commentText?: string | null, created?: string | null, answerId?: number | null, modified?: string | null, PlanFeedback?: { __typename?: 'PlanFeedback', id?: number | null } | null, user?: { __typename?: 'User', surName?: string | null, givenName?: string | null } | null }> | null, errors?: { __typename?: 'AffiliationErrors', general?: string | null, planId?: string | null, versionedSectionId?: string | null, versionedQuestionId?: string | null, json?: string | null } | null } | null };
 
 export type ProjectFundingsQueryVariables = Exact<{
   projectId: Scalars['Int']['input'];
@@ -4487,6 +4525,177 @@ export function useUpdateAnswerMutation(baseOptions?: Apollo.MutationHookOptions
 export type UpdateAnswerMutationHookResult = ReturnType<typeof useUpdateAnswerMutation>;
 export type UpdateAnswerMutationResult = Apollo.MutationResult<UpdateAnswerMutation>;
 export type UpdateAnswerMutationOptions = Apollo.BaseMutationOptions<UpdateAnswerMutation, UpdateAnswerMutationVariables>;
+export const RemoveAnswerCommentDocument = gql`
+    mutation RemoveAnswerComment($answerCommentId: Int!, $answerId: Int!) {
+  removeAnswerComment(answerCommentId: $answerCommentId, answerId: $answerId) {
+    id
+    errors {
+      general
+    }
+    answerId
+    commentText
+  }
+}
+    `;
+export type RemoveAnswerCommentMutationFn = Apollo.MutationFunction<RemoveAnswerCommentMutation, RemoveAnswerCommentMutationVariables>;
+
+/**
+ * __useRemoveAnswerCommentMutation__
+ *
+ * To run a mutation, you first call `useRemoveAnswerCommentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveAnswerCommentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeAnswerCommentMutation, { data, loading, error }] = useRemoveAnswerCommentMutation({
+ *   variables: {
+ *      answerCommentId: // value for 'answerCommentId'
+ *      answerId: // value for 'answerId'
+ *   },
+ * });
+ */
+export function useRemoveAnswerCommentMutation(baseOptions?: Apollo.MutationHookOptions<RemoveAnswerCommentMutation, RemoveAnswerCommentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RemoveAnswerCommentMutation, RemoveAnswerCommentMutationVariables>(RemoveAnswerCommentDocument, options);
+      }
+export type RemoveAnswerCommentMutationHookResult = ReturnType<typeof useRemoveAnswerCommentMutation>;
+export type RemoveAnswerCommentMutationResult = Apollo.MutationResult<RemoveAnswerCommentMutation>;
+export type RemoveAnswerCommentMutationOptions = Apollo.BaseMutationOptions<RemoveAnswerCommentMutation, RemoveAnswerCommentMutationVariables>;
+export const UpdateAnswerCommentDocument = gql`
+    mutation UpdateAnswerComment($answerCommentId: Int!, $answerId: Int!, $commentText: String!) {
+  updateAnswerComment(
+    answerCommentId: $answerCommentId
+    answerId: $answerId
+    commentText: $commentText
+  ) {
+    commentText
+    answerId
+    id
+    errors {
+      general
+      commentText
+      answerId
+    }
+  }
+}
+    `;
+export type UpdateAnswerCommentMutationFn = Apollo.MutationFunction<UpdateAnswerCommentMutation, UpdateAnswerCommentMutationVariables>;
+
+/**
+ * __useUpdateAnswerCommentMutation__
+ *
+ * To run a mutation, you first call `useUpdateAnswerCommentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateAnswerCommentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateAnswerCommentMutation, { data, loading, error }] = useUpdateAnswerCommentMutation({
+ *   variables: {
+ *      answerCommentId: // value for 'answerCommentId'
+ *      answerId: // value for 'answerId'
+ *      commentText: // value for 'commentText'
+ *   },
+ * });
+ */
+export function useUpdateAnswerCommentMutation(baseOptions?: Apollo.MutationHookOptions<UpdateAnswerCommentMutation, UpdateAnswerCommentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateAnswerCommentMutation, UpdateAnswerCommentMutationVariables>(UpdateAnswerCommentDocument, options);
+      }
+export type UpdateAnswerCommentMutationHookResult = ReturnType<typeof useUpdateAnswerCommentMutation>;
+export type UpdateAnswerCommentMutationResult = Apollo.MutationResult<UpdateAnswerCommentMutation>;
+export type UpdateAnswerCommentMutationOptions = Apollo.BaseMutationOptions<UpdateAnswerCommentMutation, UpdateAnswerCommentMutationVariables>;
+export const RemoveFeedbackCommentDocument = gql`
+    mutation RemoveFeedbackComment($planId: Int!, $planFeedbackCommentId: Int!) {
+  removeFeedbackComment(
+    planId: $planId
+    planFeedbackCommentId: $planFeedbackCommentId
+  ) {
+    id
+    errors {
+      general
+    }
+    answerId
+    commentText
+  }
+}
+    `;
+export type RemoveFeedbackCommentMutationFn = Apollo.MutationFunction<RemoveFeedbackCommentMutation, RemoveFeedbackCommentMutationVariables>;
+
+/**
+ * __useRemoveFeedbackCommentMutation__
+ *
+ * To run a mutation, you first call `useRemoveFeedbackCommentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveFeedbackCommentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeFeedbackCommentMutation, { data, loading, error }] = useRemoveFeedbackCommentMutation({
+ *   variables: {
+ *      planId: // value for 'planId'
+ *      planFeedbackCommentId: // value for 'planFeedbackCommentId'
+ *   },
+ * });
+ */
+export function useRemoveFeedbackCommentMutation(baseOptions?: Apollo.MutationHookOptions<RemoveFeedbackCommentMutation, RemoveFeedbackCommentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RemoveFeedbackCommentMutation, RemoveFeedbackCommentMutationVariables>(RemoveFeedbackCommentDocument, options);
+      }
+export type RemoveFeedbackCommentMutationHookResult = ReturnType<typeof useRemoveFeedbackCommentMutation>;
+export type RemoveFeedbackCommentMutationResult = Apollo.MutationResult<RemoveFeedbackCommentMutation>;
+export type RemoveFeedbackCommentMutationOptions = Apollo.BaseMutationOptions<RemoveFeedbackCommentMutation, RemoveFeedbackCommentMutationVariables>;
+export const UpdateFeedbackCommentDocument = gql`
+    mutation UpdateFeedbackComment($planId: Int!, $planFeedbackCommentId: Int!, $commentText: String!) {
+  updateFeedbackComment(
+    planId: $planId
+    planFeedbackCommentId: $planFeedbackCommentId
+    commentText: $commentText
+  ) {
+    answerId
+    commentText
+    id
+    errors {
+      general
+    }
+  }
+}
+    `;
+export type UpdateFeedbackCommentMutationFn = Apollo.MutationFunction<UpdateFeedbackCommentMutation, UpdateFeedbackCommentMutationVariables>;
+
+/**
+ * __useUpdateFeedbackCommentMutation__
+ *
+ * To run a mutation, you first call `useUpdateFeedbackCommentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateFeedbackCommentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateFeedbackCommentMutation, { data, loading, error }] = useUpdateFeedbackCommentMutation({
+ *   variables: {
+ *      planId: // value for 'planId'
+ *      planFeedbackCommentId: // value for 'planFeedbackCommentId'
+ *      commentText: // value for 'commentText'
+ *   },
+ * });
+ */
+export function useUpdateFeedbackCommentMutation(baseOptions?: Apollo.MutationHookOptions<UpdateFeedbackCommentMutation, UpdateFeedbackCommentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateFeedbackCommentMutation, UpdateFeedbackCommentMutationVariables>(UpdateFeedbackCommentDocument, options);
+      }
+export type UpdateFeedbackCommentMutationHookResult = ReturnType<typeof useUpdateFeedbackCommentMutation>;
+export type UpdateFeedbackCommentMutationResult = Apollo.MutationResult<UpdateFeedbackCommentMutation>;
+export type UpdateFeedbackCommentMutationOptions = Apollo.BaseMutationOptions<UpdateFeedbackCommentMutation, UpdateFeedbackCommentMutationVariables>;
 export const AddPlanDocument = gql`
     mutation AddPlan($projectId: Int!, $versionedTemplateId: Int!) {
   addPlan(projectId: $projectId, versionedTemplateId: $versionedTemplateId) {
@@ -6038,6 +6247,20 @@ export const AnswerByVersionedQuestionIdDocument = gql`
       answerId
       created
       modified
+      user {
+        surName
+        givenName
+      }
+    }
+    feedbackComments {
+      id
+      commentText
+      created
+      answerId
+      modified
+      PlanFeedback {
+        id
+      }
       user {
         surName
         givenName

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -3900,7 +3900,7 @@ export type AddFeedbackCommentMutationVariables = Exact<{
 }>;
 
 
-export type AddFeedbackCommentMutation = { __typename?: 'Mutation', addFeedbackComment?: { __typename?: 'PlanFeedbackComment', id?: number | null, answerId?: number | null, errors?: { __typename?: 'PlanFeedbackCommentErrors', general?: string | null } | null } | null };
+export type AddFeedbackCommentMutation = { __typename?: 'Mutation', addFeedbackComment?: { __typename?: 'PlanFeedbackComment', id?: number | null, answerId?: number | null, errors?: { __typename?: 'PlanFeedbackCommentErrors', general?: string | null } | null, PlanFeedback?: { __typename?: 'PlanFeedback', id?: number | null } | null } | null };
 
 export type AddPlanMutationVariables = Exact<{
   projectId: Scalars['Int']['input'];
@@ -4768,6 +4768,9 @@ export const AddFeedbackCommentDocument = gql`
     answerId
     errors {
       general
+    }
+    PlanFeedback {
+      id
     }
   }
 }

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -1511,6 +1511,7 @@ export enum PaginationType {
 /** A Data Managament Plan (DMP) */
 export type Plan = {
   __typename?: 'Plan';
+  /** Answers associated with the plan */
   answers?: Maybe<Array<Answer>>;
   /** The timestamp when the Object was created */
   created?: Maybe<Scalars['String']['output']>;
@@ -1522,6 +1523,8 @@ export type Plan = {
   errors?: Maybe<PlanErrors>;
   /** Whether or not the plan is featured on the public plans page */
   featured?: Maybe<Scalars['Boolean']['output']>;
+  /** Feedback associated with the plan */
+  feedback?: Maybe<Array<PlanFeedback>>;
   /** The funding for the plan */
   fundings?: Maybe<Array<PlanFunding>>;
   /** The unique identifer for the Object */
@@ -4176,7 +4179,7 @@ export type AnswerByVersionedQuestionIdQueryVariables = Exact<{
 }>;
 
 
-export type AnswerByVersionedQuestionIdQuery = { __typename?: 'Query', answerByVersionedQuestionId?: { __typename?: 'Answer', id?: number | null, json?: string | null, modified?: string | null, created?: string | null, versionedQuestion?: { __typename?: 'VersionedQuestion', id?: number | null } | null, plan?: { __typename?: 'Plan', id?: number | null } | null, comments?: Array<{ __typename?: 'AnswerComment', id?: number | null, commentText: string, answerId: number, created?: string | null, modified?: string | null, user?: { __typename?: 'User', surName?: string | null, givenName?: string | null } | null }> | null, feedbackComments?: Array<{ __typename?: 'PlanFeedbackComment', id?: number | null, commentText?: string | null, created?: string | null, answerId?: number | null, modified?: string | null, PlanFeedback?: { __typename?: 'PlanFeedback', id?: number | null } | null, user?: { __typename?: 'User', surName?: string | null, givenName?: string | null } | null }> | null, errors?: { __typename?: 'AffiliationErrors', general?: string | null, planId?: string | null, versionedSectionId?: string | null, versionedQuestionId?: string | null, json?: string | null } | null } | null };
+export type AnswerByVersionedQuestionIdQuery = { __typename?: 'Query', answerByVersionedQuestionId?: { __typename?: 'Answer', id?: number | null, json?: string | null, modified?: string | null, created?: string | null, versionedQuestion?: { __typename?: 'VersionedQuestion', id?: number | null } | null, plan?: { __typename?: 'Plan', id?: number | null } | null, comments?: Array<{ __typename?: 'AnswerComment', id?: number | null, commentText: string, answerId: number, created?: string | null, modified?: string | null, user?: { __typename?: 'User', id?: number | null, surName?: string | null, givenName?: string | null } | null }> | null, feedbackComments?: Array<{ __typename?: 'PlanFeedbackComment', id?: number | null, commentText?: string | null, created?: string | null, answerId?: number | null, modified?: string | null, PlanFeedback?: { __typename?: 'PlanFeedback', id?: number | null } | null, user?: { __typename?: 'User', id?: number | null, surName?: string | null, givenName?: string | null } | null }> | null, errors?: { __typename?: 'AffiliationErrors', general?: string | null, planId?: string | null, versionedSectionId?: string | null, versionedQuestionId?: string | null, json?: string | null } | null } | null };
 
 export type ProjectFundingsQueryVariables = Exact<{
   projectId: Scalars['Int']['input'];
@@ -4212,7 +4215,7 @@ export type PlanQueryVariables = Exact<{
 }>;
 
 
-export type PlanQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id?: number | null, visibility?: PlanVisibility | null, status?: PlanStatus | null, created?: string | null, modified?: string | null, dmpId?: string | null, registered?: string | null, title?: string | null, versionedTemplate?: { __typename?: 'VersionedTemplate', name: string, template?: { __typename?: 'Template', id?: number | null, name: string } | null } | null, fundings?: Array<{ __typename?: 'PlanFunding', id?: number | null, projectFunding?: { __typename?: 'ProjectFunding', affiliation?: { __typename?: 'Affiliation', displayName: string } | null } | null }> | null, project?: { __typename?: 'Project', title: string, fundings?: Array<{ __typename?: 'ProjectFunding', funderOpportunityNumber?: string | null, affiliation?: { __typename?: 'Affiliation', displayName: string, name: string } | null }> | null } | null, members?: Array<{ __typename?: 'PlanMember', isPrimaryContact?: boolean | null, projectMember?: { __typename?: 'ProjectMember', givenName?: string | null, surName?: string | null, email?: string | null, orcid?: string | null, memberRoles?: Array<{ __typename?: 'MemberRole', label: string }> | null } | null }> | null, versionedSections?: Array<{ __typename?: 'PlanSectionProgress', answeredQuestions: number, displayOrder: number, versionedSectionId: number, title: string, totalQuestions: number }> | null } | null };
+export type PlanQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id?: number | null, visibility?: PlanVisibility | null, status?: PlanStatus | null, created?: string | null, createdById?: number | null, modified?: string | null, dmpId?: string | null, registered?: string | null, title?: string | null, versionedTemplate?: { __typename?: 'VersionedTemplate', name: string, template?: { __typename?: 'Template', id?: number | null, name: string } | null, owner?: { __typename?: 'Affiliation', uri: string } | null } | null, fundings?: Array<{ __typename?: 'PlanFunding', id?: number | null, projectFunding?: { __typename?: 'ProjectFunding', affiliation?: { __typename?: 'Affiliation', displayName: string } | null } | null }> | null, project?: { __typename?: 'Project', title: string, fundings?: Array<{ __typename?: 'ProjectFunding', funderOpportunityNumber?: string | null, affiliation?: { __typename?: 'Affiliation', displayName: string, name: string } | null }> | null, collaborators?: Array<{ __typename?: 'ProjectCollaborator', accessLevel?: ProjectCollaboratorAccessLevel | null, user?: { __typename?: 'User', id?: number | null } | null }> | null } | null, members?: Array<{ __typename?: 'PlanMember', isPrimaryContact?: boolean | null, projectMember?: { __typename?: 'ProjectMember', givenName?: string | null, surName?: string | null, email?: string | null, orcid?: string | null, memberRoles?: Array<{ __typename?: 'MemberRole', label: string }> | null } | null }> | null, versionedSections?: Array<{ __typename?: 'PlanSectionProgress', answeredQuestions: number, displayOrder: number, versionedSectionId: number, title: string, totalQuestions: number }> | null, feedback?: Array<{ __typename?: 'PlanFeedback', id?: number | null, completed?: string | null }> | null } | null };
 
 export type PlanMembersQueryVariables = Exact<{
   planId: Scalars['Int']['input'];
@@ -4397,7 +4400,7 @@ export type TemplateCollaboratorsQuery = { __typename?: 'Query', template?: { __
 export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id?: number | null, givenName?: string | null, surName?: string | null, languageId: string, emails?: Array<{ __typename?: 'UserEmail', id?: number | null, email: string, isPrimary: boolean, isConfirmed: boolean } | null> | null, errors?: { __typename?: 'UserErrors', general?: string | null, email?: string | null, password?: string | null, role?: string | null } | null, affiliation?: { __typename?: 'Affiliation', id?: number | null, name: string, searchName: string, uri: string } | null } | null };
+export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id?: number | null, givenName?: string | null, surName?: string | null, languageId: string, role: UserRole, emails?: Array<{ __typename?: 'UserEmail', id?: number | null, email: string, isPrimary: boolean, isConfirmed: boolean } | null> | null, errors?: { __typename?: 'UserErrors', general?: string | null, email?: string | null, password?: string | null, role?: string | null } | null, affiliation?: { __typename?: 'Affiliation', id?: number | null, name: string, searchName: string, uri: string } | null } | null };
 
 
 export const AddAffiliationDocument = gql`
@@ -6350,6 +6353,7 @@ export const AnswerByVersionedQuestionIdDocument = gql`
       created
       modified
       user {
+        id
         surName
         givenName
       }
@@ -6364,6 +6368,7 @@ export const AnswerByVersionedQuestionIdDocument = gql`
         id
       }
       user {
+        id
         surName
         givenName
       }
@@ -6643,6 +6648,9 @@ export const PlanDocument = gql`
         name
       }
       name
+      owner {
+        uri
+      }
     }
     fundings {
       id
@@ -6663,6 +6671,12 @@ export const PlanDocument = gql`
         funderOpportunityNumber
       }
       title
+      collaborators {
+        user {
+          id
+        }
+        accessLevel
+      }
     }
     members {
       isPrimaryContact
@@ -6684,10 +6698,15 @@ export const PlanDocument = gql`
       totalQuestions
     }
     created
+    createdById
     modified
     dmpId
     registered
     title
+    feedback {
+      id
+      completed
+    }
   }
 }
     `;
@@ -8142,6 +8161,7 @@ export const MeDocument = gql`
     givenName
     surName
     languageId
+    role
     emails {
       id
       email

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -463,6 +463,8 @@ export type AnswerComment = {
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** User who made the comment */
+  user?: Maybe<User>;
 };
 
 /** A collection of errors related to the Answer Comment */
@@ -742,7 +744,9 @@ export type Mutation = {
   addAffiliation?: Maybe<Affiliation>;
   /** Answer a question */
   addAnswer?: Maybe<Answer>;
-  /** Add a comment to an answer within a round of feedback */
+  /** Add comment for an answer  */
+  addAnswerComment?: Maybe<AnswerComment>;
+  /** Add feedback comment for an answer within a round of feedback */
   addFeedbackComment?: Maybe<PlanFeedbackComment>;
   /** Add a new License (don't make the URI up! should resolve to an taxonomy HTML/JSON representation of the object) */
   addLicense?: Maybe<License>;
@@ -808,7 +812,9 @@ export type Mutation = {
   publishPlan?: Maybe<Plan>;
   /** Delete an Affiliation (only applicable to AffiliationProvenance == DMPTOOL) */
   removeAffiliation?: Maybe<Affiliation>;
-  /** Remove a comment to an answer within a round of feedback */
+  /** Remove answer comment */
+  removeAnswerComment?: Maybe<AnswerComment>;
+  /** Remove feedback comment for an answer within a round of feedback */
   removeFeedbackComment?: Maybe<PlanFeedbackComment>;
   /** Delete a License */
   removeLicense?: Maybe<License>;
@@ -860,6 +866,10 @@ export type Mutation = {
   updateAffiliation?: Maybe<Affiliation>;
   /** Edit an answer */
   updateAnswer?: Maybe<Answer>;
+  /** Update comment for an answer  */
+  updateAnswerComment?: Maybe<AnswerComment>;
+  /** Update feedback comment for an answer within a round of feedback */
+  updateFeedbackComment?: Maybe<PlanFeedbackComment>;
   /** Update a License record */
   updateLicense?: Maybe<License>;
   /** Update the member role */
@@ -929,10 +939,17 @@ export type MutationAddAnswerArgs = {
 };
 
 
+export type MutationAddAnswerCommentArgs = {
+  answerId: Scalars['Int']['input'];
+  commentText: Scalars['String']['input'];
+};
+
+
 export type MutationAddFeedbackCommentArgs = {
   answerId: Scalars['Int']['input'];
   commentText: Scalars['String']['input'];
   planFeedbackId: Scalars['Int']['input'];
+  planId: Scalars['Int']['input'];
 };
 
 
@@ -1065,6 +1082,7 @@ export type MutationArchiveTemplateArgs = {
 
 export type MutationCompleteFeedbackArgs = {
   planFeedbackId: Scalars['Int']['input'];
+  planId: Scalars['Int']['input'];
   summaryText?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1122,8 +1140,15 @@ export type MutationRemoveAffiliationArgs = {
 };
 
 
+export type MutationRemoveAnswerCommentArgs = {
+  answerCommentId: Scalars['Int']['input'];
+  answerId: Scalars['Int']['input'];
+};
+
+
 export type MutationRemoveFeedbackCommentArgs = {
-  PlanFeedbackCommentId: Scalars['Int']['input'];
+  planFeedbackCommentId: Scalars['Int']['input'];
+  planId: Scalars['Int']['input'];
 };
 
 
@@ -1243,6 +1268,20 @@ export type MutationUpdateAffiliationArgs = {
 export type MutationUpdateAnswerArgs = {
   answerId: Scalars['Int']['input'];
   json?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type MutationUpdateAnswerCommentArgs = {
+  answerCommentId: Scalars['Int']['input'];
+  answerId: Scalars['Int']['input'];
+  commentText: Scalars['String']['input'];
+};
+
+
+export type MutationUpdateFeedbackCommentArgs = {
+  commentText: Scalars['String']['input'];
+  planFeedbackCommentId: Scalars['Int']['input'];
+  planId: Scalars['Int']['input'];
 };
 
 
@@ -1543,8 +1582,6 @@ export type PlanErrors = {
 /** A round of administrative feedback for a Data Managament Plan (DMP) */
 export type PlanFeedback = {
   __typename?: 'PlanFeedback';
-  /** An overall summary that can be sent to the user upon completion */
-  adminSummary?: Maybe<Scalars['String']['output']>;
   /** The timestamp that the feedback was marked as complete */
   completed?: Maybe<Scalars['String']['output']>;
   /** The admin who completed the feedback round */
@@ -1564,11 +1601,13 @@ export type PlanFeedback = {
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The plan the user wants feedback on */
-  plan: Plan;
+  plan?: Maybe<Plan>;
   /** The timestamp of when the user requested the feedback */
-  requested: Scalars['String']['output'];
+  requested?: Maybe<Scalars['String']['output']>;
   /** The user who requested the round of feedback */
-  requestedBy: User;
+  requestedBy?: Maybe<User>;
+  /** An overall summary that can be sent to the user upon completion */
+  summaryText?: Maybe<Scalars['String']['output']>;
 };
 
 export type PlanFeedbackComment = {
@@ -1578,7 +1617,7 @@ export type PlanFeedbackComment = {
   /** The answer the comment is related to */
   answer?: Maybe<Answer>;
   /** The comment */
-  comment?: Maybe<Scalars['String']['output']>;
+  commentText?: Maybe<Scalars['String']['output']>;
   /** The timestamp when the Object was created */
   created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
@@ -1606,13 +1645,13 @@ export type PlanFeedbackCommentErrors = {
 /** A collection of errors related to the PlanFeedback */
 export type PlanFeedbackErrors = {
   __typename?: 'PlanFeedbackErrors';
-  adminSummary?: Maybe<Scalars['String']['output']>;
   completedById?: Maybe<Scalars['String']['output']>;
   feedbackComments?: Maybe<Scalars['String']['output']>;
   /** General error messages such as the object already exists */
   general?: Maybe<Scalars['String']['output']>;
   planId?: Maybe<Scalars['String']['output']>;
   requestedById?: Maybe<Scalars['String']['output']>;
+  summaryText?: Maybe<Scalars['String']['output']>;
 };
 
 /** Funding associated with a plan */
@@ -2178,7 +2217,7 @@ export type Query = {
   affiliationTypes?: Maybe<Array<Scalars['String']['output']>>;
   /** Perform a search for Affiliations matching the specified name */
   affiliations?: Maybe<AffiliationSearchResults>;
-  /** Get the sepecific answer */
+  /** Get the specific answer */
   answer?: Maybe<Answer>;
   /** Get an answer by versionedQuestionId */
   answerByVersionedQuestionId?: Maybe<Answer>;
@@ -2406,6 +2445,7 @@ export type QueryPlanFeedbackArgs = {
 
 export type QueryPlanFeedbackCommentsArgs = {
   planFeedbackId: Scalars['Int']['input'];
+  planId: Scalars['Int']['input'];
 };
 
 
@@ -4080,7 +4120,7 @@ export type AnswerByVersionedQuestionIdQueryVariables = Exact<{
 }>;
 
 
-export type AnswerByVersionedQuestionIdQuery = { __typename?: 'Query', answerByVersionedQuestionId?: { __typename?: 'Answer', id?: number | null, json?: string | null, modified?: string | null, versionedQuestion?: { __typename?: 'VersionedQuestion', id?: number | null } | null, plan?: { __typename?: 'Plan', id?: number | null } | null, errors?: { __typename?: 'AffiliationErrors', general?: string | null, planId?: string | null, versionedSectionId?: string | null, versionedQuestionId?: string | null, json?: string | null } | null } | null };
+export type AnswerByVersionedQuestionIdQuery = { __typename?: 'Query', answerByVersionedQuestionId?: { __typename?: 'Answer', id?: number | null, json?: string | null, modified?: string | null, created?: string | null, versionedQuestion?: { __typename?: 'VersionedQuestion', id?: number | null } | null, plan?: { __typename?: 'Plan', id?: number | null } | null, comments?: Array<{ __typename?: 'AnswerComment', id?: number | null, commentText: string, answerId: number, created?: string | null, modified?: string | null, user?: { __typename?: 'User', surName?: string | null, givenName?: string | null } | null }> | null, errors?: { __typename?: 'AffiliationErrors', general?: string | null, planId?: string | null, versionedSectionId?: string | null, versionedQuestionId?: string | null, json?: string | null } | null } | null };
 
 export type ProjectFundingsQueryVariables = Exact<{
   projectId: Scalars['Int']['input'];
@@ -5992,7 +6032,19 @@ export const AnswerByVersionedQuestionIdDocument = gql`
     plan {
       id
     }
+    comments {
+      id
+      commentText
+      answerId
+      created
+      modified
+      user {
+        surName
+        givenName
+      }
+    }
     modified
+    created
     errors {
       general
       planId

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -3864,6 +3864,14 @@ export type UpdateAnswerCommentMutationVariables = Exact<{
 
 export type UpdateAnswerCommentMutation = { __typename?: 'Mutation', updateAnswerComment?: { __typename?: 'AnswerComment', commentText: string, answerId: number, id?: number | null, errors?: { __typename?: 'AnswerCommentErrors', general?: string | null, commentText?: string | null, answerId?: string | null } | null } | null };
 
+export type AddAnswerCommentMutationVariables = Exact<{
+  answerId: Scalars['Int']['input'];
+  commentText: Scalars['String']['input'];
+}>;
+
+
+export type AddAnswerCommentMutation = { __typename?: 'Mutation', addAnswerComment?: { __typename?: 'AnswerComment', commentText: string, id?: number | null, answerId: number, errors?: { __typename?: 'AnswerCommentErrors', general?: string | null } | null } | null };
+
 export type RemoveFeedbackCommentMutationVariables = Exact<{
   planId: Scalars['Int']['input'];
   planFeedbackCommentId: Scalars['Int']['input'];
@@ -3880,6 +3888,16 @@ export type UpdateFeedbackCommentMutationVariables = Exact<{
 
 
 export type UpdateFeedbackCommentMutation = { __typename?: 'Mutation', updateFeedbackComment?: { __typename?: 'PlanFeedbackComment', answerId?: number | null, commentText?: string | null, id?: number | null, errors?: { __typename?: 'PlanFeedbackCommentErrors', general?: string | null } | null } | null };
+
+export type AddFeedbackCommentMutationVariables = Exact<{
+  planId: Scalars['Int']['input'];
+  planFeedbackId: Scalars['Int']['input'];
+  answerId: Scalars['Int']['input'];
+  commentText: Scalars['String']['input'];
+}>;
+
+
+export type AddFeedbackCommentMutation = { __typename?: 'Mutation', addFeedbackComment?: { __typename?: 'PlanFeedbackComment', id?: number | null, answerId?: number | null, errors?: { __typename?: 'PlanFeedbackCommentErrors', general?: string | null } | null } | null };
 
 export type AddPlanMutationVariables = Exact<{
   projectId: Scalars['Int']['input'];
@@ -4610,6 +4628,45 @@ export function useUpdateAnswerCommentMutation(baseOptions?: Apollo.MutationHook
 export type UpdateAnswerCommentMutationHookResult = ReturnType<typeof useUpdateAnswerCommentMutation>;
 export type UpdateAnswerCommentMutationResult = Apollo.MutationResult<UpdateAnswerCommentMutation>;
 export type UpdateAnswerCommentMutationOptions = Apollo.BaseMutationOptions<UpdateAnswerCommentMutation, UpdateAnswerCommentMutationVariables>;
+export const AddAnswerCommentDocument = gql`
+    mutation AddAnswerComment($answerId: Int!, $commentText: String!) {
+  addAnswerComment(answerId: $answerId, commentText: $commentText) {
+    commentText
+    id
+    answerId
+    errors {
+      general
+    }
+  }
+}
+    `;
+export type AddAnswerCommentMutationFn = Apollo.MutationFunction<AddAnswerCommentMutation, AddAnswerCommentMutationVariables>;
+
+/**
+ * __useAddAnswerCommentMutation__
+ *
+ * To run a mutation, you first call `useAddAnswerCommentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddAnswerCommentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addAnswerCommentMutation, { data, loading, error }] = useAddAnswerCommentMutation({
+ *   variables: {
+ *      answerId: // value for 'answerId'
+ *      commentText: // value for 'commentText'
+ *   },
+ * });
+ */
+export function useAddAnswerCommentMutation(baseOptions?: Apollo.MutationHookOptions<AddAnswerCommentMutation, AddAnswerCommentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddAnswerCommentMutation, AddAnswerCommentMutationVariables>(AddAnswerCommentDocument, options);
+      }
+export type AddAnswerCommentMutationHookResult = ReturnType<typeof useAddAnswerCommentMutation>;
+export type AddAnswerCommentMutationResult = Apollo.MutationResult<AddAnswerCommentMutation>;
+export type AddAnswerCommentMutationOptions = Apollo.BaseMutationOptions<AddAnswerCommentMutation, AddAnswerCommentMutationVariables>;
 export const RemoveFeedbackCommentDocument = gql`
     mutation RemoveFeedbackComment($planId: Int!, $planFeedbackCommentId: Int!) {
   removeFeedbackComment(
@@ -4696,6 +4753,51 @@ export function useUpdateFeedbackCommentMutation(baseOptions?: Apollo.MutationHo
 export type UpdateFeedbackCommentMutationHookResult = ReturnType<typeof useUpdateFeedbackCommentMutation>;
 export type UpdateFeedbackCommentMutationResult = Apollo.MutationResult<UpdateFeedbackCommentMutation>;
 export type UpdateFeedbackCommentMutationOptions = Apollo.BaseMutationOptions<UpdateFeedbackCommentMutation, UpdateFeedbackCommentMutationVariables>;
+export const AddFeedbackCommentDocument = gql`
+    mutation AddFeedbackComment($planId: Int!, $planFeedbackId: Int!, $answerId: Int!, $commentText: String!) {
+  addFeedbackComment(
+    planId: $planId
+    planFeedbackId: $planFeedbackId
+    answerId: $answerId
+    commentText: $commentText
+  ) {
+    id
+    answerId
+    errors {
+      general
+    }
+  }
+}
+    `;
+export type AddFeedbackCommentMutationFn = Apollo.MutationFunction<AddFeedbackCommentMutation, AddFeedbackCommentMutationVariables>;
+
+/**
+ * __useAddFeedbackCommentMutation__
+ *
+ * To run a mutation, you first call `useAddFeedbackCommentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddFeedbackCommentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addFeedbackCommentMutation, { data, loading, error }] = useAddFeedbackCommentMutation({
+ *   variables: {
+ *      planId: // value for 'planId'
+ *      planFeedbackId: // value for 'planFeedbackId'
+ *      answerId: // value for 'answerId'
+ *      commentText: // value for 'commentText'
+ *   },
+ * });
+ */
+export function useAddFeedbackCommentMutation(baseOptions?: Apollo.MutationHookOptions<AddFeedbackCommentMutation, AddFeedbackCommentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddFeedbackCommentMutation, AddFeedbackCommentMutationVariables>(AddFeedbackCommentDocument, options);
+      }
+export type AddFeedbackCommentMutationHookResult = ReturnType<typeof useAddFeedbackCommentMutation>;
+export type AddFeedbackCommentMutationResult = Apollo.MutationResult<AddFeedbackCommentMutation>;
+export type AddFeedbackCommentMutationOptions = Apollo.BaseMutationOptions<AddFeedbackCommentMutation, AddFeedbackCommentMutationVariables>;
 export const AddPlanDocument = gql`
     mutation AddPlan($projectId: Int!, $versionedTemplateId: Int!) {
   addPlan(projectId: $projectId, versionedTemplateId: $versionedTemplateId) {

--- a/graphql/mutations/answer.mutations.graphql
+++ b/graphql/mutations/answer.mutations.graphql
@@ -65,3 +65,14 @@ mutation UpdateAnswerComment($answerCommentId: Int!, $answerId: Int!, $commentTe
     }
   }
 }
+
+mutation AddAnswerComment($answerId: Int!, $commentText: String!) {
+  addAnswerComment(answerId: $answerId, commentText: $commentText) {
+    commentText
+    id
+    answerId
+    errors {
+      general
+    }
+  }
+}

--- a/graphql/mutations/answer.mutations.graphql
+++ b/graphql/mutations/answer.mutations.graphql
@@ -41,3 +41,27 @@ mutation UpdateAnswer($answerId: Int!, $json: String) {
     }
   }
 }
+
+mutation RemoveAnswerComment($answerCommentId: Int!, $answerId: Int!) {
+  removeAnswerComment(answerCommentId: $answerCommentId, answerId: $answerId) {
+    id
+    errors {
+      general
+    }
+    answerId
+    commentText
+  }
+}
+
+mutation UpdateAnswerComment($answerCommentId: Int!, $answerId: Int!, $commentText: String!) {
+  updateAnswerComment(answerCommentId: $answerCommentId, answerId: $answerId, commentText: $commentText) {
+    commentText
+    answerId
+    id
+    errors {
+      general
+      commentText
+      answerId
+    }
+  }
+}

--- a/graphql/mutations/feedback.muations.graphql
+++ b/graphql/mutations/feedback.muations.graphql
@@ -1,0 +1,21 @@
+mutation RemoveFeedbackComment($planId: Int!, $planFeedbackCommentId: Int!) {
+  removeFeedbackComment(planId: $planId, planFeedbackCommentId: $planFeedbackCommentId) {
+    id
+    errors {
+      general
+    }
+    answerId
+    commentText
+  }
+}
+
+mutation UpdateFeedbackComment($planId: Int!, $planFeedbackCommentId: Int!, $commentText: String!) {
+  updateFeedbackComment(planId: $planId, planFeedbackCommentId: $planFeedbackCommentId, commentText: $commentText) {
+    answerId
+    commentText
+    id
+    errors {
+      general
+    }
+  }
+}

--- a/graphql/mutations/feedback.muations.graphql
+++ b/graphql/mutations/feedback.muations.graphql
@@ -19,11 +19,11 @@ mutation UpdateFeedbackComment($planId: Int!, $planFeedbackCommentId: Int!, $com
     }
   }
 }
-
 mutation AddFeedbackComment($planId: Int!, $planFeedbackId: Int!, $answerId: Int!, $commentText: String!) {
   addFeedbackComment(planId: $planId, planFeedbackId: $planFeedbackId, answerId: $answerId, commentText: $commentText) {
     id
     answerId
+    commentText
     errors {
       general
     }

--- a/graphql/mutations/feedback.muations.graphql
+++ b/graphql/mutations/feedback.muations.graphql
@@ -19,3 +19,13 @@ mutation UpdateFeedbackComment($planId: Int!, $planFeedbackCommentId: Int!, $com
     }
   }
 }
+
+mutation AddFeedbackComment($planId: Int!, $planFeedbackId: Int!, $answerId: Int!, $commentText: String!) {
+  addFeedbackComment(planId: $planId, planFeedbackId: $planFeedbackId, answerId: $answerId, commentText: $commentText) {
+    id
+    answerId
+    errors {
+      general
+    }
+  }
+}

--- a/graphql/queries/answer.query.graphql
+++ b/graphql/queries/answer.query.graphql
@@ -19,6 +19,20 @@ query AnswerByVersionedQuestionId($projectId: Int!, $planId: Int!, $versionedQue
         givenName
       }
     }
+    feedbackComments {
+      id
+      commentText
+      created
+      answerId
+      modified
+      PlanFeedback {
+        id
+      }
+      user {
+        surName
+        givenName
+      }
+    }
     modified
     created
     errors {

--- a/graphql/queries/answer.query.graphql
+++ b/graphql/queries/answer.query.graphql
@@ -8,7 +8,19 @@ query AnswerByVersionedQuestionId($projectId: Int!, $planId: Int!, $versionedQue
     plan {
       id
     }
+     comments {
+      id
+      commentText
+      answerId
+      created
+      modified
+      user {
+        surName
+        givenName
+      }
+    }
     modified
+    created
     errors {
       general
       planId

--- a/graphql/queries/answer.query.graphql
+++ b/graphql/queries/answer.query.graphql
@@ -15,6 +15,7 @@ query AnswerByVersionedQuestionId($projectId: Int!, $planId: Int!, $versionedQue
       created
       modified
       user {
+        id
         surName
         givenName
       }
@@ -29,6 +30,7 @@ query AnswerByVersionedQuestionId($projectId: Int!, $planId: Int!, $versionedQue
         id
       }
       user {
+        id
         surName
         givenName
       }

--- a/graphql/queries/plan.query.graphql
+++ b/graphql/queries/plan.query.graphql
@@ -7,6 +7,9 @@ query Plan($planId: Int!) {
         name
       }
       name
+      owner {
+        uri
+      }
     }
     fundings {
       id
@@ -27,6 +30,12 @@ query Plan($planId: Int!) {
         funderOpportunityNumber
       }
       title
+      collaborators {
+        user {
+          id
+        }
+        accessLevel
+      }
     }
     members {
       isPrimaryContact
@@ -48,9 +57,14 @@ query Plan($planId: Int!) {
       totalQuestions
     }
     created
+    createdById
     modified
     dmpId
     registered
     title
+    feedback {
+      id
+      completed
+    }
   }
 }

--- a/graphql/queries/users.query.graphql
+++ b/graphql/queries/users.query.graphql
@@ -4,6 +4,7 @@ query Me{
     givenName
     surName
     languageId
+    role
     emails {
       id
       email

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -216,6 +216,7 @@
       "linkCollapse": "Collapse",
       "continue": "Continue",
       "edit": "Edit",
+      "delete": "Delete",
       "preview": "Preview",
       "publish": "Publish",
       "close": "Close",

--- a/messages/en-US/planBuilderPlanOverview.json
+++ b/messages/en-US/planBuilderPlanOverview.json
@@ -195,7 +195,12 @@
       "lastSaves": "Last saved {minutes} minutes ago",
       "noComments": "There are no comments",
       "sampleTextAdded": "Sample text added",
-      "commentSent": "Comment sent"
+      "commentSent": "Comment successfully added",
+      "commentedDeleted": "Comment successfully deleted",
+      "commentUpdated": "Comment successfully updated"
+    },
+    "buttons": {
+      "commentWithNumber": "{number} Comments"
     },
     "you": "you",
     "admin": "Admin",

--- a/messages/en-US/planBuilderPlanOverview.json
+++ b/messages/en-US/planBuilderPlanOverview.json
@@ -192,7 +192,10 @@
       "unsavedChanges": "Unsaved changes",
       "savedJustNow": "Saved just now",
       "lastSavedOneMinuteAgo": "Last saved 1 minute ago",
-      "lastSaves": "Last saved {minutes} minutes ago"
+      "lastSaves": "Last saved {minutes} minutes ago",
+      "noComments": "There are no comments",
+      "sampleTextAdded": "Sample text added",
+      "commentSent": "Comment sent"
     },
     "you": "you",
     "admin": "Admin",

--- a/messages/en-US/planBuilderPlanOverview.json
+++ b/messages/en-US/planBuilderPlanOverview.json
@@ -196,7 +196,7 @@
       "noComments": "There are no comments",
       "sampleTextAdded": "Sample text added",
       "commentSent": "Comment successfully added",
-      "commentedDeleted": "Comment successfully deleted",
+      "commentDeleted": "Comment successfully deleted",
       "commentUpdated": "Comment successfully updated"
     },
     "buttons": {

--- a/messages/en-US/planBuilderPlanOverview.json
+++ b/messages/en-US/planBuilderPlanOverview.json
@@ -193,7 +193,10 @@
       "savedJustNow": "Saved just now",
       "lastSavedOneMinuteAgo": "Last saved 1 minute ago",
       "lastSaves": "Last saved {minutes} minutes ago"
-    }
+    },
+    "you": "you",
+    "admin": "Admin",
+    "edited": "edited"
   },
   "ProjectsProjectFunding": {
     "buttons": {

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -216,6 +216,7 @@
       "linkCollapse": "Retrair",
       "continue": "Avançar",
       "edit": "Alterar",
+      "delete": "Excluir",
       "preview": "Pré-visualizar",
       "publish": "Publicar",
       "close": "Fechar",

--- a/messages/pt-BR/planBuilderPlanOverview.json
+++ b/messages/pt-BR/planBuilderPlanOverview.json
@@ -196,7 +196,7 @@
       "noComments": "Não há comentários",
       "sampleTextAdded": "Exemplo de texto adicionado",
       "commentSent": "Comentário enviado",
-      "commentedDeleted": "Comentário excluído com sucesso",
+      "commentDeleted": "Comentário excluído com sucesso",
       "commentUpdated": "Comentário atualizado com sucesso"
     },
     "buttons": {

--- a/messages/pt-BR/planBuilderPlanOverview.json
+++ b/messages/pt-BR/planBuilderPlanOverview.json
@@ -193,7 +193,10 @@
       "savedJustNow": "Salvo há pouco",
       "lastSavedOneMinuteAgo": "Última salvo há 1 minuto",
       "lastSaves": "Salvo há {minutes} minutos atrás"
-    }
+    },
+    "you": "você",
+    "admin": "administrador",
+    "edited": "editado"
   },
   "ProjectsProjectFunding": {
     "buttons": {

--- a/messages/pt-BR/planBuilderPlanOverview.json
+++ b/messages/pt-BR/planBuilderPlanOverview.json
@@ -195,7 +195,12 @@
       "lastSaves": "Salvo há {minutes} minutos atrás",
       "noComments": "Não há comentários",
       "sampleTextAdded": "Exemplo de texto adicionado",
-      "commentSent": "Comentário enviado"
+      "commentSent": "Comentário enviado",
+      "commentedDeleted": "Comentário excluído com sucesso",
+      "commentUpdated": "Comentário atualizado com sucesso"
+    },
+    "buttons": {
+      "commentWithNumber": "{number} Comentários"
     },
     "you": "você",
     "admin": "administrador",

--- a/messages/pt-BR/planBuilderPlanOverview.json
+++ b/messages/pt-BR/planBuilderPlanOverview.json
@@ -192,7 +192,10 @@
       "unsavedChanges": "Alterações não Salvas",
       "savedJustNow": "Salvo há pouco",
       "lastSavedOneMinuteAgo": "Última salvo há 1 minuto",
-      "lastSaves": "Salvo há {minutes} minutos atrás"
+      "lastSaves": "Salvo há {minutes} minutos atrás",
+      "noComments": "Não há comentários",
+      "sampleTextAdded": "Exemplo de texto adicionado",
+      "commentSent": "Comentário enviado"
     },
     "you": "você",
     "admin": "administrador",

--- a/middleware.ts
+++ b/middleware.ts
@@ -101,7 +101,12 @@ export async function middleware(request: NextRequest) {
   //Refresh tokens if necessary
   if (!accessToken && refreshToken) {
     try {
-      await refreshAuthTokens(cookies);
+      const refreshResult = await refreshAuthTokens(cookies);
+
+      // If refresh helper tells us to redirect, do it now
+      if (refreshResult?.shouldRedirect) {
+        return NextResponse.redirect(new URL(`/${locale}/login`, request.url));
+      }
     } catch (error) {
       logECS('error', 'refreshing', {
         error,

--- a/public/icons/iconset.svg
+++ b/public/icons/iconset.svg
@@ -95,4 +95,8 @@
   <symbol id="icon-solid-down_arrow" viewBox="0 -960 960 960">
     <path d="M480-360 280-560h400L480-360Z"/>
   </symbol>
+
+  <symbol id="icon-right-panel_close" viewBox="0 -960 960 960">
+    <path d="M300-640v320l160-160-160-160ZM200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm440-80h120v-560H640v560Zm-80 0v-560H200v560h360Zm80 0h120-120Z"/>
+  </symbol>
 </svg>

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -107,3 +107,16 @@ code {
   font-weight: bold;
   font-size: inherit; // Inherits the font size from its parent
 }
+
+// Font classes
+.font-small {
+  font-size: var(--fs-small);
+}
+
+.font-base {
+  font-size: var(--fs-base);
+}
+
+.font-large {
+  font-size: var(--fs-large);
+}

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -1,40 +1,64 @@
-import {DateValue, parseDate} from "@internationalized/date";
+import {
+  DateValue,
+  parseDate,
+} from "@internationalized/date";
+
 
 export const formatWithTimeAndDate = (timestamp: string): string => {
-    if (timestamp) {
-        // Parse the ISO date string into a Date object
-        const date = new Date(parseInt(timestamp));
+  if (timestamp) {
+    // Parse the ISO date string into a Date object
+    const date = new Date(parseInt(timestamp));
 
-        // Define arrays for month names
-        const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+    // Define arrays for month names
+    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-        // Extract date components
-        const hours = date.getHours().toString().padStart(2, '0');
-        const minutes = date.getMinutes().toString().padStart(2, '0');
-        const day = date.getDate();
-        const month = date.getMonth(); // Month is 0-based
-        const year = date.getFullYear();
+    // Extract date components
+    const hours = date.getHours().toString().padStart(2, '0');
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+    const day = date.getDate();
+    const month = date.getMonth(); // Month is 0-based
+    const year = date.getFullYear();
 
-        // Format the final string
-        return `${hours}:${minutes} on ${months[month]} ${day}, ${year}`;
-    } else {
-        return 'No date';
-    }
+    // Format the final string
+    return `${hours}:${minutes} on ${months[month]} ${day}, ${year}`;
+  } else {
+    return 'No date';
+  }
 }
 
 export const formatShortMonthDayYear = (timestamp: string): string => {
-    if (timestamp) {
-        const date = new Date(parseInt(timestamp));
-        const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' };
-        return date.toLocaleDateString('en-US', options);
-    } else {
-        return 'No date';
-    }
+  if (timestamp) {
+    const date = new Date(parseInt(timestamp));
+    const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' };
+    return date.toLocaleDateString('en-US', options);
+  } else {
+    return 'No date';
+  }
 
 }
 
 // Helper function to safely get a CalendarDate value
 export const getCalendarDateValue = (dateValue: DateValue | string | null) => {
-    if (!dateValue) return null;
-    return typeof dateValue === 'string' ? parseDate(dateValue) : dateValue;
+  if (!dateValue) return null;
+  return typeof dateValue === 'string' ? parseDate(dateValue) : dateValue;
 };
+
+
+// Convert Timestamp into relative time - like "2 days ago"
+export const formatRelativeFromTimestamp = (timestampMs: string, locale: string) => {
+  const now = Date.now();
+  const diffMs = Number(timestampMs) - now;
+
+  const diffSec = Math.round(diffMs / 1000);
+  const diffMin = Math.round(diffSec / 60);
+  const diffHrs = Math.round(diffMin / 60);
+  const diffDays = Math.round(diffHrs / 24);
+
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+
+  if (Math.abs(diffDays) >= 1) return rtf.format(diffDays, "day");
+  if (Math.abs(diffHrs) >= 1) return rtf.format(diffHrs, "hour");
+  if (Math.abs(diffMin) >= 1) return rtf.format(diffMin, "minute");
+
+  return rtf.format(diffSec, "second");
+}


### PR DESCRIPTION
## Description

- Added a `CommentsDrawer` component to separate out the code to generate the Comments drawer, making it easier for testing and to better organize an already complex page
-  Added `CommentList` component to list out all the comments
- Added new Server Actions for comment mutations: `addAnswerCommentAction`, `addFeedbackCommentAction`, `removeAnswerCommentAction`, `removeFeedbackCommentAction`,`updateAnswerCommentAction`, `updateFeedbackCommentAction`
- Added a `useComments` hook to consolidate comments code into one place, separate from the main page, since that page is already very complex.
- Added new graphql mutations: `RemoveAnswerComment`, `AddAnswerComment`, `UpdateAnswerComment`, `RemoveFeedbackComment`, `AddFeedbackComment` and `UpdateFeedbackComment`
- Added unit tests
- Added translations

Fixes # ([321](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/321))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
This was tested manually and with unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules

*NOTE: Please be aware that this branch must be run with the following backend
## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch `feature/243/JS-add-resolvers-for-answer-comments`. Also, if you have time, please take a look at the PR for that branch here:https://github.com/CDLUC3/dmsp_backend_prototype/pull/385

## Functionality/Requirements
The requirements for this page was to list out comments from both the `feedbackComments` table (that stores admin feedback associated with rounds of feedback that was requested by owner) and `answerComments` table. 

These comments should be listed in chronological order with the `Admin` comments marked with `(Admin)` next to the user's name. 

For additional requirements, please take a look at the [Comments.md](https://github.com/CDLUC3/dmsp_frontend_prototype/blob/feature/321/JS-add-comment-functionality/app/%5Blocale%5D/projects/%5BprojectId%5D/dmp/%5Bdmpid%5D/s/%5Bsid%5D/q/%5Bqid%5D/Comments.md) file
