### PR TITLE
(#761) Added description text to project search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added the ability to edit the `Plan title` [#608]
 - Added the page for adding a funder manually [#497]
 - Added missing `planId` from the `PlanFundings` errors [#322](https://github.com/CDLUC3/dmsp_backend_prototype/issues/322)
+- Added description to project search page [#761](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/761)
 
 ### Updated
 - Updated the shared`RadioGroupComponent` and `CheckboxGroupComponent` components to be more like a wrapper to reduce duplicate of code and make it more flexible [#743]

--- a/app/[locale]/projects/[projectId]/projects-search/page.tsx
+++ b/app/[locale]/projects/[projectId]/projects-search/page.tsx
@@ -109,7 +109,7 @@ const ProjectsCreateProjectProjectSearch = () => {
     <>
       <PageHeader
         title="Search for Projects"
-        description=""
+        description="Enter details of your project to help find it in this funder's database. The more you enter the more likely it is to find your project."
         showBackButton={true}
         breadcrumbs={
           <Breadcrumbs>


### PR DESCRIPTION
## Description

Added description text to the Project Search page.

Fixes [#761](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/761)

## Type of change

- [X] Chore

## How Has This Been Tested?
- Manually loaded the page and checked that the new static text is displayed.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I updated the CHANGELOG.md and added documentation if necessary
