### PR TITLE
[Bug fix] - Updated Question Detail page to use sampleText if useSampleTextAsDefault is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Updated the funding-search page on the create project step to link to the new page to add the funder manually [#497]
 
 ### Fixed
+- Update `PlanOverviewQuestionPage` to make sure that `sample text` displays initially when it is present and `useSampleTextAsDefault` is set to true [#677]
 - Fixed issue with saved data not loading on the `Funding Detail` page after saving [#659]
 - Flapping test `should render PlanCreate component with funder checkbox` required additional clearing of mocks to perform consistently.
 - Bad test on DateRangeQuestionComponent tests that were consistently failing because of multiple matches in my environment.

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/__tests__/page.spec.tsx
@@ -441,9 +441,9 @@ describe('PlanOverviewSectionPage', () => {
 
   it('should generate correct completed description for questions', async () => {
     render(
-        <MockedProvider mocks={mocks} addTypename={false}>
-          <PlanOverviewSectionPage />
-        </MockedProvider>
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <PlanOverviewSectionPage />
+      </MockedProvider>
     );
 
     // Wait for data to load
@@ -597,6 +597,7 @@ describe('PlanOverviewSectionPage', () => {
                 sampleText: 'Sample for question 1',
                 versionedSectionId: 456,
                 versionedTemplateId: 789,
+                hasAnswer: false,
               },
             ],
           },

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
@@ -63,15 +63,15 @@ beforeEach(() => {
   // Cannot get the escaping to work in the mock JSON file, so doing it programmatically here
   const affiliationQuery = 'query Affiliations($name: String!){ ' +
     'affiliations(name: $name) { ' +
-      'totalCount ' +
-      'nextCursor ' +
-      'items { ' +
-        'id ' +
-        'displayName ' +
-        'uri ' +
-      '} ' +
+    'totalCount ' +
+    'nextCursor ' +
+    'items { ' +
+    'id ' +
+    'displayName ' +
+    'uri ' +
     '} ' +
-  '}';
+    '} ' +
+    '}';
 
   const json: AffiliationSearchQuestionType = {
     type: 'affiliationSearch',
@@ -246,6 +246,32 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(bestPracticeDataFormat).toBeInTheDocument();
     const bestPracticeDataVolume = screen.getByRole('heading', { level: 3, name: 'dataVolume' });
     expect(bestPracticeDataVolume).toBeInTheDocument();
+  })
+
+  it('should load sampleText in textArea if useSampleTextAsDefault is true and sampleText exists in question', async () => {
+
+    (usePublishedQuestionQuery as jest.Mock).mockReturnValue({
+      data: mockQuestionDataForTextArea,
+      loading: false,
+      error: undefined,
+    });
+
+    (useAnswerByVersionedQuestionIdQuery as jest.Mock).mockReturnValue({
+      data: mockAnswerDataForTextArea,
+      loading: false,
+      error: undefined,
+    });
+
+    await act(async () => {
+      render(
+        <PlanOverviewQuestionPage />
+      );
+    });
+
+    // Check that the textArea question field is in page
+    const textAreaQuestion = screen.getByLabelText('question-text-editor');
+    expect(textAreaQuestion).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes('Sample text'))).toBeInTheDocument();
   })
 
   it('should load correct question content for checkbox question', async () => {

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
@@ -60,18 +60,20 @@ import PlanOverviewQuestionPage from "../page";
 import { AffiliationSearchQuestionType } from "@dmptool/types";
 
 beforeEach(() => {
-  // Cannot get the escaping to work in the mock JSON file, so doing it programmatically here
-  const affiliationQuery = 'query Affiliations($name: String!){ ' +
-    'affiliations(name: $name) { ' +
-    'totalCount ' +
-    'nextCursor ' +
-    'items { ' +
-    'id ' +
-    'displayName ' +
-    'uri ' +
-    '} ' +
-    '} ' +
-    '}';
+  const affiliationQuery = `
+  query Affiliations($name: String!) {
+    affiliations(name: $name) {
+      totalCount
+      nextCursor
+      items {
+        id
+        displayName
+        uri
+      }
+    }
+  }
+`;
+
 
   const json: AffiliationSearchQuestionType = {
     type: 'affiliationSearch',

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
@@ -979,7 +979,12 @@ const PlanOverviewQuestionPage: React.FC = () => {
       handleTextChange,
     },
     textAreaProps: {
-      content: formData.textAreaContent,
+      content:
+        !formData.textAreaContent &&
+          question?.useSampleTextAsDefault &&
+          !!question?.sampleText
+          ? question.sampleText
+          : formData.textAreaContent,
       setContent: buildSetContent('textAreaContent', setFormData),
       handleTextAreaChange
     },

--- a/components/hooks/useRenderQuestionField.tsx
+++ b/components/hooks/useRenderQuestionField.tsx
@@ -197,11 +197,11 @@ export function useRenderQuestionField({
       if (parsed.type === 'selectBox' && 'options' in parsed) {
         if (selectBoxProps?.setSelectedSelectValue) {
           return (
-              <SelectboxQuestionComponent
-                  parsedQuestion={parsed}
-                  selectedSelectValue={selectBoxProps.selectedSelectValue}
-                  handleSelectChange={selectBoxProps.handleSelectChange}
-              />
+            <SelectboxQuestionComponent
+              parsedQuestion={parsed}
+              selectedSelectValue={selectBoxProps.selectedSelectValue}
+              handleSelectChange={selectBoxProps.handleSelectChange}
+            />
           );
         }
       }
@@ -211,11 +211,11 @@ export function useRenderQuestionField({
       if (parsed.type === 'multiselectBox' && 'options' in parsed) {
         if (multiSelectBoxProps?.handleMultiSelectChange) {
           return (
-              <MultiSelectQuestionComponent
-                  parsedQuestion={parsed}
-                  selectedMultiSelectValues={multiSelectBoxProps.selectedMultiSelectValues}
-                  handleMultiSelectChange={multiSelectBoxProps.handleMultiSelectChange}
-              />
+            <MultiSelectQuestionComponent
+              parsedQuestion={parsed}
+              selectedMultiSelectValues={multiSelectBoxProps.selectedMultiSelectValues}
+              handleMultiSelectChange={multiSelectBoxProps.handleMultiSelectChange}
+            />
           );
         }
       }

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -429,6 +429,8 @@ export type Answer = {
   createdById?: Maybe<Scalars['Int']['output']>;
   /** Errors associated with the Object */
   errors?: Maybe<AffiliationErrors>;
+  /** The feedback comments associated with the answer */
+  feedbackComments?: Maybe<Array<PlanFeedbackComment>>;
   /** The unique identifer for the Object */
   id?: Maybe<Scalars['Int']['output']>;
   /** The answer to the question */
@@ -463,6 +465,8 @@ export type AnswerComment = {
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** User who made the comment */
+  user?: Maybe<User>;
 };
 
 /** A collection of errors related to the Answer Comment */
@@ -742,7 +746,9 @@ export type Mutation = {
   addAffiliation?: Maybe<Affiliation>;
   /** Answer a question */
   addAnswer?: Maybe<Answer>;
-  /** Add a comment to an answer within a round of feedback */
+  /** Add comment for an answer  */
+  addAnswerComment?: Maybe<AnswerComment>;
+  /** Add feedback comment for an answer within a round of feedback */
   addFeedbackComment?: Maybe<PlanFeedbackComment>;
   /** Add a new License (don't make the URI up! should resolve to an taxonomy HTML/JSON representation of the object) */
   addLicense?: Maybe<License>;
@@ -808,7 +814,9 @@ export type Mutation = {
   publishPlan?: Maybe<Plan>;
   /** Delete an Affiliation (only applicable to AffiliationProvenance == DMPTOOL) */
   removeAffiliation?: Maybe<Affiliation>;
-  /** Remove a comment to an answer within a round of feedback */
+  /** Remove answer comment */
+  removeAnswerComment?: Maybe<AnswerComment>;
+  /** Remove feedback comment for an answer within a round of feedback */
   removeFeedbackComment?: Maybe<PlanFeedbackComment>;
   /** Delete a License */
   removeLicense?: Maybe<License>;
@@ -860,6 +868,10 @@ export type Mutation = {
   updateAffiliation?: Maybe<Affiliation>;
   /** Edit an answer */
   updateAnswer?: Maybe<Answer>;
+  /** Update comment for an answer  */
+  updateAnswerComment?: Maybe<AnswerComment>;
+  /** Update feedback comment for an answer within a round of feedback */
+  updateFeedbackComment?: Maybe<PlanFeedbackComment>;
   /** Update a License record */
   updateLicense?: Maybe<License>;
   /** Update the member role */
@@ -929,10 +941,17 @@ export type MutationAddAnswerArgs = {
 };
 
 
+export type MutationAddAnswerCommentArgs = {
+  answerId: Scalars['Int']['input'];
+  commentText: Scalars['String']['input'];
+};
+
+
 export type MutationAddFeedbackCommentArgs = {
   answerId: Scalars['Int']['input'];
   commentText: Scalars['String']['input'];
   planFeedbackId: Scalars['Int']['input'];
+  planId: Scalars['Int']['input'];
 };
 
 
@@ -1065,6 +1084,7 @@ export type MutationArchiveTemplateArgs = {
 
 export type MutationCompleteFeedbackArgs = {
   planFeedbackId: Scalars['Int']['input'];
+  planId: Scalars['Int']['input'];
   summaryText?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1122,8 +1142,15 @@ export type MutationRemoveAffiliationArgs = {
 };
 
 
+export type MutationRemoveAnswerCommentArgs = {
+  answerCommentId: Scalars['Int']['input'];
+  answerId: Scalars['Int']['input'];
+};
+
+
 export type MutationRemoveFeedbackCommentArgs = {
-  PlanFeedbackCommentId: Scalars['Int']['input'];
+  planFeedbackCommentId: Scalars['Int']['input'];
+  planId: Scalars['Int']['input'];
 };
 
 
@@ -1243,6 +1270,20 @@ export type MutationUpdateAffiliationArgs = {
 export type MutationUpdateAnswerArgs = {
   answerId: Scalars['Int']['input'];
   json?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type MutationUpdateAnswerCommentArgs = {
+  answerCommentId: Scalars['Int']['input'];
+  answerId: Scalars['Int']['input'];
+  commentText: Scalars['String']['input'];
+};
+
+
+export type MutationUpdateFeedbackCommentArgs = {
+  commentText: Scalars['String']['input'];
+  planFeedbackCommentId: Scalars['Int']['input'];
+  planId: Scalars['Int']['input'];
 };
 
 
@@ -1470,6 +1511,7 @@ export enum PaginationType {
 /** A Data Managament Plan (DMP) */
 export type Plan = {
   __typename?: 'Plan';
+  /** Answers associated with the plan */
   answers?: Maybe<Array<Answer>>;
   /** The timestamp when the Object was created */
   created?: Maybe<Scalars['String']['output']>;
@@ -1481,6 +1523,8 @@ export type Plan = {
   errors?: Maybe<PlanErrors>;
   /** Whether or not the plan is featured on the public plans page */
   featured?: Maybe<Scalars['Boolean']['output']>;
+  /** Feedback associated with the plan */
+  feedback?: Maybe<Array<PlanFeedback>>;
   /** The funding for the plan */
   fundings?: Maybe<Array<PlanFunding>>;
   /** The unique identifer for the Object */
@@ -1543,8 +1587,6 @@ export type PlanErrors = {
 /** A round of administrative feedback for a Data Managament Plan (DMP) */
 export type PlanFeedback = {
   __typename?: 'PlanFeedback';
-  /** An overall summary that can be sent to the user upon completion */
-  adminSummary?: Maybe<Scalars['String']['output']>;
   /** The timestamp that the feedback was marked as complete */
   completed?: Maybe<Scalars['String']['output']>;
   /** The admin who completed the feedback round */
@@ -1564,21 +1606,23 @@ export type PlanFeedback = {
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The plan the user wants feedback on */
-  plan: Plan;
+  plan?: Maybe<Plan>;
   /** The timestamp of when the user requested the feedback */
-  requested: Scalars['String']['output'];
+  requested?: Maybe<Scalars['String']['output']>;
   /** The user who requested the round of feedback */
-  requestedBy: User;
+  requestedBy?: Maybe<User>;
+  /** An overall summary that can be sent to the user upon completion */
+  summaryText?: Maybe<Scalars['String']['output']>;
 };
 
 export type PlanFeedbackComment = {
   __typename?: 'PlanFeedbackComment';
   /** The round of plan feedback the comment belongs to */
   PlanFeedback?: Maybe<PlanFeedback>;
-  /** The answer the comment is related to */
-  answer?: Maybe<Answer>;
+  /** The answerId the comment is related to */
+  answerId?: Maybe<Scalars['Int']['output']>;
   /** The comment */
-  comment?: Maybe<Scalars['String']['output']>;
+  commentText?: Maybe<Scalars['String']['output']>;
   /** The timestamp when the Object was created */
   created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
@@ -1591,6 +1635,8 @@ export type PlanFeedbackComment = {
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** User who made the comment */
+  user?: Maybe<User>;
 };
 
 /** A collection of errors related to the PlanFeedbackComment */
@@ -1606,13 +1652,13 @@ export type PlanFeedbackCommentErrors = {
 /** A collection of errors related to the PlanFeedback */
 export type PlanFeedbackErrors = {
   __typename?: 'PlanFeedbackErrors';
-  adminSummary?: Maybe<Scalars['String']['output']>;
   completedById?: Maybe<Scalars['String']['output']>;
   feedbackComments?: Maybe<Scalars['String']['output']>;
   /** General error messages such as the object already exists */
   general?: Maybe<Scalars['String']['output']>;
   planId?: Maybe<Scalars['String']['output']>;
   requestedById?: Maybe<Scalars['String']['output']>;
+  summaryText?: Maybe<Scalars['String']['output']>;
 };
 
 /** Funding associated with a plan */
@@ -2178,7 +2224,7 @@ export type Query = {
   affiliationTypes?: Maybe<Array<Scalars['String']['output']>>;
   /** Perform a search for Affiliations matching the specified name */
   affiliations?: Maybe<AffiliationSearchResults>;
-  /** Get the sepecific answer */
+  /** Get the specific answer */
   answer?: Maybe<Answer>;
   /** Get an answer by versionedQuestionId */
   answerByVersionedQuestionId?: Maybe<Answer>;
@@ -2406,6 +2452,7 @@ export type QueryPlanFeedbackArgs = {
 
 export type QueryPlanFeedbackCommentsArgs = {
   planFeedbackId: Scalars['Int']['input'];
+  planId: Scalars['Int']['input'];
 };
 
 
@@ -4239,7 +4286,7 @@ export type PublishedQuestionQueryVariables = Exact<{
 }>;
 
 
-export type PublishedQuestionQuery = { __typename?: 'Query', publishedQuestion?: { __typename?: 'VersionedQuestion', id?: number | null, guidanceText?: string | null, displayOrder?: number | null, questionText?: string | null, json?: string | null, requirementText?: string | null, sampleText?: string | null, versionedSectionId: number, versionedTemplateId: number, required?: boolean | null, errors?: { __typename?: 'VersionedQuestionErrors', general?: string | null, questionText?: string | null, requirementText?: string | null, sampleText?: string | null, displayOrder?: string | null, versionedSectionId?: string | null } | null } | null };
+export type PublishedQuestionQuery = { __typename?: 'Query', publishedQuestion?: { __typename?: 'VersionedQuestion', id?: number | null, guidanceText?: string | null, displayOrder?: number | null, questionText?: string | null, json?: string | null, requirementText?: string | null, sampleText?: string | null, useSampleTextAsDefault?: boolean | null, versionedSectionId: number, versionedTemplateId: number, required?: boolean | null, errors?: { __typename?: 'VersionedQuestionErrors', general?: string | null, questionText?: string | null, requirementText?: string | null, sampleText?: string | null, displayOrder?: string | null, versionedSectionId?: string | null } | null } | null };
 
 export type TopLevelResearchDomainsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -6963,6 +7010,7 @@ export const PublishedQuestionDocument = gql`
     json
     requirementText
     sampleText
+    useSampleTextAsDefault
     versionedSectionId
     versionedTemplateId
     required

--- a/graphql/queries/questions.query.graphql
+++ b/graphql/queries/questions.query.graphql
@@ -76,6 +76,7 @@ query PublishedQuestion($versionedQuestionId: Int!) {
     json
     requirementText
     sampleText
+    useSampleTextAsDefault
     versionedSectionId
     versionedTemplateId
     required


### PR DESCRIPTION
## Description

Currently, even if a `textArea` `question` is created with `sampleText` and with `useSampleTextAsDefault` is true, we are not using it on the Question Detail page.

- Updated the `content` value for `textAreaProps` to initially use the `sampleText` value if there is `sampleText` and `useSampleTextAsDefault` is true.
- Added a unit test for it

Fixes # ([677](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/677))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested and tested with unit test


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
