### PR TITLE
Added curl to the Dockerfile to help with container health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added curl to the AWS Dockerfile for session manager access
 - Added bash to the AWS Dockerfile for session manager access
 - Added shared `dmptool-network` to the `docker-compose.yaml` file to allow nextJS server side actions to be able to reach the local apollo server
 - Static Feedback page with translation and text [#750]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,6 +9,10 @@ RUN mkdir -p /app
 # Set /app as the working directory in container
 WORKDIR /app
 
+# Install bash and curl so we can use session manager to attach to the container
+# and perform container health checks
+RUN apk add --no-cache bash curl
+
 # Copy package.json and package-lock.json
 # to the /app working directory
 COPY package.json ./

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -34,7 +34,8 @@ FROM public.ecr.aws/docker/library/node:22.1.0-alpine3.19 as runner
 WORKDIR /app
 
 # Install bash so we can use session manager to attach to the container
-RUN apk add --no-cache bash
+# and perform container health checks
+RUN apk add --no-cache bash curl
 
 # Set production environment
 ENV NEXT_TELEMETRY_DISABLED 1


### PR DESCRIPTION
Setting up container health checks for all the services. Installing curl so we can do `curl http://localhost:3000/en-US/healthcheck`. 