### PR TITLE
[Bug fix] - Fixed issue with entered Affiliation Label and Help text not displaying on Question Preview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Updated the funding-search page on the create project step to link to the new page to add the funder manually [#497]
 
 ### Fixed
+- Fixed issue with entered Affiliation `label` and `help` text not displaying on the `Question Preview` page
 - Update `PlanOverviewQuestionPage` to make sure that `sample text` displays initially when it is present and `useSampleTextAsDefault` is set to true [#677]
 - Updated `SectionTypeSelectPage` to only show the `Org section` and `best Practice section` headers if there are any to display [#702]
 - Fixed issue with saved data not loading on the `Funding Detail` page after saving [#659]

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@/utils/test-utils';
 import {
   useAddQuestionMutation,
   useQuestionsDisplayOrderQuery,
-  useTemplateQuery,
+  useTemplateQuery, // Added for when we test contents of Question Preview
 } from '@/generated/graphql';
 
 import { axe, toHaveNoViolations } from 'jest-axe';
@@ -17,7 +17,7 @@ import { AffiliationSearchQuestionType } from "@dmptool/types";
 expect.extend(toHaveNoViolations);
 
 
-// Mock the Apollo client creation since TypeAheadWithOther creates its own client
+// Mock the Apollo client creation since TypeAheadWithOther creates its own client. This is for when the Question Preview component opens
 jest.mock('@/lib/graphql/client/apollo-client', () => ({
   createApolloClient: jest.fn(() => ({
     query: jest.fn().mockResolvedValue({
@@ -166,7 +166,7 @@ describe("QuestionAdd", () => {
       error: undefined,
     });
 
-    (useTemplateQuery as jest.Mock).mockReturnValue({
+    (useTemplateQuery as jest.Mock).mockReturnValue({ // Added for when we test contents of Question preview
       data: mockTemplateData,
       loading: false,
       error: undefined,
@@ -1092,7 +1092,7 @@ describe("QuestionAdd", () => {
     });
   })
 
-  it('should call handleTypeAheadSearchLabelChange when typeaheadSearch label value changes', async () => {
+  it('should call handleTypeAheadSearchLabelChange when typeaheadSearch label value changes and pass correct value to Question Preview', async () => {
     (useAddQuestionMutation as jest.Mock).mockReturnValue([
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
       { loading: false, error: undefined },
@@ -1170,7 +1170,7 @@ describe("QuestionAdd", () => {
     });
   });
 
-  it('should call handleTypeAheadHelpTextChange when typeaheadSearch help text value changes', async () => {
+  it('should call handleTypeAheadHelpTextChange when typeaheadSearch help text value changes and pass correct value to Question Preview', async () => {
     (useAddQuestionMutation as jest.Mock).mockReturnValue([
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
       { loading: false, error: undefined },

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@/utils/test-utils';
 import {
   useAddQuestionMutation,
   useQuestionsDisplayOrderQuery,
+  useTemplateQuery,
 } from '@/generated/graphql';
 
 import { axe, toHaveNoViolations } from 'jest-axe';
@@ -10,10 +11,30 @@ import { useParams, useRouter } from 'next/navigation';
 import { useToast } from '@/context/ToastContext';
 import QuestionAdd from '@/components/QuestionAdd';
 import * as getParsedJSONModule from '@/components/hooks/getParsedQuestionJSON';
-import {AffiliationSearchQuestionType} from "@dmptool/types";
+import { AffiliationSearchQuestionType } from "@dmptool/types";
 
 
 expect.extend(toHaveNoViolations);
+
+
+// Mock the Apollo client creation since TypeAheadWithOther creates its own client
+jest.mock('@/lib/graphql/client/apollo-client', () => ({
+  createApolloClient: jest.fn(() => ({
+    query: jest.fn().mockResolvedValue({
+      data: {
+        affiliations: {
+          items: [
+            {
+              id: '1',
+              displayName: 'University of California',
+              uri: 'https://example.com/uc'
+            }
+          ]
+        }
+      }
+    })
+  }))
+}));
 
 jest.mock('@/components/hooks/getParsedQuestionJSON', () => {
   const actual = jest.requireActual('@/components/hooks/getParsedQuestionJSON');
@@ -28,6 +49,7 @@ jest.mock('@/components/hooks/getParsedQuestionJSON', () => {
 jest.mock("@/generated/graphql", () => ({
   useQuestionsDisplayOrderQuery: jest.fn(),
   useAddQuestionMutation: jest.fn(),
+  useTemplateQuery: jest.fn()
 }));
 
 jest.mock('next/navigation', () => ({
@@ -73,6 +95,32 @@ jest.mock('next-intl', () => ({
   }),
 }));
 
+const mockTemplateData = {
+
+  template: {
+    __typename: "Template",
+    id: 15,
+    name: "National Center for Sustainable Transportation - Project Data Management Plan",
+    description: "<p>This template is for projects funded by the National Center for Sustainable Transportation. Use of this template is <em>not</em> limited to researchers at the University of California, Davis.</p>",
+    errors: {
+      __typename: "TemplateErrors",
+      general: null,
+      name: null,
+      ownerId: null
+    },
+    latestPublishVersion: "v15",
+    latestPublishDate: "1755815345000",
+    created: "2023-09-13 17:47:34",
+    sections: [],
+    owner: {
+      displayName: "University of Example"
+    },
+    visibility: "ORGANIZATION",
+    bestPractice: false,
+    isDirty: true
+  }
+}
+
 const mockQuestionDisplayData = {
   questions: [
     {
@@ -117,7 +165,25 @@ describe("QuestionAdd", () => {
       loading: false,
       error: undefined,
     });
+
+    (useTemplateQuery as jest.Mock).mockReturnValue({
+      data: mockTemplateData,
+      loading: false,
+      error: undefined,
+    });
   });
+
+  afterEach(() => {
+    // Clean up any modals or DOM pollution
+    document.body.innerHTML = '';
+
+    // Clear all mocks to prevent state bleeding
+    jest.clearAllMocks();
+
+    // Reset any global state that might have been modified
+    window.location.hash = '';
+  });
+
 
   it("should render correct fields and content", async () => {
     (useAddQuestionMutation as jest.Mock).mockReturnValue([
@@ -1026,18 +1092,19 @@ describe("QuestionAdd", () => {
     });
   })
 
-  it('should call handleTypeAheadSearchLabelChange when typeaheadSearch label value changes', () => {
+  it('should call handleTypeAheadSearchLabelChange when typeaheadSearch label value changes', async () => {
     (useAddQuestionMutation as jest.Mock).mockReturnValue([
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
       { loading: false, error: undefined },
     ]);
+
     const json: AffiliationSearchQuestionType = {
       meta: {
         schemaVersion: "1.0"
       },
       type: "affiliationSearch",
       attributes: {
-        label: "Enter the search term to find your affiliation",
+        label: "Affiliation search label",
       },
       graphQL: {
         query: "\nquery Affiliations($name: String!){\n  affiliations(name: $name) {\n    totalCount\n    nextCursor\n    items {\n      id\n      displayName\n      uri\n    }\n  }\n}",
@@ -1064,24 +1131,46 @@ describe("QuestionAdd", () => {
     };
     const mockTypeAheadJSON = JSON.stringify(json);
 
-    render(
-      <QuestionAdd
-        questionType="affiliationSearch"
-        questionName="Affiliation Search"
-        questionJSON={mockTypeAheadJSON}
-        sectionId="1"
-      />);
+    await act(async () => {
+      render(
+        <QuestionAdd
+          questionType="affiliationSearch"
+          questionName="Affiliation Search"
+          questionJSON={mockTypeAheadJSON}
+          sectionId="1"
+        />
+      );
+    });
 
     // Find the label input rendered by AffiliationSearch
     const labelInput = screen.getByPlaceholderText('Enter search label');
 
     // Simulate user typing
-    fireEvent.change(labelInput, { target: { value: 'New Institution Label' } });
+    await act(async () => {
+      fireEvent.change(labelInput, { target: { value: 'New Institution Label' } });
+    });
 
     expect(labelInput).toHaveValue('New Institution Label');
+
+    // Click the preview button
+    const previewButton = screen.getByRole('button', { name: /buttons.previewQuestion/i });
+
+    await act(async () => {
+      fireEvent.click(previewButton);
+    });
+
+    // Wait for the modal to appear
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
+    });
+
+    // Check if the new label appears in the preview
+    await waitFor(() => {
+      expect(screen.getByText('New Institution Label')).toBeInTheDocument();
+    });
   });
 
-  it('should call handleTypeAheadHelpTextChange when typeaheadSearch help text value changes', () => {
+  it('should call handleTypeAheadHelpTextChange when typeaheadSearch help text value changes', async () => {
     (useAddQuestionMutation as jest.Mock).mockReturnValue([
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
       { loading: false, error: undefined },
@@ -1092,7 +1181,7 @@ describe("QuestionAdd", () => {
       },
       type: "affiliationSearch",
       attributes: {
-        label: "Enter the search term to find your affiliation",
+        help: "Enter the search term to find your affiliation",
       },
       graphQL: {
         query: "\nquery Affiliations($name: String!){\n  affiliations(name: $name) {\n    totalCount\n    nextCursor\n    items {\n      id\n      displayName\n      uri\n    }\n  }\n}",
@@ -1134,8 +1223,68 @@ describe("QuestionAdd", () => {
     fireEvent.change(helpTextInput, { target: { value: 'Enter a search term' } });
 
     expect(helpTextInput).toHaveValue('Enter a search term');
+
+    // Click the preview button
+    const previewButton = screen.getByRole('button', { name: /buttons.previewQuestion/i });
+
+    await act(async () => {
+      fireEvent.click(previewButton);
+    });
+
+    // Wait for the modal to appear
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
+    });
+
+    // Check if the new label appears in the preview
+    await waitFor(() => {
+      expect(screen.getByText('Enter a search term')).toBeInTheDocument();
+    });
   });
 
+});
+
+describe("Accessibility", () => {
+  let mockRouter;
+  beforeEach(() => {
+    HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
+    window.scrollTo = jest.fn(); // Called by the wrapping PageHeader
+    const mockTemplateId = 123;
+    const mockUseParams = useParams as jest.Mock;
+
+    // Mock window.tinymce
+    window.tinymce = {
+      init: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    // Mock the return value of useParams
+    mockUseParams.mockReturnValue({ templateId: `${mockTemplateId}` });
+
+    // Mock the router
+    mockRouter = { push: jest.fn() };
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+
+    (useQuestionsDisplayOrderQuery as jest.Mock).mockReturnValue({
+      data: mockQuestionDisplayData,
+      loading: false,
+      error: undefined,
+    });
+
+    (useTemplateQuery as jest.Mock).mockReturnValue({
+      data: mockTemplateData,
+      loading: false,
+      error: undefined,
+    });
+  });
+
+  afterEach(() => {
+    // Clean up DOM
+    document.body.innerHTML = '';
+
+    // Reset all mocks
+    jest.clearAllMocks();
+  });
   it('should pass axe accessibility test', async () => {
     (useAddQuestionMutation as jest.Mock).mockReturnValue([
       jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
@@ -1171,11 +1320,20 @@ describe("QuestionAdd", () => {
       expect(results).toHaveNoViolations();
     });
   });
-});
+
+})
 
 describe("Error handling", () => {
   let mockRouter;
   beforeEach(() => {
+
+    // Clean up DOM
+    document.body.innerHTML = '';
+
+    // Reset all mocks
+    jest.clearAllMocks();
+
+
     HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
     window.scrollTo = jest.fn(); // Called by the wrapping PageHeader
     const mockTemplateId = 123;

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -201,11 +201,34 @@ const QuestionAdd = ({
   // Handler for typeahead search label changes
   const handleTypeAheadSearchLabelChange = (value: string) => {
     setTypeaheadSearchLabel(value);
+    // Update the label in the question JSON and sync to question state
+    if (parsedQuestionJSON && (parsedQuestionJSON?.type === "affiliationSearch")) {
+      const updatedParsed = structuredClone(parsedQuestionJSON); // To avoid mutating state directly
+
+      if (updatedParsed?.attributes) {
+        updatedParsed.attributes.label = value;
+        setQuestion(prev => ({
+          ...prev,
+          json: JSON.stringify(updatedParsed),
+        }));
+      }
+    }
   };
 
   // Handler for typeahead help text changes
   const handleTypeAheadHelpTextChange = (value: string) => {
     setTypeAheadHelpText(value);
+    if (parsedQuestionJSON && (parsedQuestionJSON?.type === "affiliationSearch")) {
+      const updatedParsed = structuredClone(parsedQuestionJSON); // To avoid mutating state directly
+
+      if (updatedParsed?.attributes) {
+        updatedParsed.attributes.help = value;
+        setQuestion(prev => ({
+          ...prev,
+          json: JSON.stringify(updatedParsed),
+        }));
+      }
+    }
   };
 
   // Handle changes from RadioGroup
@@ -281,8 +304,8 @@ const QuestionAdd = ({
       return;
     }
     return questionTypeHandlers[questionType as keyof typeof questionTypeHandlers](
-        parsed,
-        userInput
+      parsed,
+      userInput
     );
   };
 


### PR DESCRIPTION
## Description

- Added back some code for affiliation event handlers and updated location of `label` and `help` text in `json` so that the updated values appear on the`Question Preview` page. (See screenshots for further description)

Fixes # ([669](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/669))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested and updated unit tests.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshots
### When a user is adding a new `AffiliationSearch` question type, and they enter a `label` and `help` text for that question
![AddQuestion](https://github.com/user-attachments/assets/1925fd25-6463-46a8-86cd-d355dc5a1f3b)

### Users should be able to see the values they entered in the Question Preview
![Preview](https://github.com/user-attachments/assets/32673a40-766c-48d0-aea5-d34259b3f0f3)
