### PR TITLE
Added a dialog when removing a project member to message the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 ### Added
+- Added a `dialog` when removing `project members` so we can message them about the member being removed from all plans and allow users to confirm they want to delete this member [#737]
 - Added new `Comments` functionality. Added new graphql queries to get `answerComments` and `feedbackComments` for the `Question Details` page [#321]
 - Added new mutations to `add`, `update`, and `delete` comments [#321]
 - Added new `CommentList` and `CommentsDrawer` components, and `useComments` hook for the comments list [#321]

--- a/app/[locale]/projects/[projectId]/members/[memberId]/edit/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/members/[memberId]/edit/__tests__/page.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { act, fireEvent, render, screen, waitFor } from '@/utils/test-utils';
+import { act, fireEvent, render, screen, waitFor, within } from '@/utils/test-utils';
 import { useParams, useRouter } from 'next/navigation';
 import { useToast } from '@/context/ToastContext';
 import logECS from '@/utils/clientLogger';
@@ -283,11 +283,80 @@ describe("ProjectsProjectMembersEdit", () => {
       );
     });
 
-    const removeButton = screen.getByRole('button', { name: /form.labels.removeMemberFromProject/i });
-    fireEvent.click(removeButton);
+    const removeButton = screen.getByRole('button', { name: 'buttons.removeMember' });
+
+    await act(async () => {
+      fireEvent.click(removeButton);
+    })
+
+    await waitFor(() => {
+      // Modal should open
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      const heading = screen.getByRole('heading', { level: 3 });
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveTextContent('headings.removeProjectMember');
+      // Get buttons within the modal/dialog
+      const dialog = screen.getByRole('dialog');
+      const modalButtons = within(dialog).getAllByRole('button');
+      expect(modalButtons).toHaveLength(2);
+      expect(modalButtons[0]).toHaveTextContent('buttons.cancel');
+      expect(modalButtons[1]).toHaveTextContent('buttons.delete');
+    });
+
+    // Click delete button
+    const dialog = screen.getByRole('dialog');
+    const deleteButton = within(dialog).getByRole('button', { name: 'buttons.delete' });
+
+    await act(async () => {
+      fireEvent.click(deleteButton);
+    });
 
     await waitFor(() => {
       expect(mockRouter.push).toHaveBeenCalledWith('/en-US/projects/1/members');
+    });
+  });
+
+  it("should handle cancel button in Remove Member modal", async () => {
+    (useUpdateProjectMemberMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: mockResponse }),
+      { loading: false, error: undefined },
+    ]);
+
+    (useRemoveProjectMemberMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: 'value' } }),
+      { loading: false, error: undefined },
+    ]);
+
+    await act(async () => {
+      render(
+        <ProjectsProjectMembersEdit />
+      );
+    });
+
+    const removeButton = screen.getByRole('button', { name: 'buttons.removeMember' });
+
+    await act(async () => {
+      fireEvent.click(removeButton);
+    })
+
+    await waitFor(() => {
+      // Modal should open
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // Click delete button
+    const dialog = screen.getByRole('dialog');
+    const modalButtons = within(dialog).getAllByRole('button');
+    expect(modalButtons).toHaveLength(2);
+    expect(modalButtons[0]).toHaveTextContent('buttons.cancel');
+    expect(modalButtons[1]).toHaveTextContent('buttons.delete');
+
+    await act(async () => {
+      fireEvent.click(modalButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(dialog).not.toBeInTheDocument();
     });
   });
 
@@ -307,8 +376,24 @@ describe("ProjectsProjectMembersEdit", () => {
       );
     });
 
-    const removeButton = screen.getByRole('button', { name: /form.labels.removeMemberFromProject/i });
-    fireEvent.click(removeButton);
+    const removeButton = screen.getByRole('button', { name: 'buttons.removeMember' });
+
+    await act(async () => {
+      fireEvent.click(removeButton);
+    })
+
+    await waitFor(() => {
+      // Modal should open
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // Click delete button
+    const dialog = screen.getByRole('dialog');
+    const deleteButton = screen.getByRole('button', { name: 'buttons.delete' });
+
+    await act(async () => {
+      fireEvent.click(deleteButton);
+    });
 
     expect(await screen.findByText('Error removing member')).toBeInTheDocument();
   });
