### PR TITLE
Updates to logging to support OpenSearch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,9 @@ NEXT_PUBLIC_BASE_URL="http://localhost:3000"
 NEXT_PUBLIC_SERVER_ENDPOINT="http://localhost:4000"
 NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT="http://localhost:4000/graphql"
 
+# NextJS server side actions
 SERVER_ENDPOINT="http://localhost:4000"
+SERVER_LOG_LEVEL=info
 
 NEXT_PUBLIC_GRAPHQL_ENDPOINT="http://localhost:4000"
 NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT="http://localhost:4000/graphql"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ### Added
+- Added `redact` to the pino logger to prevent sensitive information from being logged
+- Added `utils/server/loggerUtils.ts` with a method to `prepareLogObject` that strips out empty values and adds available JWT info to the log to assist with debugging
+- Added `SERVER_LOG_LEVEL` to the `.env.example` file to be able to set the log level for server side actions
 - `small` button CSS class.
 - Added curl to the AWS Dockerfile for session manager access
 - Added bash to the AWS Dockerfile for session manager access
@@ -21,6 +24,8 @@
 - Added description to project search page [#761](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/761)
 
 ### Updated
+- Updated all server actions to use the new `logger` and `prepareLogObject` method to log useful information for debugging
+- Updated `logger` to use the new `SERVER_LOG_LEVEL` env variable
 - Updated language used in RelatedWorks UI, moved accept and reject buttons into the cards out of the expand section and changed order of accept and reject buttons [#799]
 - Hooked up the `ProjectsProjectCollaboration` page. Added new `server actions` to handle access level changes, revoking collaborator and resending invite [#381]
 - Optimized the `graphqlServerActionHandler` so that we can normalize errors returned and simplify client-side handling [#381]

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ These variables must be set in order for the app to work.
 * `NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT` - Graphql server schema endpoint (e.g., "http://localhost:4000/graphql")
 * `JWT_SECRET` - Secret key for JWT authentication
 * `SERVER_ENDPOINT` - Server endpoint for backend Apollo server, used for server-side code (e.g., "http://localhost:4000")
-
+* `SERVER_LOG_LEVEL` - The log level for the server (e.g., "info", "debug", "error")
 
 ### Running the App
 ```bash

--- a/app/[locale]/projects/[projectId]/collaboration/actions/removeProjectCollaboratorAction.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/actions/removeProjectCollaboratorAction.ts
@@ -11,18 +11,10 @@ export async function removeProjectCollaboratorAction({
 }: {
   projectCollaboratorId: number;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: RemoveProjectCollaboratorDocument,
-      variables: { projectCollaboratorId },
-      dataPath: "removeProjectCollaborator"
-    });
-  } catch (error) {
-    logger.error(
-        await prepareObjectForLogs({ error, projectCollaboratorId }),
-        "Remove project collaborator error"
-    );
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: RemoveProjectCollaboratorDocument,
+    variables: { projectCollaboratorId },
+    dataPath: "removeProjectCollaborator"
+  });
 }

--- a/app/[locale]/projects/[projectId]/collaboration/actions/removeProjectCollaboratorAction.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/actions/removeProjectCollaboratorAction.ts
@@ -3,16 +3,26 @@
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
 import { ActionResponse } from "@/app/types";
 import { RemoveProjectCollaboratorDocument } from "@/generated/graphql";
+import logger from "@/utils/server/logger";
+import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 
 export async function removeProjectCollaboratorAction({
   projectCollaboratorId,
 }: {
   projectCollaboratorId: number;
 }): Promise<ActionResponse> {
-  // Execute the mutation using the shared handler
-  return await executeGraphQLMutation({
-    document: RemoveProjectCollaboratorDocument,
-    variables: { projectCollaboratorId },
-    dataPath: "removeProjectCollaborator"
-  });
+  try {
+    // Execute the mutation using the shared handler
+    return await executeGraphQLMutation({
+      document: RemoveProjectCollaboratorDocument,
+      variables: { projectCollaboratorId },
+      dataPath: "removeProjectCollaborator"
+    });
+  } catch (error) {
+    logger.error(
+        await prepareObjectForLogs({ error, projectCollaboratorId }),
+        "Remove project collaborator error"
+    );
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
 }

--- a/app/[locale]/projects/[projectId]/collaboration/actions/removeProjectCollaboratorAction.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/actions/removeProjectCollaboratorAction.ts
@@ -3,8 +3,6 @@
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
 import { ActionResponse } from "@/app/types";
 import { RemoveProjectCollaboratorDocument } from "@/generated/graphql";
-import logger from "@/utils/server/logger";
-import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 
 export async function removeProjectCollaboratorAction({
   projectCollaboratorId,

--- a/app/[locale]/projects/[projectId]/collaboration/actions/resendInviteToProjectCollaborator.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/actions/resendInviteToProjectCollaborator.ts
@@ -3,16 +3,26 @@
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
 import { ActionResponse } from "@/app/types";
 import { ResendInviteToProjectCollaboratorDocument } from "@/generated/graphql";
+import logger from "@/utils/server/logger";
+import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 
 export async function resendInviteToProjectCollaboratorAction({
   projectCollaboratorId,
 }: {
   projectCollaboratorId: number;
 }): Promise<ActionResponse> {
-  // Execute the mutation using the shared handler
-  return await executeGraphQLMutation({
-    document: ResendInviteToProjectCollaboratorDocument,
-    variables: { projectCollaboratorId },
-    dataPath: "resendInviteToProjectCollaborator"
-  });
+  try {
+    // Execute the mutation using the shared handler
+    return await executeGraphQLMutation({
+      document: ResendInviteToProjectCollaboratorDocument,
+      variables: { projectCollaboratorId },
+      dataPath: "resendInviteToProjectCollaborator"
+    });
+  } catch (error) {
+    logger.error(
+        await prepareObjectForLogs({ error, projectCollaboratorId }),
+        "Resend project collaborator invitation error"
+    );
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
 }

--- a/app/[locale]/projects/[projectId]/collaboration/actions/resendInviteToProjectCollaborator.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/actions/resendInviteToProjectCollaborator.ts
@@ -11,18 +11,10 @@ export async function resendInviteToProjectCollaboratorAction({
 }: {
   projectCollaboratorId: number;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: ResendInviteToProjectCollaboratorDocument,
-      variables: { projectCollaboratorId },
-      dataPath: "resendInviteToProjectCollaborator"
-    });
-  } catch (error) {
-    logger.error(
-        await prepareObjectForLogs({ error, projectCollaboratorId }),
-        "Resend project collaborator invitation error"
-    );
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: ResendInviteToProjectCollaboratorDocument,
+    variables: { projectCollaboratorId },
+    dataPath: "resendInviteToProjectCollaborator"
+  });
 }

--- a/app/[locale]/projects/[projectId]/collaboration/actions/resendInviteToProjectCollaborator.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/actions/resendInviteToProjectCollaborator.ts
@@ -3,8 +3,6 @@
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
 import { ActionResponse } from "@/app/types";
 import { ResendInviteToProjectCollaboratorDocument } from "@/generated/graphql";
-import logger from "@/utils/server/logger";
-import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 
 export async function resendInviteToProjectCollaboratorAction({
   projectCollaboratorId,

--- a/app/[locale]/projects/[projectId]/collaboration/actions/updateProjectCollaboratorAction.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/actions/updateProjectCollaboratorAction.ts
@@ -3,6 +3,8 @@
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
 import { ActionResponse } from "@/app/types";
 import { UpdateProjectCollaboratorDocument } from "@/generated/graphql";
+import logger from "@/utils/server/logger";
+import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 
 export async function updateProjectCollaboratorAction({
   projectCollaboratorId,
@@ -11,12 +13,18 @@ export async function updateProjectCollaboratorAction({
   projectCollaboratorId: number;
   accessLevel: string;
 }): Promise<ActionResponse> {
-
-  // Execute the mutation using the shared handler
-  return await executeGraphQLMutation({
-    document: UpdateProjectCollaboratorDocument,
-    variables: { projectCollaboratorId, accessLevel },
-    dataPath: "updateProjectCollaborator"
-  });
-
+  try {
+    // Execute the mutation using the shared handler
+    return await executeGraphQLMutation({
+      document: UpdateProjectCollaboratorDocument,
+      variables: { projectCollaboratorId, accessLevel },
+      dataPath: "updateProjectCollaborator"
+    });
+  } catch (error) {
+    logger.error(
+        await prepareObjectForLogs({ error, projectCollaboratorId, accessLevel }),
+        "Update project collaborator error"
+    );
+    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
+  }
 }

--- a/app/[locale]/projects/[projectId]/collaboration/actions/updateProjectCollaboratorAction.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/actions/updateProjectCollaboratorAction.ts
@@ -13,18 +13,10 @@ export async function updateProjectCollaboratorAction({
   projectCollaboratorId: number;
   accessLevel: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: UpdateProjectCollaboratorDocument,
-      variables: { projectCollaboratorId, accessLevel },
-      dataPath: "updateProjectCollaborator"
-    });
-  } catch (error) {
-    logger.error(
-        await prepareObjectForLogs({ error, projectCollaboratorId, accessLevel }),
-        "Update project collaborator error"
-    );
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: UpdateProjectCollaboratorDocument,
+    variables: { projectCollaboratorId, accessLevel },
+    dataPath: "updateProjectCollaborator"
+  });
 }

--- a/app/[locale]/projects/[projectId]/collaboration/actions/updateProjectCollaboratorAction.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/actions/updateProjectCollaboratorAction.ts
@@ -3,8 +3,6 @@
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
 import { ActionResponse } from "@/app/types";
 import { UpdateProjectCollaboratorDocument } from "@/generated/graphql";
-import logger from "@/utils/server/logger";
-import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 
 export async function updateProjectCollaboratorAction({
   projectCollaboratorId,

--- a/app/[locale]/projects/[projectId]/collaboration/invite/actions/addCollaboratorAction.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/invite/actions/addCollaboratorAction.ts
@@ -2,6 +2,7 @@
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
 import logger from "@/utils/server/logger";
+import { prepareObjectForLogs } from '@/utils/server/loggerUtils';
 import { CollaboratorResponse } from "@/app/types";
 import { AddProjectCollaboratorDocument } from "@/generated/graphql";
 
@@ -23,7 +24,10 @@ export async function addProjectCollaboratorAction({
     });
 
   } catch (error) {
-    logger.error({ error }, `[Add Project Collaborator Error]: ${error}`);
+    logger.error(
+      await prepareObjectForLogs({ error, projectId, email, accessLevel }),
+      "Add project collaborator error"
+    );
     return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
   }
 }

--- a/app/[locale]/projects/[projectId]/collaboration/invite/actions/addCollaboratorAction.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/invite/actions/addCollaboratorAction.ts
@@ -1,8 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
-import { prepareObjectForLogs } from '@/utils/server/loggerUtils';
 import { CollaboratorResponse } from "@/app/types";
 import { AddProjectCollaboratorDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/collaboration/invite/actions/addCollaboratorAction.ts
+++ b/app/[locale]/projects/[projectId]/collaboration/invite/actions/addCollaboratorAction.ts
@@ -15,19 +15,10 @@ export async function addProjectCollaboratorAction({
   email: string;
   accessLevel: string;
 }): Promise<CollaboratorResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: AddProjectCollaboratorDocument,
-      variables: { projectId, email, accessLevel },
-      dataPath: "addProjectCollaborator"
-    });
-
-  } catch (error) {
-    logger.error(
-      await prepareObjectForLogs({ error, projectId, email, accessLevel }),
-      "Add project collaborator error"
-    );
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: AddProjectCollaboratorDocument,
+    variables: { projectId, email, accessLevel },
+    dataPath: "addProjectCollaborator"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/publishPlanAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/publishPlanAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { PublishPlanDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/publishPlanAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/publishPlanAction.ts
@@ -12,16 +12,10 @@ export async function publishPlanAction({
   planId: number;
   visibility: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: PublishPlanDocument,
-      variables: { planId, visibility },
-      dataPath: "publishPlan"
-    });
-
-  } catch (error) {
-    logger.error({ error }, `[Publish Plan Error]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: PublishPlanDocument,
+    variables: { planId, visibility },
+    dataPath: "publishPlan"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/updatePlanStatusAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/updatePlanStatusAction.ts
@@ -12,16 +12,10 @@ export async function updatePlanStatusAction({
   planId: number;
   status: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: UpdatePlanStatusDocument,
-      variables: { planId, status },
-      dataPath: "updatePlanStatus"
-    });
-
-  } catch (error) {
-    logger.error({ error }, `[Update Plan Status Error]: ${error}`,);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: UpdatePlanStatusDocument,
+    variables: { planId, status },
+    dataPath: "updatePlanStatus"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/updatePlanStatusAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/updatePlanStatusAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { UpdatePlanStatusDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/updatePlanTitleAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/updatePlanTitleAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { UpdatePlanTitleDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/updatePlanTitleAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/actions/updatePlanTitleAction.ts
@@ -12,16 +12,10 @@ export async function updatePlanTitleAction({
   planId: number;
   title: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: UpdatePlanTitleDocument,
-      variables: { planId, title },
-      dataPath: "updatePlanTitle"
-    });
-
-  } catch (error) {
-    logger.error({ error }, `[Update Plan Title Error]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: UpdatePlanTitleDocument,
+    variables: { planId, title },
+    dataPath: "updatePlanTitle"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/members/actions/addPlanMemberAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/members/actions/addPlanMemberAction.ts
@@ -12,16 +12,10 @@ export async function addPlanMemberAction({
   planId: number;
   projectMemberId: number;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: AddPlanMemberDocument,
-      variables: { planId, projectMemberId },
-      dataPath: "addPlanMember"
-    });
-
-  } catch (error) {
-    logger.error({ error }, `[Add Plan Member Error]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: AddPlanMemberDocument,
+    variables: { planId, projectMemberId },
+    dataPath: "addPlanMember"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/members/actions/addPlanMemberAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/members/actions/addPlanMemberAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { AddPlanMemberDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addAnswerAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addAnswerAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { AddAnswerDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addAnswerAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addAnswerAction.ts
@@ -16,15 +16,10 @@ export async function addAnswerAction({
   versionedQuestionId: number;
   json: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: AddAnswerDocument,
-      variables: { planId, versionedSectionId, versionedQuestionId, json },
-      dataPath: "addAnswer"
-    });
-  } catch (error) {
-    logger.error({ error }, `[Add new answer for question]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: AddAnswerDocument,
+    variables: { planId, versionedSectionId, versionedQuestionId, json },
+    dataPath: "addAnswer"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addAnswerCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addAnswerCommentAction.ts
@@ -12,15 +12,10 @@ export async function addAnswerCommentAction({
   answerId: number;
   commentText: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: AddAnswerCommentDocument,
-      variables: { answerId, commentText },
-      dataPath: "addAnswerComment"
-    });
-  } catch (error) {
-    logger.error({ error }, `[Add answerComment from answer]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: AddAnswerCommentDocument,
+    variables: { answerId, commentText },
+    dataPath: "addAnswerComment"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addAnswerCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addAnswerCommentAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { AddAnswerCommentDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addFeedbackCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addFeedbackCommentAction.ts
@@ -16,15 +16,10 @@ export async function addFeedbackCommentAction({
   answerId: number;
   commentText: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: AddFeedbackCommentDocument,
-      variables: { planId, planFeedbackId, answerId, commentText },
-      dataPath: "addFeedbackComment"
-    });
-  } catch (error) {
-    logger.error({ error }, `[Add feedbackComment from answer]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: AddFeedbackCommentDocument,
+    variables: { planId, planFeedbackId, answerId, commentText },
+    dataPath: "addFeedbackComment"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addFeedbackCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/addFeedbackCommentAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { AddFeedbackCommentDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeAnswerCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeAnswerCommentAction.ts
@@ -12,15 +12,10 @@ export async function removeAnswerCommentAction({
   answerId: number;
   answerCommentId: number;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: RemoveAnswerCommentDocument,
-      variables: { answerId, answerCommentId },
-      dataPath: "removeAnswerComment"
-    });
-  } catch (error) {
-    logger.error({ error }, `[Remove answerComment from answer]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: RemoveAnswerCommentDocument,
+    variables: { answerId, answerCommentId },
+    dataPath: "removeAnswerComment"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeAnswerCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeAnswerCommentAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { RemoveAnswerCommentDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeFeedbackCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeFeedbackCommentAction.ts
@@ -12,15 +12,10 @@ export async function removeFeedbackCommentAction({
   planId: number;
   planFeedbackCommentId: number;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: RemoveFeedbackCommentDocument,
-      variables: { planId, planFeedbackCommentId },
-      dataPath: "removeFeedbackComment"
-    });
-  } catch (error) {
-    logger.error({ error }, `[Remove feedbackComment from answer]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: RemoveFeedbackCommentDocument,
+    variables: { planId, planFeedbackCommentId },
+    dataPath: "removeFeedbackComment"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeFeedbackCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/removeFeedbackCommentAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { RemoveFeedbackCommentDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateAnswerAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateAnswerAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { UpdateAnswerDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateAnswerAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateAnswerAction.ts
@@ -12,16 +12,10 @@ export async function updateAnswerAction({
   answerId: number;
   json: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: UpdateAnswerDocument,
-      variables: { answerId, json },
-      dataPath: "updateAnswer"
-    });
-
-  } catch (error) {
-    logger.error({ error }, `[Update answer for question]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: UpdateAnswerDocument,
+    variables: { answerId, json },
+    dataPath: "updateAnswer"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateAnswerCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateAnswerCommentAction.ts
@@ -14,15 +14,10 @@ export async function updateAnswerCommentAction({
   answerCommentId: number;
   commentText: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: UpdateAnswerCommentDocument,
-      variables: { answerId, answerCommentId, commentText },
-      dataPath: "updateAnswerComment"
-    });
-  } catch (error) {
-    logger.error({ error }, `[Update answerComment from answer]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: UpdateAnswerCommentDocument,
+    variables: { answerId, answerCommentId, commentText },
+    dataPath: "updateAnswerComment"
+  });
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateAnswerCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateAnswerCommentAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { UpdateAnswerCommentDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateFeedbackCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateFeedbackCommentAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { UpdateFeedbackCommentDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateFeedbackCommentAction.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/actions/updateFeedbackCommentAction.ts
@@ -14,15 +14,10 @@ export async function updateFeedbackCommentAction({
   planFeedbackCommentId: number;
   commentText: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: UpdateFeedbackCommentDocument,
-      variables: { planId, planFeedbackCommentId, commentText },
-      dataPath: "updateFeedbackComment"
-    });
-  } catch (error) {
-    logger.error({ error }, `[Update feedbackComment from answer]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: UpdateFeedbackCommentDocument,
+    variables: { planId, planFeedbackCommentId, commentText },
+    dataPath: "updateFeedbackComment"
+  });
 }

--- a/app/[locale]/projects/[projectId]/fundings/[projectFundingId]/edit/actions/removeProjectFundingAction.ts
+++ b/app/[locale]/projects/[projectId]/fundings/[projectFundingId]/edit/actions/removeProjectFundingAction.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
 import { ActionResponse } from "@/app/types";
 import { RemoveProjectFundingDocument } from "@/generated/graphql";
 

--- a/app/[locale]/projects/[projectId]/fundings/[projectFundingId]/edit/actions/removeProjectFundingAction.ts
+++ b/app/[locale]/projects/[projectId]/fundings/[projectFundingId]/edit/actions/removeProjectFundingAction.ts
@@ -10,16 +10,10 @@ export async function removeProjectFundingAction({
 }: {
   projectFundingId: number;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: RemoveProjectFundingDocument,
-      variables: { projectFundingId },
-      dataPath: "removeProjectFunding"
-    });
-
-  } catch (error) {
-    logger.error({ error }, `[RemoveProjectFunding Error]: ${error}`);
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: RemoveProjectFundingDocument,
+    variables: { projectFundingId },
+    dataPath: "removeProjectFunding"
+  });
 }

--- a/app/[locale]/template/[templateId]/actions/updateSectionDisplayOrderAction.ts
+++ b/app/[locale]/template/[templateId]/actions/updateSectionDisplayOrderAction.ts
@@ -13,19 +13,10 @@ export async function updateSectionDisplayOrderAction({
   sectionId: number;
   newDisplayOrder: number;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: UpdateSectionDisplayOrderDocument,
-      variables: { sectionId, newDisplayOrder },
-      dataPath: "updateSectionDisplayOrder"
-    });
-
-  } catch (error) {
-    logger.error(
-      await prepareObjectForLogs({ error, sectionId, newDisplayOrder }),
-      "Update section display order error"
-    );
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: UpdateSectionDisplayOrderDocument,
+    variables: { sectionId, newDisplayOrder },
+    dataPath: "updateSectionDisplayOrder"
+  });
 }

--- a/app/[locale]/template/[templateId]/actions/updateSectionDisplayOrderAction.ts
+++ b/app/[locale]/template/[templateId]/actions/updateSectionDisplayOrderAction.ts
@@ -2,6 +2,7 @@
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
 import logger from "@/utils/server/logger";
+import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 import { ActionResponse } from "@/app/types";
 import { UpdateSectionDisplayOrderDocument } from "@/generated/graphql";
 
@@ -21,7 +22,10 @@ export async function updateSectionDisplayOrderAction({
     });
 
   } catch (error) {
-    logger.error({ error }, `[Update Section Display Order Error]: ${error}`);
+    logger.error(
+      await prepareObjectForLogs({ error, sectionId, newDisplayOrder }),
+      "Update section display order error"
+    );
     return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
   }
 }

--- a/app/[locale]/template/[templateId]/actions/updateSectionDisplayOrderAction.ts
+++ b/app/[locale]/template/[templateId]/actions/updateSectionDisplayOrderAction.ts
@@ -1,8 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
-import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 import { ActionResponse } from "@/app/types";
 import { UpdateSectionDisplayOrderDocument } from "@/generated/graphql";
 

--- a/app/[locale]/template/[templateId]/actions/updateTemplateAction.ts
+++ b/app/[locale]/template/[templateId]/actions/updateTemplateAction.ts
@@ -13,20 +13,10 @@ export async function updateTemplateAction({
   templateId: number;
   name: string;
 }): Promise<ActionResponse> {
-  try {
-    // Execute the mutation using the shared handler
-    return await executeGraphQLMutation({
-      document: UpdateTemplateDocument,
-      variables: { templateId, name },
-      dataPath: "updateTemplate"
-    });
-
-  } catch (error) {
-    logger.error({ error }, `[Update Template Error]: ${error}`);
-    logger.error(
-      await prepareObjectForLogs({ error, templateId, name }),
-      "Update template error"
-    )
-    return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
-  }
+  // Execute the mutation using the shared handler
+  return await executeGraphQLMutation({
+    document: UpdateTemplateDocument,
+    variables: { templateId, name },
+    dataPath: "updateTemplate"
+  });
 }

--- a/app/[locale]/template/[templateId]/actions/updateTemplateAction.ts
+++ b/app/[locale]/template/[templateId]/actions/updateTemplateAction.ts
@@ -2,6 +2,7 @@
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
 import logger from "@/utils/server/logger";
+import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 import { ActionResponse } from "@/app/types";
 import { UpdateTemplateDocument } from "@/generated/graphql";
 
@@ -22,6 +23,10 @@ export async function updateTemplateAction({
 
   } catch (error) {
     logger.error({ error }, `[Update Template Error]: ${error}`);
+    logger.error(
+      await prepareObjectForLogs({ error, templateId, name }),
+      "Update template error"
+    )
     return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
   }
 }

--- a/app/[locale]/template/[templateId]/actions/updateTemplateAction.ts
+++ b/app/[locale]/template/[templateId]/actions/updateTemplateAction.ts
@@ -1,8 +1,6 @@
 "use server";
 
 import { executeGraphQLMutation } from "@/utils/server/graphqlServerActionHandler";
-import logger from "@/utils/server/logger";
-import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 import { ActionResponse } from "@/app/types";
 import { UpdateTemplateDocument } from "@/generated/graphql";
 

--- a/app/api/check-auth/__tests__/route.spec.ts
+++ b/app/api/check-auth/__tests__/route.spec.ts
@@ -5,9 +5,30 @@ import { NextResponse } from 'next/server';
 import { GET } from '../route';
 import { getAuthTokenServer } from '@/utils/getAuthTokenServer';
 import { verifyJwtToken } from '@/lib/server/auth';
-import logger from '@/utils/server/logger';
 
-jest.mock('@/utils/server/logger');
+jest.mock('@/utils/server/logger', () => {
+  // Define the mock before using it in the factory
+  const mockError: jest.Mock = jest.fn();
+
+  // Avoid requireActual to prevent constructing the real logger
+  return {
+    __esModule: true,
+    // Mock the named export
+    createLogger: jest.fn(() => ({
+      error: mockError,
+    })),
+    // Also mock the default logger for modules that import default
+    default: {
+      error: mockError,
+    },
+    mockError,
+    // If tests rely on these constants, you can stub them here
+    REDACTION_KEYS: ['token'],
+    REDACTION_MESSAGE: '[MASKED]',
+  };
+});
+
+import logger from '@/utils/server/logger';
 
 jest.mock('@/utils/getAuthTokenServer', () => ({
   getAuthTokenServer: jest.fn(),
@@ -47,7 +68,11 @@ describe('GET Function', () => {
     const data = await response.json();
 
     expect(data).toEqual({ authenticated: false })
-    expect(logger.error).toHaveBeenCalledWith({ error: "User verification failed", route: "/api/check-auth", token: "valid-token" });
+    expect(logger.error).toHaveBeenCalledWith({
+      error: new Error("User verification failed"),
+      route: "/api/check-auth",
+      token: "valid-token"
+    }, "Token verification failed");
   })
 
   it('should return false for "authenticated" if there is no "dmspt" auth cookie/token', async () => {

--- a/app/api/check-auth/route.ts
+++ b/app/api/check-auth/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getAuthTokenServer } from '@/utils/getAuthTokenServer';
 import { verifyJwtToken } from '@/lib/server/auth';
-import logger from '@/utils/server/logger';
+import { createLogger } from '@/utils/server/logger';
 
+const logger = createLogger();
 const LOGIN = `${process.env.NEXT_PUBLIC_BASE_URL}/login`;
 
 export async function GET() {
@@ -17,10 +18,10 @@ export async function GET() {
         } else {
           logger.error(
             {
-              error: 'User verification failed',
+              error: new Error('User verification failed'),
               token,
               route: '/api/check-auth',
-            }
+            }, 'Token verification failed'
           )
           return NextResponse.json({ authenticated: false });
         }

--- a/utils/server/__tests__/logger.spec.ts
+++ b/utils/server/__tests__/logger.spec.ts
@@ -52,7 +52,8 @@ describe('logger', () => {
 
     expect(output["log.level"]).toEqual("info");
     expect(output.userId).toEqual(123);
-    expect(output.email).toEqual("[MASKED]");
+    // Email masking occurs in the prepareObjectForLogs function, not in the logger itself
+    expect(output.email).toEqual("tester@example.com");
     expect(output.givenName).toEqual("[MASKED]");
     expect(output.surName).toEqual("[MASKED]");
     expect(output.password).toEqual("[MASKED]");

--- a/utils/server/__tests__/logger.spec.ts
+++ b/utils/server/__tests__/logger.spec.ts
@@ -1,0 +1,63 @@
+import { createLogger } from '../logger';
+import { Writable } from 'stream';
+
+interface TestResponse {
+  "log.level": string;
+  "@timestamp": string;
+  "process.pid": number;
+  "host.hostname": string;
+  "ecs.version": string;
+  userId: number;
+  email: string;
+  givenName: string;
+  surName: string;
+  password: string;
+  pwd: string;
+  accessLevel: string;
+  nested: {
+    email: string;
+  };
+  array: {
+    email: string;
+  }[];
+  message: string;
+}
+
+describe('logger', () => {
+  let output: TestResponse;
+
+  it("redacts sensitive information", () => {
+    // Send the logs to our test stream
+    const dest = new Writable({
+      write(chunk, _enc, cb) {
+        output = JSON.parse(chunk.toString());
+        cb();
+      },
+    });
+
+    const logger = createLogger(dest);
+
+    logger.info(
+        {
+          userId: 123,
+          email: "tester@example.com",
+          givenName: "Test",
+          surName: "User",
+          password: "abcdefg",
+          pwd: "hijklmn",
+          accessLevel: "tester",
+        },
+        "Testing redaction"
+    );
+
+    expect(output["log.level"]).toEqual("info");
+    expect(output.userId).toEqual(123);
+    expect(output.email).toEqual("[MASKED]");
+    expect(output.givenName).toEqual("[MASKED]");
+    expect(output.surName).toEqual("[MASKED]");
+    expect(output.password).toEqual("[MASKED]");
+    expect(output.pwd).toEqual("[MASKED]");
+    expect(output.accessLevel).toEqual("tester");
+    expect(output.message).toEqual("Testing redaction");
+  });
+});

--- a/utils/server/__tests__/loggerUtils.spec.ts
+++ b/utils/server/__tests__/loggerUtils.spec.ts
@@ -1,0 +1,85 @@
+// loggerHelper.test.ts
+import { prepareObjectForLogs} from '../loggerUtils'; // adjust path
+import { serverFetchAccessToken } from '@/utils/server/serverAuthHelper';
+import { REDACTION_MESSAGE } from "@/utils/server/logger";
+
+jest.mock('@/utils/server/serverAuthHelper', () => ({
+  serverFetchAccessToken: jest.fn(),
+}));
+
+interface TestLog {
+  app?: string;
+  env?: string;
+  jti?: string;
+  userId?: number;
+  someKey?: string;
+  otherKey?: string;
+  nullKey?: string | null;
+  password?: string;
+  email?: string;
+  safe?: string;
+}
+
+describe('prepareObjectForLogs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should include token values when present', async () => {
+    (serverFetchAccessToken as jest.Mock).mockResolvedValue({
+      jti: 'token-jti',
+      id: 42,
+    });
+
+    const result: TestLog = await prepareObjectForLogs({});
+
+    expect(result.app).toEqual('nextJS');
+    expect(result.env).toBeTruthy();
+    expect(result.jti).toEqual('token-jti');
+    expect(result.userId).toEqual(42);
+  });
+
+  it('should handle undefined token gracefully', async () => {
+    (serverFetchAccessToken as jest.Mock).mockResolvedValue(undefined);
+
+    const result: TestLog = await prepareObjectForLogs({});
+
+    expect(result.app).toEqual('nextJS');
+    expect(result.env).toBeTruthy();
+    expect(result.jti).toBeFalsy();
+    expect(result.userId).toBeFalsy();
+  });
+
+  it('should merge context and object, removing undefined/null', async () => {
+    (serverFetchAccessToken as jest.Mock).mockResolvedValue({
+      jti: 'abc',
+      id: 99,
+    });
+
+    const obj = { someKey: 'value', otherKey: undefined, nullKey: null };
+    const result: TestLog = await prepareObjectForLogs(obj);
+
+    expect(result).toMatchObject({
+      app: 'nextJS',
+      env: expect.any(String),
+      jti: 'abc',
+      userId: 99,
+      someKey: 'value',
+    });
+
+    // Ensure null/undefined dropped
+    expect(result).not.toHaveProperty('otherKey');
+    expect(result).not.toHaveProperty('nullKey');
+  });
+
+  it('should redact sensitive keys', async () => {
+    (serverFetchAccessToken as jest.Mock).mockResolvedValue(undefined);
+
+    const obj = { password: 'supersecret', safe: 'keepme', email: 'hide' };
+    const result: TestLog = await prepareObjectForLogs(obj);
+
+    expect(result.password).toBe(REDACTION_MESSAGE);
+    expect(result.email).toBe(REDACTION_MESSAGE);
+    expect(result.safe).toBe('keepme');
+  });
+});

--- a/utils/server/__tests__/loggerUtils.spec.ts
+++ b/utils/server/__tests__/loggerUtils.spec.ts
@@ -75,11 +75,11 @@ describe('prepareObjectForLogs', () => {
   it('should redact sensitive keys', async () => {
     (serverFetchAccessToken as jest.Mock).mockResolvedValue(undefined);
 
-    const obj = { password: 'supersecret', safe: 'keepme', email: 'hide' };
+    const obj = { password: 'supersecret', safe: 'keepme', email: 'hide@example.com' };
     const result: TestLog = await prepareObjectForLogs(obj);
 
     expect(result.password).toBe(REDACTION_MESSAGE);
-    expect(result.email).toBe(REDACTION_MESSAGE);
+    expect(result.email).toBe("h**e@example.com");
     expect(result.safe).toBe('keepme');
   });
 });

--- a/utils/server/graphqlServerActionHandler.ts
+++ b/utils/server/graphqlServerActionHandler.ts
@@ -3,6 +3,7 @@
 import { DocumentNode, print } from "graphql";
 import { cookies } from "next/headers";
 import logger from "@/utils/server/logger";
+import { prepareObjectForLogs } from "@/utils/server/loggerUtils";
 import { serverRefreshAuthTokens, serverFetchCsrfToken } from "@/utils/server/serverAuthHelper";
 
 type GraphQLErrorCode = "UNAUTHENTICATED" | "FORBIDDEN" | "INTERNAL_SERVER_ERROR" | string;
@@ -128,7 +129,10 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
               const refreshResult = await serverRefreshAuthTokens();
 
               if (!refreshResult) {
-                logger.error({ error: "UNAUTHENTICATED" }, "Auth token refresh failed with no result");
+                logger.error(
+                  await prepareObjectForLogs({ error: new Error("UNAUTHENTICATED"), mutationString, variables }),
+                  "Auth token refresh failed with no result"
+                );
                 return { success: false, redirect: "/login" };
               }
 
@@ -137,7 +141,10 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
               const setCookieHeader = refreshResult?.response?.headers?.get("set-cookie");
 
               if (!setCookieHeader) {
-                logger.error({ error: "UNAUTHENTICATED" }, "No set-cookie header found in refresh response");
+                logger.error(
+                  await prepareObjectForLogs({ error: new Error("UNAUTHENTICATED"), mutationString, variables }),
+                  "No set-cookie header found in refresh response"
+                );
                 return { success: false, redirect: "/login" };
               }
 
@@ -178,7 +185,10 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
               const retryResult = await retryResponse.json();
 
               if (retryResult.errors) {
-                logger.error({ error: "GRAPHQL_ERROR" }, `[GraphQL Retry Error]: ${retryResult.errors[0]?.message}`);
+                logger.error(
+                  await prepareObjectForLogs({ error: new Error("GRAPHQL_ERROR"), mutationString, variables }),
+                  `[GraphQL Retry Error]: ${retryResult.errors[0]?.message}`
+                );
                 return {
                   success: false,
                   errors: normalizeErrors(retryResult.errors.map((err: GraphQLError) => err.message))
@@ -193,7 +203,10 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
                 data: retryData as T
               };
             } catch (error) {
-              logger.error({ error }, "Token refresh failed");
+              logger.error(
+                await prepareObjectForLogs({ error, mutationString, variables }),
+                "Token refresh failed"
+              );
               return { success: false, redirect: "/login" };
             }
 
@@ -202,16 +215,25 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
               await serverFetchCsrfToken();
               return { success: false, errors: ["Forbidden. Please check your permissions."] };
             } catch (error) {
-              logger.error({ error }, "Fetching CSRF token failed");
+              logger.error(
+                await prepareObjectForLogs({ error, mutationString, variables }),
+                "Fetching CSRF token failed"
+              );
               return { success: false, redirect: "/login" };
             }
 
           case "INTERNAL_SERVER_ERROR":
-            logger.error({ error: "INTERNAL_SERVER_ERROR" }, `[GraphQL Error]: INTERNAL_SERVER_ERROR - ${message}`);
+            logger.error(
+              await prepareObjectForLogs({ error: new Error("INTERNAL_SERVER_ERROR"), mutationString, variables }),
+              "Internal server error"
+            );
             return { success: false, redirect: "/500-error" };
 
           default:
-            logger.error({ error: "GRAPHQL_ERROR" }, `[GraphQL Error]: ${message}`);
+            logger.error(
+              await prepareObjectForLogs({ error: new Error("GRAPHQL_ERROR"), mutationString, variables }),
+              "GraphQL error"
+            );
             return { success: false, errors: normalizeErrors(message) };
         }
       }
@@ -225,7 +247,10 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
       data: responseData as T,
     };
   } catch (networkError) {
-    logger.error({ error: "NETWORK_ERROR" }, `[GraphQL Network Error]: ${networkError}`);
+    logger.error(
+      await prepareObjectForLogs({ error: networkError, mutationString, variables }),
+      "GraphQL network error"
+    );
     return { success: false, errors: ["There was a problem connecting to the server. Please try again."] };
   }
 }

--- a/utils/server/graphqlServerActionHandler.ts
+++ b/utils/server/graphqlServerActionHandler.ts
@@ -98,10 +98,15 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
       Cookie: cookieString,
     };
 
-    console.log('server', `${process.env.SERVER_ENDPOINT}/graphql`)
-    console.log('headers', headers)
-    console.log('mutationString', mutationString)
-    console.log('variables', variables)
+    logger.debug(
+      await prepareObjectForLogs({
+        server: `${process.env.SERVER_ENDPOINT}/graphql`,
+        headers,
+        mutationString,
+        variables
+      }),
+      "graphqlServerActionHandler sending mutation"
+    );
 
     // Make the GraphQL request
     const response = await fetch(`${process.env.SERVER_ENDPOINT}/graphql`, {
@@ -113,8 +118,6 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
         variables,
       }),
     });
