### PR TITLE
[Bug fix] - Fixed issue with some breaking unit tests due to different timezones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Updated the funding-search page on the create project step to link to the new page to add the funder manually [#497]
 
 ### Fixed
+- Fixed issue with some breaking unit tests due to different timezones [#739]
 - Fixed some issues on the `Project details` page [#734]
 - Fixed issue with entered Affiliation `label` and `help` text not displaying on the `Question Preview` page
 - Update `PlanOverviewQuestionPage` to make sure that `sample text` displays initially when it is present and `useSampleTextAsDefault` is set to true [#677]

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentList.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentList.spec.tsx
@@ -10,8 +10,13 @@ expect.extend(toHaveNoViolations);
 
 // Mock the date utils
 jest.mock("@/utils/dateUtils", () => ({
-  formatRelativeFromTimestamp: (timestamp: string, locale: string) => {
-    return `${new Date(parseInt(timestamp)).toLocaleDateString()} (${locale})`;
+  formatRelativeFromTimestamp: (timestamp: string) => {
+    return `${new Date(parseInt(timestamp)).toLocaleDateString('en-US', {
+      timeZone: 'UTC',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric'
+    })} (en)`;
   },
 }));
 
@@ -133,8 +138,8 @@ describe("CommentList", () => {
     render(<CommentList {...defaultProps} />);
 
     expect(screen.getByText(/1\/1\/2023 \(en\)/)).toBeInTheDocument();
-    expect(screen.getByText(/1\/3\/2023 \(en\)/)).toBeInTheDocument();
-    expect(screen.getByText(/12\/31\/2022 \(en\)/)).toBeInTheDocument();
+    expect(screen.getByText(/1\/2\/2023 \(en\)/)).toBeInTheDocument();
+    expect(screen.getByText(/1\/4\/2023 \(en\)/)).toBeInTheDocument();
   });
 
   it("should show edited indicator when comment was modified", () => {

--- a/app/[locale]/template/[templateId]/history/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/history/__tests__/page.spec.tsx
@@ -11,6 +11,12 @@ import { mockScrollIntoView, mockScrollTo } from "@/__mocks__/common";
 
 expect.extend(toHaveNoViolations);
 
+// Mocking date returned from formatShortMonthDayYear so that it passes for all locales
+jest.mock('@/utils/dateUtils', () => ({
+  ...jest.requireActual('@/utils/dateUtils'),
+  formatShortMonthDayYear: jest.fn(() => 'Jun 25, 2014'),
+}));
+
 jest.mock('@/generated/graphql', () => ({
   useTemplateVersionsQuery: jest.fn(),
 }));


### PR DESCRIPTION
## Description

- Updated unit tests for `/template/[templateId]/history/__tests__/page.spec.tsx` and `/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentList.spec.tsx` which broke because dates tested were assumed to always be from same timezone. 

Fixes # ([739](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/739))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Tested my changes by running tests in the `Pacific/Auckland` timezone: `TZ=Pacific/Auckland npm test`


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