@@ -329,8 +414,24 @@ describe("ProjectsProjectMembersEdit", () => {
       );
     });
 
-    const removeButton = screen.getByRole('button', { name: /form.labels.removeMemberFromProject/i });
-    fireEvent.click(removeButton);
+    const removeButton = screen.getByRole('button', { name: 'buttons.removeMember' });
+
+    await act(async () => {
+      fireEvent.click(removeButton);
+    })
+
+    await waitFor(() => {
+      // Modal should open
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // Click delete button
+    const dialog = screen.getByRole('dialog');
+    const deleteButton = screen.getByRole('button', { name: 'buttons.delete' });
+
+    await act(async () => {
+      fireEvent.click(deleteButton);
+    });
 
     await waitFor(() => {
       expect(logECS).toHaveBeenCalledWith(

--- a/app/[locale]/projects/[projectId]/members/[memberId]/edit/page.tsx
+++ b/app/[locale]/projects/[projectId]/members/[memberId]/edit/page.tsx
@@ -10,6 +10,10 @@ import {
   Button,
   Form,
   Link,
+  Dialog,
+  DialogTrigger,
+  Modal,
+  ModalOverlay,
 } from "react-aria-components";
 
 // Components
@@ -81,6 +85,10 @@ const ProjectsProjectMembersEdit: React.FC = () => {
   const { scrollToTop } = useScrollToTop();
 
   const [errorMessages, setErrorMessages] = useState<string[]>([]);
+
+  // State for remove project member modal
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   // Field errors
   const [fieldErrors, setFieldErrors] = useState<ProjectMemberErrorInterface>({
@@ -184,7 +192,7 @@ const ProjectsProjectMembersEdit: React.FC = () => {
 
   // Handle remove member from project
   const handleRemoveMember = async () => {
-
+    setIsDeleting(true);
     const [errors, success] = await removeProjectMember();
 
     if (!success) {
@@ -198,16 +206,16 @@ const ProjectsProjectMembersEdit: React.FC = () => {
           projectRoles: errors.memberRoleIds ?? ''
         });
       }
-      setErrorMessages([errors.general || t('form.errors.updatingMember')]);
+      setErrorMessages([errors.general || t('form.errors.removingMember')]);
+      setIsDeleting(false);
 
+      // Scroll to top of page for errors
+      scrollToTop(topRef);
     } else {
       // Show success message
       showRemoveSuccessToast();
       router.push(PROJECT_MEMBERS_ROUTE);
     }
-
-    // Scroll to top of page
-    scrollToTop(topRef);
   }
 
   // update the project member
@@ -274,10 +282,6 @@ const ProjectsProjectMembersEdit: React.FC = () => {
       ...prevErrors,
       [name]: error
     }));
-    if (error.length > 1) {
-      setErrorMessages(prev => [...prev, error]);
-    }
-
     return error;
   }
 
@@ -285,15 +289,6 @@ const ProjectsProjectMembersEdit: React.FC = () => {
   const isFormValid = (): boolean => {
     // Initialize a flag for form validity
     let isValid = true;
-    // Field errors
-    const errors: ProjectMemberErrorInterface = {
-      givenName: '',
-      surName: '',
-      affiliationId: '',
-      email: '',
-      orcid: '',
-      projectRoles: ''
-    };
 
     // Iterate over formData to validate each field
     Object.keys(projectMemberData).forEach((key) => {
@@ -304,7 +299,6 @@ const ProjectsProjectMembersEdit: React.FC = () => {
       const error = validateField(name, value);
       if (error) {
         isValid = false;
-        errors[name] = error;
       }
     });
     return isValid;
@@ -372,7 +366,7 @@ const ProjectsProjectMembersEdit: React.FC = () => {
         showBackButton={false}
         breadcrumbs={
           <Breadcrumbs>
-            <Breadcrumb><Link href="/">{Global('breadcrumbs.home')}</Link></Breadcrumb>
+            <Breadcrumb><Link href={routePath('app.home')}>{Global('breadcrumbs.home')}</Link></Breadcrumb>
             <Breadcrumb><Link href={routePath('projects.index')}>{Global('breadcrumbs.projects')}</Link></Breadcrumb>
             <Breadcrumb><Link href={routePath('projects.show', { projectId })}>{Global('breadcrumbs.project')}</Link></Breadcrumb>
             <Breadcrumb><Link href={PROJECT_MEMBERS_ROUTE}>{t('breadcrumbs.projectMembers')}</Link></Breadcrumb>
@@ -387,8 +381,6 @@ const ProjectsProjectMembersEdit: React.FC = () => {
       <LayoutContainer>
         <ContentContainer>
           <div ref={topRef}>
-            <h2>Test{fieldErrors.givenName}</h2>
-
             <Form onSubmit={handleFormSubmit} className={styles.editForm}>
               <div className={styles.formSection}>
                 <FormInput
@@ -481,18 +473,50 @@ const ProjectsProjectMembersEdit: React.FC = () => {
             </Form>
           </div>
 
-          <section className={styles.dangerZone} aria-labelledby="remove-section">
-            <h2 id="remove-section">{t('headings.h2RemoveMember')}</h2>
+          {/* Delete Project Member Modal */}
+          <section className={styles.dangerZone} aria-labelledby="remove-member" data-testid="remove-member">
+            <h2 id="remove-member">{t('headings.h2RemoveMember')}</h2>
             <p>
               {t('paragraphs.removeMember')}
             </p>
-            <Button
-              onPress={handleRemoveMember}
-              className="secondary"
-              aria-label={t('form.labels.removeMemberFromProject')}
-            >
-              {t('buttons.removeMember')}
-            </Button>
+            <DialogTrigger isOpen={isDeleteModalOpen} onOpenChange={setIsDeleteModalOpen}>
+              <Button
+                className="secondary"
+                isDisabled={isDeleting}
+              >
+                {isDeleting ? `${t('buttons.removing')}...` : t('buttons.removeMember')}
+              </Button>
+              <ModalOverlay>
+                <Modal>
+                  <Dialog>
+                    {({ close }) => (
+                      <>
+                        <h3>{t('headings.removeProjectMember')}</h3>
+                        <p>{t('paragraphs.modalInfo')}</p>
+                        <div className={styles.deleteConfirmButtons}>
+                          <Button
+                            className="secondary"
+                            aria-label={t('form.labels.removeMemberFromProject')}
+                            autoFocus
+                            onPress={close}>
+                            {Global('buttons.cancel')}
+                          </Button>
+                          <Button
+                            className="primary"
+                            onPress={() => {
+                              handleRemoveMember();
+                              close();
+                            }}
+                          >
+                            {Global('buttons.delete')}
+                          </Button>
+                        </div>
+                      </>
+                    )}
+                  </Dialog>
+                </Modal>
+              </ModalOverlay>
+            </DialogTrigger>
           </section>
         </ContentContainer>
       </LayoutContainer>

--- a/app/[locale]/projects/[projectId]/members/page.tsx
+++ b/app/[locale]/projects/[projectId]/members/page.tsx
@@ -43,6 +43,7 @@ const ProjectsProjectMembers = () => {
   const { data, loading, error: queryError } = useProjectMembersQuery(
     {
       variables: { projectId: Number(projectId) },
+      fetchPolicy: 'network-only',// So that when members are deleted the page refreshes 
       notifyOnNetworkStatusChange: true
     }
   );

--- a/messages/en-US/planBuilderProjectOverview.json
+++ b/messages/en-US/planBuilderProjectOverview.json
@@ -205,13 +205,16 @@
       "projectMembers": "Project members"
     },
     "buttons": {
-      "removeMember": "Remove member"
+      "removeMember": "Remove member",
+      "removing": "Removing"
     },
     "headings": {
-      "h2RemoveMember": "Remove member"
+      "h2RemoveMember": "Remove member",
+      "removeProjectMember": "Remove project member"
     },
     "paragraphs": {
-      "removeMember": "Removing this member means they will no longer be able to access this plan. This is not reversible."
+      "removeMember": "Removing this member means they will no longer be able to access this plan. This is not reversible.",
+      "modalInfo": "Please note that if you remove this project member, the member will also be removed from any associated plans. Also, if this is the only member under the project, it cannot be deleted."
     },
     "form": {
       "errors": {


### PR DESCRIPTION

## Description

While I was working on backend changes for removing project and plan members, I felt that we needed a way to message a user when they click on the Project Member `Remove member` button to let them know that deleting the member will also delete them from the Plan. 

Fixes # ([737](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/737))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually and using unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
