### PR TITLE
Small change to hide section headings if there is nothing to display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Updated the funding-search page on the create project step to link to the new page to add the funder manually [#497]
 
 ### Fixed
+- Updated `SectionTypeSelectPage` to only show the `Org section` and `best Practice section` headers if there are any to display [#702]
 - Fixed issue with saved data not loading on the `Funding Detail` page after saving [#659]
 - Flapping test `should render PlanCreate component with funder checkbox` required additional clearing of mocks to perform consistently.
 - Bad test on DateRangeQuestionComponent tests that were consistently failing because of multiple matches in my environment.

--- a/app/[locale]/template/[templateId]/section/new/page.tsx
+++ b/app/[locale]/template/[templateId]/section/new/page.tsx
@@ -242,6 +242,16 @@ const SectionTypeSelectPage: React.FC = () => {
     return null;
   };
 
+  const hasOrgSections =
+    (filteredSections && filteredSections.some(s => s?.bestPractice === false)) ||
+    (sections && sections.some(s => s?.bestPractice === false));
+
+  const hasBestPracticeSections =
+    (filteredBestPracticeSections && filteredBestPracticeSections.some(s => s?.bestPractice === true)) ||
+    (bestPracticeSections && bestPracticeSections.some(s => s?.bestPractice === true));
+
+
+
   // Show loading message
   if (loading) {
     return <div>{Global('messaging.loading')}...</div>;
@@ -293,9 +303,11 @@ const SectionTypeSelectPage: React.FC = () => {
           </div>
 
           <div>
-            <h2>
-              {AddNewSection('headings.previouslyCreatedSections')}
-            </h2>
+
+            {/* Only show heading if there are org sections and not both */}
+            {hasOrgSections && (
+              <h2>{AddNewSection('headings.previouslyCreatedSections')}</h2>
+            )}
 
             {/*Organization Sections */}
             <div className="card-grid-list">
@@ -374,10 +386,10 @@ const SectionTypeSelectPage: React.FC = () => {
                   : renderLoadMore(sections, 'sections')}
               </div>
             )}
-
-            <h2>
-              {AddNewSection('headings.bestPracticeSections')}
-            </h2>
+            {/* Only show heading if there are best practice sections and not both */}
+            {hasBestPracticeSections && (
+              <h2>{AddNewSection('headings.bestPracticeSections')}</h2>
+            )}
 
             {/*Best Practice sections */}
             <div className="card-grid-list">


### PR DESCRIPTION
## Description

I wanted to double check that the sections were displaying as expected, because when I was testing on `dev`, I didn't see any sections.

It is working, but I did make a change to hide the `<h2>` heading for each of the section lists (Org and Best practice) if there is nothing to display.

Fixes # ([702](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/702))

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 


## Screen recording
Showing an example of the "Org" sections and "Best Practice" sections displaying correctly on the page.

https://github.com/user-attachments/assets/d40d70d2-bd7c-4d2e-8449-7725dd2aa514

## Screenshot
If there are no Best Practice templates, for example, then the heading for that section does not display:
<img width="901" height="977" alt="image" src="https://github.com/user-attachments/assets/49badf87-4c2f-4eb2-af82-51127eb98e89" />

