### PR TITLE
Updates related to commenting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Added missing `planId` from the `PlanFundings` errors [#322](https://github.com/CDLUC3/dmsp_backend_prototype/issues/322)
 
 ### Updated
+- Updated `Commenting` logic on the `PlanOverviewQuestionPage` so that the `creator` or anybody with `role="OWN"` can delete anybody's comments [#321]
+- Updated to show disabled `Comment` button with a tooltip message when there is no `answer` yet. [#321]
 - Updated the shared`RadioGroupComponent` and `CheckboxGroupComponent` components to be more like a wrapper to reduce duplicate of code and make it more flexible [#743]
 - Project over is now using sidebar to allow for collaboration [#750]
 - Sidebar is now using global styling rather than css modules [#750]

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentList.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentList.tsx
@@ -17,6 +17,7 @@ interface CommentListProps {
   editingCommentId: number | null | undefined;
   editingCommentText: string;
   me: MeQuery | null | undefined;
+  planOwners: number[] | null | undefined;
   handleEditComment: (comment: MergedComment) => void;
   handleUpdateComment: (comment: MergedComment) => void;
   handleCancelEdit: () => void;
@@ -31,6 +32,7 @@ const CommentList = React.memo(function CommentList(props: CommentListProps) {
     editingCommentId,
     editingCommentText,
     me,
+    planOwners,
     handleEditComment,
     handleUpdateComment,
     handleCancelEdit,
@@ -136,8 +138,9 @@ const CommentList = React.memo(function CommentList(props: CommentListProps) {
                     </Button>
                   )}
 
-                  {/**Only display the delete button for the user who created the comment*/}
-                  {(comment?.user?.id === me?.me?.id) && (
+                  {/**Only display the delete button for the user who created the comment 
+                   * or a project collaborator with role 'OWN' */}
+                  {((comment?.user?.id === me?.me?.id) || planOwners?.includes(me?.me?.id as number)) && (
                     <Button
                       className={`${styles.deEmphasize} link`}
                       type="button"

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/Comments.md
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/Comments.md
@@ -16,6 +16,10 @@ The Comments Drawer code was placed into its own `CommentsDrawer` component for 
 ## Comments hook
 All comments handlers and associated states were consolidated into one hook at `hooks/useComment.tsx`.
 
+## Comment button
+The comment button will be disabled when there is not yet an `answer` for the question, and a `tooltip` message will display on hover saying:
+> You need to save an answer before users can comment.
+
 ## Adding comments
 
 ### ADMIN and SUPERADMIN
@@ -31,4 +35,4 @@ If the user is a `project collaborator` they can also add comments.
 Only the user who added the comment can edit their own comment. An `edit` link will display under the user's comment, allowing them to edit it.
 
 ## Deleting comments
-The creator of the plan can `delete` any comments. Users who added the comments can delete their own.
+The creator of the plan can `delete` any comments. Users who added the comments can delete their own. User's with `role="OWN"` can also delete comments.

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentsDrawer.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/CommentsDrawer.tsx
@@ -32,6 +32,7 @@ export interface CommentsDrawerProps {
   handleEditComment: (comment: MergedComment) => void;
   handleDeleteComment: (comment: MergedComment) => void;
   me: MeQuery | null | undefined;
+  planOwners: number[] | undefined | null;
   locale: string;
   commentsEndRef: React.RefObject<HTMLDivElement>;
   canAddComments: boolean;
@@ -52,6 +53,7 @@ const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
   handleEditComment,
   handleDeleteComment,
   me,
+  planOwners,
   locale,
   commentsEndRef,
   canAddComments,
@@ -96,6 +98,7 @@ const CommentsDrawer: React.FC<CommentsDrawerProps> = ({
             editingCommentId={editingCommentId}
             editingCommentText={editingCommentText}
             me={me}
+            planOwners={planOwners}
             handleEditComment={handleEditComment}
             handleUpdateComment={handleUpdateComment}
             handleCancelEdit={handleCancelEdit}

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/PlanOverviewQuestionPage.module.scss
@@ -73,6 +73,12 @@
   font-size: 0.75rem;
 }
 
+.buttonSmallDisabled {
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.5; // visually indicate disabled state because tooltip does not work with disabled button
+}
+
   /* We want buttons to be side by side on larger screens
   but stack on top of each other on mobile*/
   .modalAction {
@@ -240,4 +246,10 @@
   align-items: center;
 }
 
+.tooltip {
+  background-color: var(--gray-500);
+  color: var(--gray-50);
+  border-radius: 0.375rem;
+  font-size: var(--fs-small);
+}
 /* End Comments Drawer Styles */

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentsDrawer.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/CommentsDrawer.spec.tsx
@@ -115,6 +115,7 @@ describe("CommentsDrawer", () => {
     handleEditComment: jest.fn(),
     handleDeleteComment: jest.fn(),
     me: createMockMeQuery(),
+    planOwners: [1, 2, 3],
     locale: "en",
     commentsEndRef: { current: null },
     canAddComments: true,

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/__tests__/page.spec.tsx
@@ -303,6 +303,32 @@ describe('PlanOverviewQuestionPage render of questions', () => {
     expect(bestPracticeDataVolume).toBeInTheDocument();
   })
 
+  it('should display disabled comment button when an answer does not exist for the question', async () => {
+
+    (usePublishedQuestionQuery as jest.Mock).mockReturnValue({
+      data: mockQuestionDataForTextArea,
+      loading: false,
+      error: undefined,
+    });
+
+    (useAnswerByVersionedQuestionIdQuery as jest.Mock).mockReturnValue({
+      data: null,
+      loading: false,
+      error: undefined,
+    });
+
+    await act(async () => {
+      render(
+        <PlanOverviewQuestionPage />
+      );
+    });
+
+    // check for comment button
+    const commentButton = screen.getByRole('button', { name: 'buttons.commentWithNumber' });
+    expect(commentButton).toBeInTheDocument();
+    expect(commentButton).toHaveClass('buttonSmallDisabled');
+  })
+
   it('should load sampleText in textArea if useSampleTextAsDefault is true and sampleText exists in question', async () => {
 
     (usePublishedQuestionQuery as jest.Mock).mockReturnValue({

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/useComments.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/hooks/useComments.tsx
@@ -28,6 +28,7 @@ export interface AnswerComment {
   commentText: string;
   answerId: number;
   created?: string | null;
+  createdById?: number | null;
   modified?: string | null;
   user?: {
     __typename?: "User";
@@ -42,6 +43,7 @@ export interface FeedbackComment {
   id?: number | null;
   commentText?: string | null;
   created?: string | null;
+  createdById?: number | null;
   answerId?: number | null;
   modified?: string | null;
   PlanFeedback?: {
@@ -227,6 +229,7 @@ export const useComments = ({
         commentText: newComment,
         answerId,
         created: new Date().getTime().toString(),
+        createdById: me?.me?.id,
         modified: new Date().getTime().toString(),
         type: 'feedback',
         isAnswerComment: false,
@@ -246,6 +249,7 @@ export const useComments = ({
         commentText: newComment,
         answerId,
         created: new Date().getTime().toString(),
+        createdById: me?.me?.id,
         modified: new Date().getTime().toString(),
         type: 'answer',
         isAnswerComment: true,

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
@@ -13,6 +13,8 @@ import {
   Link,
   OverlayArrow,
   Popover,
+  Tooltip,
+  TooltipTrigger
 } from "react-aria-components";
 import { CalendarDate, DateValue } from "@internationalized/date";
 import DOMPurify from 'dompurify';
@@ -1213,15 +1215,30 @@ const PlanOverviewQuestionPage: React.FC = () => {
                       </Button>
                     )}
 
-                    {/**Only show comments if an answer has been saved so far */}
-                    {answerId && (
+                    {/**Only show active comment button if an answer exists, otherwise show a disabled button with message */}
+                    {answerId ? (
                       <Button
                         ref={openCommentsButtonRef}
-                        className={`${styles.buttonSmall} ${mergedComments.length > 0 ? styles.buttonWithComments : null}`}
+                        className={styles.buttonSmall}
                         onPress={toggleCommentsDrawer}
                       >
                         {t('buttons.commentWithNumber', { number: mergedComments.length })}
                       </Button>
+                    ) : (
+                      <TooltipTrigger delay={0}>
+                        <Button
+                          ref={openCommentsButtonRef}
+                          className={styles.buttonSmallDisabled}
+                        >
+                          {t('buttons.commentWithNumber', { number: mergedComments.length })}
+                        </Button>
+                        <Tooltip
+                          placement="bottom"
+                          className={`${styles.tooltip} py-2 px-2`}
+                        >
+                          {PlanOverview('page.commentTooltip')}
+                        </Tooltip>
+                      </TooltipTrigger>
                     )}
 
                   </div>
@@ -1386,6 +1403,7 @@ const PlanOverviewQuestionPage: React.FC = () => {
           handleEditComment={handleEditComment}
           handleDeleteComment={handleDeleteComment}
           me={me}
+          planOwners={plan?.planOwners}
           locale={locale}
           commentsEndRef={commentsEndRef}
           canAddComments={canAddComments}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -454,6 +454,7 @@ export interface MergedComment {
   commentText?: string | null;
   answerId?: number | null;
   created?: string | null;
+  createdById?: number | null;
   type: 'answer' | 'feedback';
   isAnswerComment: boolean;
   isFeedbackComment: boolean;

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -3074,7 +3074,7 @@ export type Template = {
   latestPublishDate?: Maybe<Scalars['String']['output']>;
   /** The last published version */
   latestPublishVersion?: Maybe<Scalars['String']['output']>;
-  /** The last published visibility */
+  /** Visibility set for the last published template */
   latestPublishVisibility?: Maybe<TemplateVisibility>;
   /** The timestamp when the Object was last modifed */
   modified?: Maybe<Scalars['String']['output']>;
@@ -3163,7 +3163,7 @@ export type TemplateSearchResult = {
   latestPublishDate?: Maybe<Scalars['String']['output']>;
   /** The last published version */
   latestPublishVersion?: Maybe<Scalars['String']['output']>;
-  /** The last published visibility */
+  /** Visibility set for the last published template */
   latestPublishVisibility?: Maybe<TemplateVisibility>;
   /** The timestamp when the Template was last modified */
   modified?: Maybe<Scalars['String']['output']>;
@@ -4247,7 +4247,7 @@ export type AnswerByVersionedQuestionIdQueryVariables = Exact<{
 }>;
 
 
-export type AnswerByVersionedQuestionIdQuery = { __typename?: 'Query', answerByVersionedQuestionId?: { __typename?: 'Answer', id?: number | null, json?: string | null, modified?: string | null, created?: string | null, versionedQuestion?: { __typename?: 'VersionedQuestion', id?: number | null } | null, plan?: { __typename?: 'Plan', id?: number | null } | null, comments?: Array<{ __typename?: 'AnswerComment', id?: number | null, commentText: string, answerId: number, created?: string | null, modified?: string | null, user?: { __typename?: 'User', id?: number | null, surName?: string | null, givenName?: string | null } | null }> | null, feedbackComments?: Array<{ __typename?: 'PlanFeedbackComment', id?: number | null, commentText?: string | null, created?: string | null, answerId?: number | null, modified?: string | null, PlanFeedback?: { __typename?: 'PlanFeedback', id?: number | null } | null, user?: { __typename?: 'User', id?: number | null, surName?: string | null, givenName?: string | null } | null }> | null, errors?: { __typename?: 'AffiliationErrors', general?: string | null, planId?: string | null, versionedSectionId?: string | null, versionedQuestionId?: string | null, json?: string | null } | null } | null };
+export type AnswerByVersionedQuestionIdQuery = { __typename?: 'Query', answerByVersionedQuestionId?: { __typename?: 'Answer', id?: number | null, json?: string | null, modified?: string | null, created?: string | null, versionedQuestion?: { __typename?: 'VersionedQuestion', id?: number | null } | null, plan?: { __typename?: 'Plan', id?: number | null } | null, comments?: Array<{ __typename?: 'AnswerComment', id?: number | null, commentText: string, answerId: number, created?: string | null, createdById?: number | null, modified?: string | null, user?: { __typename?: 'User', id?: number | null, surName?: string | null, givenName?: string | null } | null }> | null, feedbackComments?: Array<{ __typename?: 'PlanFeedbackComment', id?: number | null, commentText?: string | null, created?: string | null, createdById?: number | null, answerId?: number | null, modified?: string | null, PlanFeedback?: { __typename?: 'PlanFeedback', id?: number | null } | null, user?: { __typename?: 'User', id?: number | null, surName?: string | null, givenName?: string | null } | null }> | null, errors?: { __typename?: 'AffiliationErrors', general?: string | null, planId?: string | null, versionedSectionId?: string | null, versionedQuestionId?: string | null, json?: string | null } | null } | null };
 
 export type ProjectFundingsQueryVariables = Exact<{
   projectId: Scalars['Int']['input'];
@@ -6470,6 +6470,7 @@ export const AnswerByVersionedQuestionIdDocument = gql`
       commentText
       answerId
       created
+      createdById
       modified
       user {
         id
@@ -6481,6 +6482,7 @@ export const AnswerByVersionedQuestionIdDocument = gql`
       id
       commentText
       created
+      createdById
       answerId
       modified
       PlanFeedback {

--- a/graphql/queries/answer.query.graphql
+++ b/graphql/queries/answer.query.graphql
@@ -13,6 +13,7 @@ query AnswerByVersionedQuestionId($projectId: Int!, $planId: Int!, $versionedQue
       commentText
       answerId
       created
+      createdById
       modified
       user {
         id
@@ -24,6 +25,7 @@ query AnswerByVersionedQuestionId($projectId: Int!, $planId: Int!, $versionedQue
       id
       commentText
       created
+      createdById
       answerId
       modified
       PlanFeedback {

--- a/messages/en-US/planBuilderPlanOverview.json
+++ b/messages/en-US/planBuilderPlanOverview.json
@@ -26,6 +26,7 @@
       "requiredByFunderInfo": "The funder has marked this as a required question on their template. You can leave it blank in the tool but should complete it before submitting your grant.",
       "jumpToGuidance": "Jump to additional guidance",
       "viewSampleAnswer": "View sample answer",
+      "commentTooltip": "You need to save an answer before users can comment.",
       "guidanceBy": "Guidance by {funder}",
       "funderSampleText": "{funder} sample text",
       "participantsWillBeNotified": "Participants will be notified once submitted.",

--- a/messages/pt-BR/planBuilderPlanOverview.json
+++ b/messages/pt-BR/planBuilderPlanOverview.json
@@ -26,6 +26,7 @@
       "requiredByFunderInfo": "O financiador marcou isso como uma pergunta necessária no seu modelo. Você pode deixá-lo em branco na ferramenta, mas deve completá-lo antes de enviar sua subvenção.",
       "jumpToGuidance": "Pule para orientação adicional",
       "viewSampleAnswer": "Ver amostra da resposta",
+      "commentTooltip": "Você precisa salvar uma resposta antes que os usuários possam comentar.",
       "guidanceBy": "Guia por {funder}",
       "funderSampleText": "{funder} texto de exemplo",
       "participantsWillBeNotified": "Os participantes serão notificados assim que submetidos.",


### PR DESCRIPTION
## Description

- Updated `Commenting` logic on the `PlanOverviewQuestionPage` so that the `creator` or anybody with `role="OWN"` can delete anybody's comments
- Updated to show disabled `Comment` button with a tooltip message when there is no `answer` yet. 

Fixes # ([321](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/321))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually tested and tested with unit test.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules
* Note: There is a backend change that is needed for this to work: https://github.com/CDLUC3/dmsp_backend_prototype/issues/243

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