-
-    console.log('response', response)
 
     const result = await response.json();
 
@@ -241,6 +244,13 @@ export async function executeGraphQLMutation<T = unknown, V = Record<string, unk
 
     // Extract data using provided path
     const responseData = getNestedValue(result.data, dataPath);
+
+    logger.debug(
+      await prepareObjectForLogs({
+        response: responseData
+      }),
+      "graphqlServerActionHandler received response"
+    );
 
     return {
       success: true,

--- a/utils/server/logger.ts
+++ b/utils/server/logger.ts
@@ -1,6 +1,16 @@
 import { ecsFormat } from '@elastic/ecs-pino-format';
 import pino from 'pino';
 
-const logger = pino(ecsFormat());
+// Fetch the log level from the environment variables, defaulting to 'info' if not set
+const logLevel = process.env.SERVER_LOG_LEVEL || 'info';
 
+// Create and export the logger instance with ECS format
+const logger = pino({
+  level: logLevel,
+  redact: {
+    paths: ['email', 'givenName', 'surName', 'password', 'pwd'],
+    censor: '[MASKED]'
+  },
+  ...ecsFormat()
+});
 export default logger;

--- a/utils/server/logger.ts
+++ b/utils/server/logger.ts
@@ -3,7 +3,6 @@ import pino from 'pino';
 
 // The fields that should be redacted from the logs
 export const REDACTION_KEYS = [
-  'email',
   'givenName',
   'surName',
   'password',

--- a/utils/server/logger.ts
+++ b/utils/server/logger.ts
@@ -1,16 +1,34 @@
 import { ecsFormat } from '@elastic/ecs-pino-format';
 import pino from 'pino';
 
+// The fields that should be redacted from the logs
+export const REDACTION_KEYS = [
+  'email',
+  'givenName',
+  'surName',
+  'password',
+  'pwd',
+  'token',
+  'secret',
+  'jwtSecret',
+];
+
+export const REDACTION_MESSAGE = '[MASKED]';
+
 // Fetch the log level from the environment variables, defaulting to 'info' if not set
 const logLevel = process.env.SERVER_LOG_LEVEL || 'info';
 
-// Create and export the logger instance with ECS format
-const logger = pino({
-  level: logLevel,
-  redact: {
-    paths: ['email', 'givenName', 'surName', 'password', 'pwd'],
-    censor: '[MASKED]'
-  },
-  ...ecsFormat()
-});
+export function createLogger(dest?: pino.DestinationStream) {
+  return pino({
+    level: logLevel,
+    redact: {
+      paths: REDACTION_KEYS,
+      censor: REDACTION_MESSAGE,
+    },
+    ...ecsFormat(),
+  }, dest);
+}
+
+// default instance
+const logger = createLogger();
 export default logger;

--- a/utils/server/loggerUtils.ts
+++ b/utils/server/loggerUtils.ts
@@ -1,29 +1,42 @@
 import { serverFetchAccessToken, JWTAccessToken } from "@/utils/server/serverAuthHelper";
+import { REDACTION_KEYS, REDACTION_MESSAGE } from "@/utils/server/logger";
 
 export interface LoggerContext {
-    app: string;
-    env: string;
-    jti?: string;
-    userId?: number;
+  app: string;
+  env: string;
+  jti?: string;
+  userId?: number;
 }
 
 // Attach important information from the JWT to the log so we can tie activity to
 // activity in the Apollo server backend and other services
 async function buildLogContext(): Promise<LoggerContext> {
-    const token: JWTAccessToken | undefined = await serverFetchAccessToken();
-    return {
-        app: "nextJS",
-        env: String(process.env.ENV ?? "development"),
-        jti: token?.jti,
-        userId: token?.id
-    }
+  const token: JWTAccessToken | undefined = await serverFetchAccessToken();
+  return {
+    app: "nextJS",
+    env: String(process.env.ENV ?? "development"),
+    jti: token?.jti,
+    userId: token?.id
+  }
 }
 
 // Filter out undefined fields for cleaner logs and attach JWT info
 export async function prepareObjectForLogs(obj: object): Promise<object> {
-    const logContext = await buildLogContext();
-    const payload = { ...logContext, ...obj };
-    return Object.fromEntries(
-        Object.entries(payload).filter(([_, v]) => v !== undefined && v !== null)
-    );
+  const logContext = await buildLogContext();
+  const payload = { ...logContext, ...obj };
+
+  // Remove any keys with undefined or null values
+  const cleansed = Object.fromEntries(
+    Object.entries(payload).filter(([_, v]) => {
+        return v !== undefined && v !== null
+    })
+  );
+
+  // Redact the values of any keys that are sensitive
+  for (const key of REDACTION_KEYS) {
+    if (key in cleansed) {
+      cleansed[key] = REDACTION_MESSAGE;
+    }
+  }
+  return cleansed;
 }

--- a/utils/server/loggerUtils.ts
+++ b/utils/server/loggerUtils.ts
@@ -8,6 +8,28 @@ export interface LoggerContext {
   userId?: number;
 }
 
+function maskEmail(email: string): string {
+  const parts = email.split('@');
+  if (parts.length !== 2) {
+    // Not a valid email format
+    return email;
+  }
+
+  const localPart = parts[0];
+  const domainPart = parts[1];
+
+  if (localPart.length <= 2) {
+    // If the local part is too short, we can't mask it properly, so we just return the redaction message
+    return REDACTION_MESSAGE;
+  }
+
+  const firstChar = localPart.charAt(0);
+  const lastChar = localPart.charAt(localPart.length - 1);
+  const maskedSection = '*'.repeat(localPart.length - 2);
+
+  return `${firstChar}${maskedSection}${lastChar}@${domainPart}`;
+}
+
 // Attach important information from the JWT to the log so we can tie activity to
 // activity in the Apollo server backend and other services
 async function buildLogContext(): Promise<LoggerContext> {
@@ -20,23 +42,46 @@ async function buildLogContext(): Promise<LoggerContext> {
   }
 }
 
+// Inspect the keys and values of the object and recursively mask any sensitive information
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function redactSensitiveInfo(obj: any): any {
+
+  console.log("REDACTING:", obj)
+
+  if (Array.isArray(obj)) {
+    return obj.map(redactSensitiveInfo);
+  } else if (obj !== null && typeof obj === 'object') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const redactedObj: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      if (REDACTION_KEYS.includes(key)) {
+        redactedObj[key] = REDACTION_MESSAGE;
+      } else {
+        redactedObj[key] = redactSensitiveInfo(value);
+      }
+    }
+    return redactedObj;
+  } else if (typeof obj === 'string') {
+    // Replace any email addresses with the redaction message
+    const emailRegex = /([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/g;
+    if (emailRegex.test(obj)) {
+      // Mask each occurrence of an email address in the string using the maskEmail function
+      return obj.replace(emailRegex, maskEmail);
+    }
+    return obj;
+  }
+  return obj;
+}
+
 // Filter out undefined fields for cleaner logs and attach JWT info
 export async function prepareObjectForLogs(obj: object): Promise<object> {
   const logContext = await buildLogContext();
-  const payload = { ...logContext, ...obj };
+  const payload = { ...logContext, ...redactSensitiveInfo(obj) };
 
   // Remove any keys with undefined or null values
-  const cleansed = Object.fromEntries(
+  return Object.fromEntries(
     Object.entries(payload).filter(([_, v]) => {
         return v !== undefined && v !== null
     })
   );
-
-  // Redact the values of any keys that are sensitive
-  for (const key of REDACTION_KEYS) {
-    if (key in cleansed) {
-      cleansed[key] = REDACTION_MESSAGE;
-    }
-  }
-  return cleansed;
 }

--- a/utils/server/loggerUtils.ts
+++ b/utils/server/loggerUtils.ts
@@ -8,7 +8,7 @@ export interface LoggerContext {
   userId?: number;
 }
 
-function maskEmail(email: string): string {
+export function maskEmail(email: string): string {
   const parts = email.split('@');
   if (parts.length !== 2) {
     // Not a valid email format

--- a/utils/server/loggerUtils.ts
+++ b/utils/server/loggerUtils.ts
@@ -1,0 +1,29 @@
+import { serverFetchAccessToken, JWTAccessToken } from "@/utils/server/serverAuthHelper";
+
+export interface LoggerContext {
+    app: string;
+    env: string;
+    jti?: string;
+    userId?: number;
+}
+
+// Attach important information from the JWT to the log so we can tie activity to
+// activity in the Apollo server backend and other services
+async function buildLogContext(): Promise<LoggerContext> {
+    const token: JWTAccessToken | undefined = await serverFetchAccessToken();
+    return {
+        app: "nextJS",
+        env: String(process.env.ENV ?? "development"),
+        jti: token?.jti,
+        userId: token?.id
+    }
+}
+
+// Filter out undefined fields for cleaner logs and attach JWT info
+export async function prepareObjectForLogs(obj: object): Promise<object> {
+    const logContext = await buildLogContext();
+    const payload = { ...logContext, ...obj };
+    return Object.fromEntries(
+        Object.entries(payload).filter(([_, v]) => v !== undefined && v !== null)
+    );
+}

--- a/utils/server/serverAuthHelper.ts
+++ b/utils/server/serverAuthHelper.ts
@@ -1,7 +1,19 @@
 'use server'
 
 import { cookies } from "next/headers";
+import jwt, { JwtPayload } from 'jsonwebtoken';
 import logger from "@/utils/server/logger";
+
+export interface JWTAccessToken extends JwtPayload {
+  id: number,
+  email: string,
+  givenName: string,
+  surName: string,
+  role: string,
+  affiliationId: string,
+  languageId: string,
+  jti: string,
+}
 
 class ServerAuthError extends Error {
   status: number | null;
@@ -26,7 +38,7 @@ class ServerAuthError extends Error {
     this.status = status;
     this.message = message;
 
-    logger.error(`${statusMsg} - ${source}`);
+    logger.error({ statusMsg, source }, "ServerAuthError");
   }
 }
 
@@ -85,7 +97,7 @@ export const serverRefreshAuthTokens = async () => {
       cookies: setCookieHeaders
     };
   } catch (err) {
-    logger.error({ error: err }, "Error refreshing auth token");
+    logger.error(err, "Error refreshing auth token");
     return null;
   }
 };
@@ -105,7 +117,23 @@ export const serverFetchCsrfToken = async () => {
 
     return response;
   } catch (err) {
-    logger.error({ error: err }, "Error getting CSRF token");
+    logger.error(err,"Error getting CSRF token");
     return null;
   }
 };
+
+// Fetch and decode the JWT Access Token
+export const serverFetchAccessToken = async (): Promise<JWTAccessToken | undefined> => {
+  try {
+    const cookieStore = await cookies();
+    const cookie = cookieStore.get("dmspt");
+    if (!cookie || !cookie.value) return undefined;
+
+    const secret = process.env.JWT_SECRET ?? "";
+    const token = jwt.verify(String(cookie?.value), secret) as JwtPayload;
+    return token ? token as JWTAccessToken : undefined;
+  } catch (err) {
+    logger.error(err, "Error decoding JWT Access Token");
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Description

Part of [#14](https://github.com/CDLUC3/dmptool-infrastructure/issues/14)

- Added a new `SERVER_LOG_LEVEL` env variable 
- Update `utils/server/logger.ts` to add Pino redaction logic and also a `createLogger` function that allows an optional destination to be passed in to facilitate testing. The default is the normal stdout.
- Updated `utils/server/serverAuthHelper` by adding a `serverFetchAccessToken` to fetch the access token so we can include things like the `jti` in logs
- Added `utils/server/loggerUtils.ts` with a function that will prepare objects for logging. It strips out properties with null/undefined values, and redacts any instances of keys that we don't want in the logs
- Added logging to the `graphqlServerActionHandler.ts` 
- Added some missing `try -> catch` blocks to several nextJS server actions that were missing them
- Updated all server actions to use the new `prepareObjectForLogs` function 
- Added tests for logger and new loggerUtils

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

All tests are passing. Verified things are working in the UI locally


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have completed manual or automated accessibility testing for my changes
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
