### PR TITLE
Add bash to AWS Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added bash to the AWS Dockerfile for session manager access
 - Added shared `dmptool-network` to the `docker-compose.yaml` file to allow nextJS server side actions to be able to reach the local apollo server
 - Static Feedback page with translation and text [#750]
 - Added `RelatedWorks` page and associated components `RelatedWorksList`, `RelatedWorksListItem`, `ExpandableNameList` and `LinkFilter`. [#672][#673]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -33,6 +33,9 @@ RUN npm run build
 FROM public.ecr.aws/docker/library/node:22.1.0-alpine3.19 as runner
 WORKDIR /app
 
+# Install bash so we can use session manager to attach to the container
+RUN apk add --no-cache bash
+
 # Set production environment
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV NODE_ENV=production


### PR DESCRIPTION
Tried to use session manager to access one of the running containers and could not because bash is not available. Adding it here