### PR TITLE
Chore/743/js update shared radio and checkbox group components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added missing `planId` from the `PlanFundings` errors [#322](https://github.com/CDLUC3/dmsp_backend_prototype/issues/322)
 
 ### Updated
+- Updated the shared`RadioGroupComponent` and `CheckboxGroupComponent` components to be more like a wrapper to reduce duplicate of code and make it more flexible [#743]
 - Project over is now using sidebar to allow for collaboration [#750]
 - Sidebar is now using global styling rather than css modules [#750]
 - Renamed collaboration components from `ProjectsProjectPlanFeedback` to `ProjectsProjectCollaboration` for better clarity and consistency: [#750]

--- a/app/[locale]/projects/[projectId]/collaboration/invite/page.tsx
+++ b/app/[locale]/projects/[projectId]/collaboration/invite/page.tsx
@@ -9,6 +9,7 @@ import {
   Form,
   Link,
   Modal,
+  Radio
 } from "react-aria-components";
 import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -106,15 +107,6 @@ const ProjectsProjectCollaborationInvite = () => {
   const INVITE_ROUTE = routePath('projects.collaboration.invite', { projectId });
   const MEMBERS_ROUTE = routePath('projects.members.index', { projectId });
   const COLLABORATION_ROUTE = routePath('projects.collaboration', { projectId });
-
-  // Access level ratio button data
-  const radioData = {
-    radioGroupLabel: t('radioButtons.access.label'),
-    radioButtonData: [
-      { value: 'edit', label: t('radioButtons.access.edit') },
-      { value: 'comment', label: t('radioButtons.access.comment') }
-    ]
-  }
 
   // Handle access level radio button change
   const handleRadioChange = (value: string) => {
@@ -267,10 +259,16 @@ const ProjectsProjectCollaborationInvite = () => {
                 <RadioGroupComponent
                   name="accessLevel"
                   value={state.accessLevel}
-                  radioGroupLabel={radioData.radioGroupLabel}
-                  radioButtonData={radioData.radioButtonData}
+                  radioGroupLabel={t('radioButtons.access.label')}
                   onChange={handleRadioChange}
-                />
+                >
+                  <div>
+                    <Radio value="edit">{t('radioButtons.access.edit')}</Radio>
+                  </div>
+                  <div>
+                    <Radio value="comment">{t('radioButtons.access.comment')}</Radio>
+                  </div>
+                </RadioGroupComponent>
               </div>
 
               <div>
@@ -323,7 +321,7 @@ const ProjectsProjectCollaborationInvite = () => {
 
             <p >
               {t.rich('para4', {
-                projectMember: (chunks) => <a href={MEMBERS_ROUTE}>{chunks}</a>
+                projectmember: (chunks) => <a href={MEMBERS_ROUTE}>{chunks}</a>
               })}
             </p>
             <p>

--- a/app/[locale]/projects/[projectId]/collaboration/invite/projectCollaboration.module.scss
+++ b/app/[locale]/projects/[projectId]/collaboration/invite/projectCollaboration.module.scss
@@ -1,3 +1,0 @@
-.radioDescription {
-  margin-left: var(--space-6);
-}

--- a/app/[locale]/projects/[projectId]/collaboration/invite/projectCollaboration.module.scss
+++ b/app/[locale]/projects/[projectId]/collaboration/invite/projectCollaboration.module.scss
@@ -1,0 +1,3 @@
+.radioDescription {
+  margin-left: var(--space-6);
+}

--- a/app/[locale]/projects/[projectId]/collaboration/page.tsx
+++ b/app/[locale]/projects/[projectId]/collaboration/page.tsx
@@ -145,7 +145,7 @@ const ProjectsProjectCollaboration = () => {
             <Breadcrumb><Link href={routePath('app.home')}>{Global('breadcrumbs.home')}</Link></Breadcrumb>
             <Breadcrumb><Link href={routePath('projects.index')}>{Global('breadcrumbs.projects')}</Link></Breadcrumb>
             <Breadcrumb><Link href={routePath('projects.show', { projectId })}>{Global('breadcrumbs.projectOverview')}</Link></Breadcrumb>
-    
+
           </Breadcrumbs>
         }
         actions={

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/fundings/page.tsx
@@ -19,6 +19,7 @@ import {
   Breadcrumb,
   Breadcrumbs,
   Button,
+  Checkbox,
   Form,
   Link,
 } from "react-aria-components";
@@ -236,8 +237,28 @@ const ProjectsProjectPlanAdjustFunding = () => {
               onChange={handleCheckboxChange}
               checkboxGroupLabel={t('fundingLabel')}
               checkboxGroupDescription={t('fundingDescription')}
-              checkboxData={checkboxData}
-            />
+            >
+              {checkboxData.map((checkbox, index) => (
+                <div key={index}>
+                  <Checkbox value={checkbox.value}>
+                    <div className="checkbox">
+                      <svg viewBox="0 0 18 18" aria-hidden="true">
+                        <polyline points="1 9 7 14 15 4" />
+                      </svg>
+                    </div>
+                    <div className="">
+                      <span>
+                        {checkbox.label}
+                      </span>
+                      <br />
+                      <span className="help">
+                        {checkbox.description}
+                      </span>
+                    </div>
+                  </Checkbox>
+                </div>
+              ))}
+            </CheckboxGroupComponent>
 
             <p>
               <strong>{t('changeWarning')}</strong>

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
@@ -13,6 +13,8 @@ import {
   Link,
   ListBoxItem,
   Modal,
+  Radio,
+  Text
 } from 'react-aria-components';
 import {
   PlanSectionProgress,
@@ -175,29 +177,6 @@ const PlanOverviewPage: React.FC = () => {
   const CHANGE_PRIMARY_CONTACT_URL = routePath('projects.dmp.members', { projectId, dmpId: planId });
   const RELATED_WORKS_URL = routePath('projects.dmp.relatedWorks', { projectId, dmpId: planId });
 
-  // Set radio button data
-  const radioData = {
-    radioGroupLabel: t('publishModal.publish.visibilityOptionsTitle'),
-    radioButtonData: [
-      {
-        value: 'public',
-        label: t('publishModal.publish.visibilityOptions.public.label'),
-        description: <><strong>{t('publishModal.publish.visibilityOptions.public.description')}</strong></>
-      },
-      {
-        value: 'organizational',
-        label: t('publishModal.publish.visibilityOptions.organization.label'),
-        description: <>{t.rich('publishModal.publish.visibilityOptions.organization.description', {
-          strong: (chunks) => <strong>{chunks}</strong>
-        })}</>
-      },
-      {
-        value: 'private',
-        label: t('publishModal.publish.visibilityOptions.private.label'),
-        description: t('publishModal.publish.visibilityOptions.private.description')
-      }
-    ]
-  }
 
   //TODO: Get research output count from backend
   const researchOutputCount = 3;
@@ -856,13 +835,43 @@ const PlanOverviewPage: React.FC = () => {
                 </p>
 
                 <Heading level={2}>{t('publishModal.publish.visibilityOptionsTitle')}</Heading>
+
+
                 <RadioGroupComponent
                   name="visibility"
                   value={state.planVisibility.toLowerCase()}
-                  radioGroupLabel={radioData.radioGroupLabel}
-                  radioButtonData={radioData.radioButtonData}
+                  radioGroupLabel={t('publishModal.publish.visibilityOptionsTitle')}
                   onChange={handleRadioChange}
-                />
+                >
+                  <div>
+                    <Radio value="public">{t('publishModal.publish.visibilityOptions.public.label')}</Radio>
+                    <Text
+                      slot="description"
+                    >
+                      <strong>{t('publishModal.publish.visibilityOptions.public.description')}</strong>
+                    </Text>
+                  </div>
+
+                  <div>
+                    <Radio value="organizational">{t('publishModal.publish.visibilityOptions.organization.label')}</Radio>
+                    <Text
+                      slot="description"
+                    >
+                      {t.rich('publishModal.publish.visibilityOptions.organization.description', {
+                        strong: (chunks) => <strong>{chunks}</strong>
+                      })}
+                    </Text>
+                  </div>
+
+                  <div>
+                    <Radio value="private">{t('publishModal.publish.visibilityOptions.private.label')}</Radio>
+                    <Text
+                      slot="description"
+                    >
+                      {t('publishModal.publish.visibilityOptions.private.description')}
+                    </Text>
+                  </div>
+                </RadioGroupComponent>
 
                 <div className="modal-actions">
                   <div>

--- a/app/[locale]/projects/[projectId]/dmp/create/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/create/page.tsx
@@ -7,6 +7,7 @@ import {
   Breadcrumb,
   Breadcrumbs,
   Button,
+  Checkbox,
   FieldError,
   Input,
   Label,
@@ -450,26 +451,47 @@ const PlanCreate: React.FC = () => {
                 onChange={(value) => handleCheckboxChange(value, 'funders')}
                 checkboxGroupLabel={PlanCreate('checkbox.filterByFunderLabel')}
                 checkboxGroupDescription={PlanCreate('checkbox.filterByFunderDescription')}
-                checkboxData={funders.map(funder => ({
-                  label: funder.name,
-                  value: funder.uri,
-                }))}
-              />
+              >
+                {funders.map((funder, index) => (
+                  <div key={index}>
+                    <Checkbox value={funder.uri}>
+                      <div className="checkbox">
+                        <svg viewBox="0 0 18 18" aria-hidden="true">
+                          <polyline points="1 9 7 14 15 4" />
+                        </svg>
+                      </div>
+                      <div className="">
+                        <span>
+                          {funder.name}
+                        </span>
+                      </div>
+                    </Checkbox>
+                  </div>
+                ))}
+              </CheckboxGroupComponent>
             )}
 
             {funders.length === 0 && hasBestPractice && (
               <CheckboxGroupComponent
                 name="bestPractices"
-                ariaLabel="best practices"
                 value={selectedFilterItems}
                 onChange={(value) => handleCheckboxChange(value, 'bestPractice')}
                 checkboxGroupLabel={PlanCreate('checkbox.filterByBestPracticesLabel')}
                 checkboxGroupDescription={PlanCreate('checkbox.filterByBestPracticesDescription')}
-                checkboxData={[{
-                  label: PlanCreate('labels.dmpBestPractice'),
-                  value: "DMP Best Practice",
-                }]}
-              />
+              >
+                <Checkbox value="DMP Best Practice" aria-label="best practices">
+                  <div className="checkbox">
+                    <svg viewBox="0 0 18 18" aria-hidden="true">
+                      <polyline points="1 9 7 14 15 4" />
+                    </svg>
+                  </div>
+                  <div className="">
+                    <span>
+                      {PlanCreate('labels.dmpBestPractice')}
+                    </span>
+                  </div>
+                </Checkbox>
+              </CheckboxGroupComponent>
             )}
           </div>
 

--- a/app/[locale]/projects/[projectId]/members/[memberId]/edit/page.tsx
+++ b/app/[locale]/projects/[projectId]/members/[memberId]/edit/page.tsx
@@ -8,6 +8,7 @@ import {
   Breadcrumb,
   Breadcrumbs,
   Button,
+  Checkbox,
   Form,
   Link,
   Dialog,
@@ -460,13 +461,27 @@ const ProjectsProjectMembersEdit: React.FC = () => {
                   isRequired={true}
                   checkboxGroupLabel={t('form.labels.checkboxGroupLabel')}
                   checkboxGroupDescription={t('form.labels.checkboxGroupDescription')}
-                  checkboxData={state.roles && state.roles.map(role => ({
-                    label: role.label,
-                    value: role?.id?.toString() ?? ''
-                  }))}
                   isInvalid={checkboxRoles.length === 0}
                   errorMessage={fieldErrors.projectRoles || t('form.errors.projectRoles')}
-                />
+                >
+                  {state.roles.map((role, index) => (
+                    <div key={index}>
+                      <Checkbox value={role?.id?.toString() ?? ''} aria-label="project roles option">
+                        <div className="checkbox">
+                          <svg viewBox="0 0 18 18" aria-hidden="true">
+                            <polyline points="1 9 7 14 15 4" />
+                          </svg>
+                        </div>
+                        <div className="">
+                          <span>
+                            {role.label}
+                          </span>
+
+                        </div>
+                      </Checkbox>
+                    </div>
+                  ))}
+                </CheckboxGroupComponent>
 
                 <Button type="submit">{Global('buttons.saveChanges')}</Button>
               </div>

--- a/app/[locale]/projects/[projectId]/project-funding/page.tsx
+++ b/app/[locale]/projects/[projectId]/project-funding/page.tsx
@@ -12,6 +12,8 @@ import {
   Button,
   Form,
   Link,
+  Radio,
+  Text
 } from "react-aria-components";
 
 // Components
@@ -49,7 +51,7 @@ const ProjectsCreateProjectFunding = () => {
       variables: {
         projectId: Number(projectId),
       }
-    }).then(({data}) => {
+    }).then(({ data }) => {
       let nextUrl: string = PROJECT_EDIT_URL;
 
       // NOTE: In the previous step, we selected a funder. So when we get to
@@ -62,22 +64,6 @@ const ProjectsCreateProjectFunding = () => {
       }
       router.push(nextUrl);
     });
-  }
-
-  const radioData = {
-    radioGroupLabel: ProjectFunding('form.radioFundingLabel'),
-    radioButtonData: [
-      {
-        value: 'yes',
-        label: ProjectFunding('form.radioYesLabel'),
-        description: ProjectFunding('form.radioYesDescription'),
-      },
-      {
-        value: 'no',
-        label: ProjectFunding('form.radioNoLabel'),
-        description: ProjectFunding('form.radioNoDescription'),
-      }
-    ]
   }
 
   return (
@@ -101,11 +87,29 @@ const ProjectsCreateProjectFunding = () => {
             <RadioGroupComponent
               name="has_funding"
               value={hasFunding}
+              radioGroupLabel={ProjectFunding('form.radioFundingLabel')}
               description={ProjectFunding('form.radioFundingDescription')}
               onChange={setHasFunding}
-              radioGroupLabel={radioData.radioGroupLabel}
-              radioButtonData={radioData.radioButtonData}
-            />
+            >
+              <div>
+                <Radio value="yes">{ProjectFunding('form.radioYesLabel')}</Radio>
+                <Text
+                  slot="description"
+                >
+                  {ProjectFunding('form.radioYesDescription')}
+                </Text>
+              </div>
+
+              <div>
+                <Radio value="no">{ProjectFunding('form.radioNoLabel')}</Radio>
+                <Text
+                  slot="description"
+                >
+                  {ProjectFunding('form.radioNoDescription')}
+                </Text>
+              </div>
+
+            </RadioGroupComponent>
 
             <Button
               type="submit"

--- a/app/[locale]/projects/[projectId]/project/page.tsx
+++ b/app/[locale]/projects/[projectId]/project/page.tsx
@@ -11,6 +11,8 @@ import {
   Button,
   Form,
   Link,
+  Radio,
+  Text
 } from "react-aria-components";
 
 //GraphQL
@@ -26,9 +28,10 @@ import { ContentContainer, LayoutContainer } from "@/components/Container";
 import {
   FormInput,
   FormTextArea,
-  RadioGroupComponent,
-  DateComponent
+  DateComponent,
+  RadioGroupComponent
 } from "@/components/Form";
+
 import ErrorMessages from '@/components/ErrorMessages';
 import ResearchDomainCascadingDropdown
   from '@/components/ResearchDomainCascadingDropdown';
@@ -90,22 +93,6 @@ const ProjectsProjectDetail = () => {
   const ProjectOverview = useTranslations('ProjectOverview');
   const ProjectDetail = useTranslations('ProjectsProjectDetail');
   const Global = useTranslations('Global');
-
-  const radioData = {
-    radioGroupLabel: ProjectDetail('labels.projectType'),
-    radioButtonData: [
-      {
-        value: 'true',
-        label: ProjectDetail('labels.mockProject'),
-        description: ProjectDetail('descriptions.mockProject')
-      },
-      {
-        value: 'false',
-        label: ProjectDetail('labels.realProject'),
-        description: ProjectDetail('descriptions.realProject')
-      }
-    ]
-  }
 
   // Initialize useUpdateProjectMutation
   const [updateProjectMutation] = useUpdateProjectMutation();
@@ -383,10 +370,27 @@ const ProjectsProjectDetail = () => {
               <RadioGroupComponent
                 name="projectType"
                 value={projectData.isTestProject.toString()}
-                radioGroupLabel={radioData.radioGroupLabel}
-                radioButtonData={radioData.radioButtonData}
+                radioGroupLabel={ProjectDetail('labels.projectType')}
                 onChange={handleRadioChange}
-              />
+              >
+                <div>
+                  <Radio value="true">{ProjectDetail('labels.mockProject')}</Radio>
+                  <Text
+                    slot="description"
+                  >
+                    {ProjectDetail('descriptions.mockProject')}
+                  </Text>
+                </div>
+
+                <div>
+                  <Radio value="false">{ProjectDetail('labels.realProject')}</Radio>
+                  <Text
+                    slot="description"
+                  >
+                    {ProjectDetail('descriptions.realProject')}
+                  </Text>
+                </div>
+              </RadioGroupComponent>
             </div>
 
             <Button type="submit" className="submit-button">{Global('buttons.save')}</Button>

--- a/app/[locale]/projects/create-project/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/create-project/__tests__/page.spec.tsx
@@ -158,7 +158,7 @@ describe('ProjectsCreateProject', () => {
     expect(screen.getByText(/form.projectTitleHelpText/i)).toBeInTheDocument();
     expect(screen.getByText(/form.checkboxLabel/i)).toBeInTheDocument();
     expect(screen.getByText(/form.checkboxHelpText/i)).toBeInTheDocument();
-    expect(screen.getByRole('checkbox', { name: /form.checkboxLabel/i })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: "isThisMockProject" })).toBeInTheDocument();
     expect(screen.getByText(/form.checkboxGroupLabel/i)).toBeInTheDocument();
     expect(screen.getByText(/form.checkboxGroupHelpText/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /buttons.continue/i })).toBeInTheDocument();

--- a/app/[locale]/projects/create-project/page.tsx
+++ b/app/[locale]/projects/create-project/page.tsx
@@ -7,6 +7,7 @@ import {
   Breadcrumb,
   Breadcrumbs,
   Button,
+  Checkbox,
   Form,
   Link,
 } from "react-aria-components";
@@ -68,14 +69,6 @@ const ProjectsCreateProject = () => {
   // localization keys
   const Global = useTranslations('Global');
   const CreateProject = useTranslations('ProjectsCreateProject');
-
-  const checkboxData = [
-    {
-      value: 'checkboxGroup',
-      label: CreateProject('form.checkboxLabel'),
-      description: CreateProject('form.checkboxHelpText')
-    }
-  ]
 
   const [addProjectMutation] = useAddProjectMutation();
 
@@ -161,7 +154,7 @@ const ProjectsCreateProject = () => {
           isTestProject,
           title: formData.projectName,
         }
-      }).then(({data}) => {
+      }).then(({ data }) => {
         const result = data!.addProject;
         const [hasErrors, errs] = checkErrors(
           result?.errors as ProjectErrors,
@@ -195,10 +188,10 @@ const ProjectsCreateProject = () => {
 
   useEffect(() => {
     // Scroll to the Project name field if there is a field-level error
-    if(fieldErrors.projectName.length > 0) {
+    if (fieldErrors.projectName.length > 0) {
       scrollToTop(inputFieldRef);
     }
-  },[fieldErrors.projectName])
+  }, [fieldErrors.projectName])
 
   return (
     <>
@@ -241,11 +234,30 @@ const ProjectsCreateProject = () => {
             <CheckboxGroupComponent
               name="checkboxGroup"
               value={formData.checkboxGroup}
+              onChange={handleCheckboxChange}
+              isRequired={false}
               checkboxGroupLabel={CreateProject('form.checkboxGroupLabel')}
               checkboxGroupDescription={CreateProject('form.checkboxGroupHelpText')}
-              checkboxData={checkboxData}
-              onChange={handleCheckboxChange}
-            />
+            >
+
+              <Checkbox value="checkboxGroup" aria-label={CreateProject('isThisMockProject')}>
+                <div className="checkbox">
+                  <svg viewBox="0 0 18 18" aria-hidden="true">
+                    <polyline points="1 9 7 14 15 4" />
+                  </svg>
+                </div>
+                <div className="">
+                  <span>
+                    {CreateProject('form.checkboxLabel')}
+                  </span>
+                  <br />
+                  <span className="help">
+                    {CreateProject('form.checkboxHelpText')}
+                  </span>
+                </div>
+              </Checkbox>
+
+            </CheckboxGroupComponent>
 
             <Button
               type="submit"

--- a/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   Link,
   Modal,
   ModalOverlay,
+  Radio,
   Tab,
   TabList,
   TabPanel,
@@ -43,6 +44,7 @@ import {
   RangeComponent,
   TypeAheadSearch
 } from '@/components/Form';
+
 import FormTextArea from '@/components/Form/FormTextArea';
 import ErrorMessages from '@/components/ErrorMessages';
 import QuestionView from '@/components/QuestionView';
@@ -53,7 +55,7 @@ import { useToast } from '@/context/ToastContext';
 import { routePath } from '@/utils/routes';
 import { stripHtmlTags } from '@/utils/general';
 import logECS from '@/utils/clientLogger';
-import {getQuestionFormatInfo, getQuestionTypes, questionTypeHandlers} from '@/utils/questionTypeHandlers';
+import { getQuestionFormatInfo, getQuestionTypes, questionTypeHandlers } from '@/utils/questionTypeHandlers';
 import { QuestionTypeMap } from "@dmptool/types";
 import {
   Question,
@@ -121,21 +123,6 @@ const QuestionEdit = () => {
 
   // Set URLs
   const TEMPLATE_URL = routePath('template.show', { templateId });
-
-  const radioData = {
-    radioGroupLabel: Global('labels.requiredField'),
-    radioButtonData: [
-      {
-        value: 'yes',
-        label: Global('form.yesLabel'),
-      },
-      {
-        value: 'no',
-        label: Global('form.noLabel')
-      }
-    ]
-  }
-
 
   // Run selected question query
   const {
@@ -664,11 +651,18 @@ const QuestionEdit = () => {
                 <RadioGroupComponent
                   name="radioGroup"
                   value={question?.required ? 'yes' : 'no'}
-                  radioGroupLabel={radioData.radioGroupLabel}
-                  radioButtonData={radioData.radioButtonData}
+                  radioGroupLabel={Global('labels.requiredField')}
                   description={Global('descriptions.requiredFieldDescription')}
                   onChange={handleRadioChange}
-                />
+                >
+                  <div>
+                    <Radio value="yes">{Global('form.yesLabel')}</Radio>
+                  </div>
+
+                  <div>
+                    <Radio value="no">{Global('form.noLabel')}</Radio>
+                  </div>
+                </RadioGroupComponent>
 
 
                 <Button type="submit" onPress={() => setFormSubmitted(true)}>{Global('buttons.saveAndUpdate')}</Button>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -298,13 +298,12 @@ export interface CheckboxGroupProps {
   name?: string;
   checkboxGroupLabel?: string;
   checkboxGroupDescription?: string;
-  checkboxData: CheckboxInterface[];
   value?: string[];
   isInvalid?: boolean;
   errorMessage?: string;
   onChange?: ((value: string[]) => void),
   isRequired?: boolean;
-  ariaLabel?: string;
+  children: ReactNode; // allow any Checkboxes or JSX
 }
 
 export interface ProjectMemberErrorInterface {
@@ -482,119 +481,119 @@ export interface ProjectFundingInterface {
 }
 
 export interface Author {
-    firstInitial: string | null;
-    givenName: string | null;
-    middleInitial: string | null;
-    middleName: string | null;
-    surname: string | null;
-    full: string | null;
-    orcid: string | null;
+  firstInitial: string | null;
+  givenName: string | null;
+  middleInitial: string | null;
+  middleName: string | null;
+  surname: string | null;
+  full: string | null;
+  orcid: string | null;
 }
 
 export interface Institution {
-    ror: string | null;
-    name: string | null;
+  ror: string | null;
+  name: string | null;
 }
 
 export interface Funder {
-    ror: string | null;
-    name: string | null;
+  ror: string | null;
+  name: string | null;
 }
 
 export interface Source {
-    name: string;
-    url: string;
+  name: string;
+  url: string;
 }
 
 export interface Work {
-    doi: string;
-    type: WorkType;
-    title: string
-    publicationDate: Date | null;
-    containerTitle: string | null;
-    authors: Author[];
-    institutions: Institution[];
-    funders: Funder[];
-    awardIds: string[];
-    source: Source;
+  doi: string;
+  type: WorkType;
+  title: string
+  publicationDate: Date | null;
+  containerTitle: string | null;
+  authors: Author[];
+  institutions: Institution[];
+  funders: Funder[];
+  awardIds: string[];
+  source: Source;
 }
 
 export enum Status {
-    Pending = "pending",
-    Related = "related",
-    Discarded = "discarded",
+  Pending = "pending",
+  Related = "related",
+  Discarded = "discarded",
 }
 
 export enum Confidence {
-    All = "all",
-    High = "high",
-    Medium = "medium",
-    Low = "low",
+  All = "all",
+  High = "high",
+  Medium = "medium",
+  Low = "low",
 }
 
 export enum RelatedWorksSortBy {
-    ConfidenceHigh = "confidence-high",
-    ConfidenceLow = "confidence-low",
-    ReviewedNew = "reviewed-new",
-    ReviewedOld = "reviewed-old",
-    PublishedNew = "published-new",
-    PublishedOld = "published-old",
-    DateFoundNew = "date-found-new",
-    DateFoundOld = "date-found-old",
+  ConfidenceHigh = "confidence-high",
+  ConfidenceLow = "confidence-low",
+  ReviewedNew = "reviewed-new",
+  ReviewedOld = "reviewed-old",
+  PublishedNew = "published-new",
+  PublishedOld = "published-old",
+  DateFoundNew = "date-found-new",
+  DateFoundOld = "date-found-old",
 }
 
 export enum WorkType {
-    Article = "article",
-    AudioVisual = "audio-visual",
-    Book = "book",
-    BookChapter = "book-chapter",
-    Collection = "collection",
-    DataPaper = "data-paper",
-    Dataset = "dataset",
-    Dissertation = "dissertation",
-    Editorial = "editorial",
-    Erratum = "erratum",
-    Event = "event",
-    Grant = "grant",
-    Image = "image",
-    InteractiveResource = "interactive-resource",
-    Letter = "letter",
-    Libguides = "libguides",
-    Model = "model",
-    Other = "other",
-    Paratext = "paratext",
-    PeerReview = "peer-review",
-    PhysicalObject = "physical-object",
-    Preprint = "preprint",
-    ReferenceEntry = "reference-entry",
-    Report = "report",
-    Retraction = "retraction",
-    Review = "review",
-    Service = "service",
-    Software = "software",
-    Sound = "sound",
-    Standard = "standard",
-    SupplementaryMaterials = "supplementary-materials",
-    Text = "text",
-    Workflow = "workflow",
+  Article = "article",
+  AudioVisual = "audio-visual",
+  Book = "book",
+  BookChapter = "book-chapter",
+  Collection = "collection",
+  DataPaper = "data-paper",
+  Dataset = "dataset",
+  Dissertation = "dissertation",
+  Editorial = "editorial",
+  Erratum = "erratum",
+  Event = "event",
+  Grant = "grant",
+  Image = "image",
+  InteractiveResource = "interactive-resource",
+  Letter = "letter",
+  Libguides = "libguides",
+  Model = "model",
+  Other = "other",
+  Paratext = "paratext",
+  PeerReview = "peer-review",
+  PhysicalObject = "physical-object",
+  Preprint = "preprint",
+  ReferenceEntry = "reference-entry",
+  Report = "report",
+  Retraction = "retraction",
+  Review = "review",
+  Service = "service",
+  Software = "software",
+  Sound = "sound",
+  Standard = "standard",
+  SupplementaryMaterials = "supplementary-materials",
+  Text = "text",
+  Workflow = "workflow",
 }
 
 export interface Match {
-    doi: boolean;
-    title: string | null;
-    abstract: string[];
-    awardIds: number[];
-    authors: number[];
-    institutions: number[];
-    funders: number[];
+  doi: boolean;
+  title: string | null;
+  abstract: string[];
+  awardIds: number[];
+  authors: number[];
+  institutions: number[];
+  funders: number[];
 }
 
 export interface RelatedWork {
-    dmpDoi: string;
-    score: number;
-    work: Work;
-    dateFound: Date;
-    dateReviewed: null | Date;
-    status: Status;
-    match: Match;
+  dmpDoi: string;
+  score: number;
+  work: Work;
+  dateFound: Date;
+  dateReviewed: null | Date;
+  status: Status;
+  match: Match;
 }

--- a/components/Form/CheckboxGroup/index.tsx
+++ b/components/Form/CheckboxGroup/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  Checkbox,
   CheckboxGroup,
   FieldError,
   Label,
@@ -14,12 +13,11 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
   value,
   checkboxGroupLabel,
   checkboxGroupDescription,
-  checkboxData,
   isInvalid,
   errorMessage,
   onChange,
   isRequired = false,
-  ariaLabel
+  children
 }) => {
   return (
     <>
@@ -39,26 +37,7 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
             {checkboxGroupDescription}
           </Text>
         )}
-        {checkboxData.map((checkbox, index) => (
-          <div key={index}>
-            <Checkbox value={checkbox.value} aria-label={ariaLabel}>
-              <div className="checkbox">
-                <svg viewBox="0 0 18 18" aria-hidden="true">
-                  <polyline points="1 9 7 14 15 4" />
-                </svg>
-              </div>
-              <div className="">
-                <span>
-                  {checkbox.label}
-                </span>
-                <br />
-                <span className="help">
-                  {checkbox.description}
-                </span>
-              </div>
-            </Checkbox>
-          </div>
-        ))}
+        {children}
       </CheckboxGroup>
     </>
   );

--- a/components/Form/QuestionComponents/BooleanQuestionComponent/__tests__/index.spec.tsx
+++ b/components/Form/QuestionComponents/BooleanQuestionComponent/__tests__/index.spec.tsx
@@ -33,8 +33,8 @@ describe('RadioButtonsQuestionComponent', () => {
       />
     );
 
-    const yesRadio = screen.getByLabelText('Yes') as HTMLInputElement;
-    const noRadio = screen.getByLabelText('No') as HTMLInputElement;
+    const yesRadio = screen.getByLabelText('form.yesLabel') as HTMLInputElement;
+    const noRadio = screen.getByLabelText('form.noLabel') as HTMLInputElement;
 
     // Check that the radios exist
     expect(yesRadio).toBeInTheDocument();
@@ -58,7 +58,7 @@ describe('RadioButtonsQuestionComponent', () => {
       />
     );
 
-    const yesRadio = screen.getByLabelText('Yes') as HTMLInputElement;
+    const yesRadio = screen.getByLabelText('form.yesLabel') as HTMLInputElement;
     fireEvent.click(yesRadio);
     expect(mockHandleBooleanChange).toHaveBeenCalledWith('yes');
   });
@@ -82,7 +82,7 @@ describe('RadioButtonsQuestionComponent', () => {
       />
     );
 
-    const noRadio = screen.getByLabelText('No') as HTMLInputElement;
+    const noRadio = screen.getByLabelText('form.noLabel') as HTMLInputElement;
     // no option should be selected by default when no selectedValue is provided
     expect(noRadio.checked).toBe(true);
   });

--- a/components/Form/QuestionComponents/BooleanQuestionComponent/index.tsx
+++ b/components/Form/QuestionComponents/BooleanQuestionComponent/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { BooleanQuestionType } from '@dmptool/types';
+import { useTranslations } from 'next-intl';
 import { RadioGroupComponent } from '@/components/Form';
+import { Radio } from 'react-aria-components';
 
 interface BooleanQuestionProps {
   parsedQuestion: BooleanQuestionType;
@@ -13,30 +15,31 @@ const BooleanQuestionComponent: React.FC<BooleanQuestionProps> = ({
   selectedValue,
   handleRadioChange
 }) => {
-  // Prepare radioButton data for Yes/No
-  const radioButtonData = [
-    {
-      value: 'yes',
-      label: 'Yes'
-    },
-    {
-      value: 'no',
-      label: 'No'
-    },
-  ];
+  // Localization keys
+  const Global = useTranslations('Global');
+
   // Set checked value based on parsedQuestion.attributes.checked
   const initialChecked = parsedQuestion?.attributes?.checked ? 'yes' : 'no';
 
   const value = selectedValue ?? initialChecked;
 
   return (
+
     <RadioGroupComponent
       name="visibility"
       value={value}
       radioGroupLabel=""
-      radioButtonData={radioButtonData}
       onChange={handleRadioChange}
-    />
+    >
+      <div>
+        <Radio value="yes">{Global('form.yesLabel')}</Radio>
+      </div>
+
+      <div>
+        <Radio value="no">{Global('form.noLabel')}</Radio>
+      </div>
+
+    </RadioGroupComponent>
   );
 };
 

--- a/components/Form/QuestionComponents/CheckboxesQuestionComponent/index.tsx
+++ b/components/Form/QuestionComponents/CheckboxesQuestionComponent/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { CheckboxesQuestionType } from '@dmptool/types';
 import { CheckboxGroupComponent } from '@/components/Form';
+import { Checkbox } from "react-aria-components";
 
 interface CheckboxesQuestionProps {
   parsedQuestion: CheckboxesQuestionType;
@@ -29,8 +30,24 @@ const CheckboxesQuestionComponent: React.FC<CheckboxesQuestionProps> = ({
       onChange={handleCheckboxGroupChange}
       checkboxGroupLabel=""
       checkboxGroupDescription={""}
-      checkboxData={checkboxData}
-    />
+    >
+      {checkboxData.map((checkbox, index) => (
+        <div key={index}>
+          <Checkbox value={checkbox.value} aria-label="checkbox">
+            <div className="checkbox">
+              <svg viewBox="0 0 18 18" aria-hidden="true">
+                <polyline points="1 9 7 14 15 4" />
+              </svg>
+            </div>
+            <div className="">
+              <span>
+                {checkbox.label}
+              </span>
+            </div>
+          </Checkbox>
+        </div>
+      ))}
+    </CheckboxGroupComponent>
   );
 };
 

--- a/components/Form/QuestionComponents/RadioButtonsQuestionComponent/index.tsx
+++ b/components/Form/QuestionComponents/RadioButtonsQuestionComponent/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RadioButtonsQuestionType } from '@dmptool/types';
 import { RadioGroupComponent } from '@/components/Form';
-
+import { Radio } from 'react-aria-components';
 interface RadioButtonQuestionTypeProps {
   parsedQuestion: RadioButtonsQuestionType;
   selectedRadioValue: string | undefined;
@@ -26,13 +26,20 @@ const RadioButtonsQuestionComponent: React.FC<RadioButtonQuestionTypeProps> = ({
   const value = (selectedRadioValue === undefined || selectedRadioValue === '') ? initialValue : selectedRadioValue;
 
   return (
-    <RadioGroupComponent
-      name={name}
-      value={value ?? ''}
-      radioGroupLabel={radioGroupLabel}
-      radioButtonData={radioButtonData}
-      onChange={handleRadioChange}
-    />
+    <>
+      <RadioGroupComponent
+        name={name}
+        value={value ?? ''}
+        radioGroupLabel={radioGroupLabel}
+        onChange={handleRadioChange}
+      >
+        {radioButtonData.map((radioButton, index) => (
+          <div key={index}>
+            <Radio value={radioButton.value}>{radioButton.label}</Radio>
+          </div>
+        ))}
+      </RadioGroupComponent>
+    </>
   );
 };
 

--- a/components/Form/RadioGroup/index.tsx
+++ b/components/Form/RadioGroup/index.tsx
@@ -2,61 +2,52 @@ import React, { ReactNode } from 'react';
 import {
   FieldError,
   Label,
-  Radio,
   RadioGroup,
   Text,
 } from "react-aria-components";
-import classNames from 'classnames';
 
-import { RadioButtonProps } from '@/app/types';
-import styles from './radioGroup.module.scss';
+interface RadioGroupComponentProps {
+  name: string;
+  value: string;
+  classes?: string;
+  description?: ReactNode;
+  radioGroupLabel: string;
+  isInvalid?: boolean;
+  errorMessage?: string;
+  onChange: (value: string) => void;
+  children: ReactNode; // allow any Radio buttons or JSX
+}
 
-const RadioGroupComponent: React.FC<RadioButtonProps> = ({
+const RadioGroupComponent: React.FC<React.PropsWithChildren<RadioGroupComponentProps>> = ({
   name,
   value,
   classes,
   description,
   radioGroupLabel,
-  radioButtonData,
   isInvalid,
   errorMessage,
-  onChange
+  onChange,
+  children,
 }) => {
-
-  const renderDescription = (desc: string | ReactNode) => {
-    // If it's a string, just render it directly
-    // If it's a ReactNode, it will be rendered as JSX
-    return desc;
-  };
   return (
-    <>
-      <RadioGroup
-        name={name}
-        value={value}
-        className={classes}
-        onChange={onChange}
-        aria-label={radioGroupLabel || 'Radio Group'}
-      >
-        <Label>{radioGroupLabel}</Label>
+    <RadioGroup
+      name={name}
+      value={value}
+      className={classes}
+      onChange={onChange}
+      aria-label={radioGroupLabel || 'Radio Group'}
+    >
+      <Label>{radioGroupLabel}</Label>
+      {description && (
         <Text slot="description" className="help">
           {description}
         </Text>
-        {radioButtonData.map((radioButton, index) => (
-          <div key={index}>
-            <Radio value={radioButton.value}>{radioButton.label}</Radio>
-            {radioButton.description && (
-              <Text
-                slot="description"
-                className={classNames('help', styles.radioDescription)}
-              >
-                {renderDescription(radioButton.description)}
-              </Text>
-            )}
-          </div>
-        ))}
-        {isInvalid && <FieldError className='error-message'>{errorMessage}</FieldError>}
-      </RadioGroup>
-    </>
+      )}
+      {children}
+      {isInvalid && (
+        <FieldError className="error-message">{errorMessage}</FieldError>
+      )}
+    </RadioGroup>
   );
 };
 

--- a/components/Form/RadioGroup/radioGroup.module.scss
+++ b/components/Form/RadioGroup/radioGroup.module.scss
@@ -1,3 +1,0 @@
-.radioDescription {
-  margin-left: var(--space-6);
-}

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -14,6 +14,7 @@ import {
   Input,
   Label,
   Link,
+  Radio,
   Tab,
   TabList,
   TabPanel,
@@ -114,21 +115,6 @@ const QuestionAdd = ({
   // localization keys
   const Global = useTranslations('Global');
   const QuestionAdd = useTranslations('QuestionAdd');
-
-  const radioData = {
-    radioGroupLabel: Global('labels.requiredField'),
-    radioButtonData: [
-      {
-        value: 'yes',
-        label: Global('form.yesLabel'),
-      },
-      {
-        value: 'no',
-        label: Global('form.noLabel')
-      }
-    ]
-  }
-
 
   // Initialize add and update question mutations
   const [addQuestionMutation] = useAddQuestionMutation();
@@ -567,11 +553,18 @@ const QuestionAdd = ({
                 <RadioGroupComponent
                   name="radioGroup"
                   value={question?.required ? 'yes' : 'no'}
-                  radioGroupLabel={radioData.radioGroupLabel}
-                  radioButtonData={radioData.radioButtonData}
+                  radioGroupLabel={Global('labels.requiredField')}
                   description={Global('descriptions.requiredFieldDescription')}
                   onChange={handleRadioChange}
-                />
+                >
+                  <div>
+                    <Radio value="yes">{Global('form.yesLabel')}</Radio>
+                  </div>
+
+                  <div>
+                    <Radio value="no">{Global('form.noLabel')}</Radio>
+                  </div>
+                </RadioGroupComponent>
 
                 {/**We need to set formSubmitted here, so that it is passed down to the child component QuestionOptionsComponent */}
                 <Button type="submit" onPress={() => setFormSubmitted(true)}>{Global('buttons.saveAndAdd')}</Button>

--- a/components/QuestionView/__tests__/index.spec.tsx
+++ b/components/QuestionView/__tests__/index.spec.tsx
@@ -697,9 +697,10 @@ describe("QuestionView", () => {
         path="/template/123"
       />
     );
-    expect(screen.getByTestId('card-body').textContent).toContain('Yes');
-    expect(screen.getByTestId('card-body').textContent).toContain('No');
-    expect(screen.getByRole('radio', { name: 'No' })).toBeChecked();
+
+    expect(screen.getByTestId('card-body').textContent).toContain('form.yesLabel');
+    expect(screen.getByTestId('card-body').textContent).toContain('form.noLabel');
+    expect(screen.getByRole('radio', { name: 'form.noLabel' })).toBeChecked();
 
     const radioButtons = screen.getByTestId('card-body').querySelectorAll('input[type="radio"]');
     act(() => {

--- a/components/Toast/index.tsx
+++ b/components/Toast/index.tsx
@@ -25,21 +25,18 @@ const Toast: React.FC<ToastProps> = ({ toast, state }) => {
 
 
   // Only pass `toast` to `useAriaToast`
-  const { toastProps, contentProps, titleProps, closeButtonProps } = useAriaToast(
-    { toast },
-    state,
-    ref
-  );
+  const { closeButtonProps } = useAriaToast({ toast }, state, ref);
 
   return (
     <div
-      {...toastProps}
+      role={toast.type === 'error' ? 'alert' : 'status'}
+      aria-live={toast.type === 'error' ? 'assertive' : 'polite'}
+      aria-atomic="true"
+      data-testid="toast"
       ref={ref}
       className={`toast toast-${toast.type ? toast.type : 'info'}`}
     >
-      <div {...contentProps}>
-        <div {...titleProps}>{toast.content}</div>
-      </div>
+      <div>{toast.content}</div>
       <Button {...closeButtonProps} aria-label="Close toast">
         ×
       </Button>

--- a/hooks/projectMemberData.tsx
+++ b/hooks/projectMemberData.tsx
@@ -21,7 +21,8 @@ export const useProjectMemberData = (projectMemberId: number) => {
   const { data, loading, error: queryError } = useProjectMemberQuery({
     variables: {
       projectMemberId: Number(projectMemberId)
-    }
+    },
+    fetchPolicy: 'network-only', // Always fetch fresh data
   })
 
   useEffect(() => {

--- a/messages/en-US/planBuilderProjectOverview.json
+++ b/messages/en-US/planBuilderProjectOverview.json
@@ -76,6 +76,7 @@
   },
   "ProjectsCreateProject": {
     "pageTitle": "Create a new project",
+    "isThisMockProject": "Is this a mock project?",
     "form": {
       "projectTitle": "What is the title for the project? (required)",
       "projectTitleHelpText": "You can change this at any time. If you already applied for funding, we recommend using the formal project title for consistency.",

--- a/messages/pt-BR/planBuilderProjectOverview.json
+++ b/messages/pt-BR/planBuilderProjectOverview.json
@@ -76,6 +76,7 @@
   },
   "ProjectsCreateProject": {
     "pageTitle": "Criar um novo blog",
+    "isThisMockProject": "Este é um projeto simulado",
     "form": {
       "projectTitle": "Qual é o título do projeto? (obrigatório)",
       "projectTitleHelpText": "Você pode alterar isso a qualquer momento. Se você já solicitou financiamento, recomendamos usar o título formal do projeto para manter a consistência.",

--- a/styles/form/_radio.scss
+++ b/styles/form/_radio.scss
@@ -58,3 +58,10 @@
     outline-offset: 2px;
   }
 }
+
+.react-aria-RadioGroup .react-aria-Radio + .react-aria-Text[slot="description"] {
+  margin: 0 0 var(--space-3) var(--space-6);
+  font-size: 1rem;
+  color: var(--slate-600);
+  display: block;
+}


### PR DESCRIPTION
## Description

Updated the shared `RadioGroupComponent` and `CheckboxGroupComponent` components to be more like a wrapper to reduce duplication of code and make them a little easier to use and more flexible

Fixes # ([743](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/743))

## Type of change
Please delete options that are not relevant
- [X] Chore

## How Has This Been Tested?
Manually tested pages


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshots of some of the pages using the updated components:

<img width="681" height="869" alt="image" src="https://github.com/user-attachments/assets/9438e3be-8019-4df0-ade4-0873d6fce3f7" />

<img width="797" height="659" alt="image" src="https://github.com/user-attachments/assets/450b4d12-cf78-4147-aa02-69a62a24f748" />

<img width="688" height="810" alt="image" src="https://github.com/user-attachments/assets/1ea36b5c-6713-4065-bbda-237472941d45" />

<img width="812" height="595" alt="image" src="https://github.com/user-attachments/assets/dfd92c2b-3f0a-4ede-85b7-21d2d4c4661e" />

<img width="634" height="870" alt="image" src="https://github.com/user-attachments/assets/8dc25f84-1d3a-4c17-9a2f-064211c3baa6" />

<img width="902" height="700" alt="image" src="https://github.com/user-attachments/assets/304ce32d-9044-40c6-9e9a-a98fd4048fbe" />

<img width="716" height="775" alt="image" src="https://github.com/user-attachments/assets/f91704fe-25c0-4cc8-bc4d-32ff005cf35d" />

<img width="621" height="649" alt="image" src="https://github.com/user-attachments/assets/a806ad23-79c9-4edd-9a67-41b23b3b51b7" />
