### PR TITLE
Add preview functionality for plan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ NEXT_PUBLIC_BASE_URL="http://localhost:3000"
 NEXT_PUBLIC_SERVER_ENDPOINT="http://localhost:4000"
 NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT="http://localhost:4000/graphql"
 
+NEXT_PUBLIC_NARRATIVE_ENDPOINT="http://localhost:3030" # Port for local narrative service
+
 SERVER_ENDPOINT="http://localhost:4000"
 
 NEXT_PUBLIC_GRAPHQL_ENDPOINT="http://localhost:4000"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added a link to open up a `preview` of the `plan` by using the `dmptool-narrative-generator` endpoint [#412]
 - Added use of pagination queries to the `template/[templateId]/section/new` page [#676]
 - `small` button CSS class.
 - Added curl to the AWS Dockerfile for session manager access

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ These variables must be set in order for the app to work.
 
 * `NEXT_PUBLIC_BASE_URL` - Base url for this app (e.g., "http://localhost:3000")
 * `NEXT_PUBLIC_SERVER_ENDPOINT` - Base url for backend server (e.g., "http://localhost:4000")
-* `NEXT_PUBLIC_NARRATIVE_ENDPOINT` - Base url for the narrative generator, used to generate the plan in different formats (html, PDF, etc)
+* `NEXT_PUBLIC_NARRATIVE_ENDPOINT` - Base url when running the narrative generator locally. The narrative generator (i.e., `dmptool-narrative-generator`) generates the plan in different formats (HTML, PDF, etc)
 * `NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT` - Graphql server schema endpoint (e.g., "http://localhost:4000/graphql")
 * `JWT_SECRET` - Secret key for JWT authentication
 * `SERVER_ENDPOINT` - Server endpoint for backend Apollo server, used for server-side code (e.g., "http://localhost:4000")

--- a/README.md
+++ b/README.md
@@ -149,8 +149,10 @@ These variables must be set in order for the app to work.
 
 * `NEXT_PUBLIC_BASE_URL` - Base url for this app (e.g., "http://localhost:3000")
 * `NEXT_PUBLIC_SERVER_ENDPOINT` - Base url for backend server (e.g., "http://localhost:4000")
+* `NEXT_PUBLIC_NARRATIVE_ENDPOINT` - Base url for the narrative generator, used to generate the plan in different formats (html, PDF, etc)
 * `NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT` - Graphql server schema endpoint (e.g., "http://localhost:4000/graphql")
 * `JWT_SECRET` - Secret key for JWT authentication
+* `SERVER_ENDPOINT` - Server endpoint for backend Apollo server, used for server-side code (e.g., "http://localhost:4000")
 
 
 ### Running the App

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
@@ -868,6 +868,33 @@ describe('PlanOverviewPage', () => {
     expect(screen.getByText('There was an error changing title')).toBeInTheDocument();
   });
 
+  it('should include correct link href for Preview button', async () => {
+    const updatedMockPlanData = {
+      ...mockPlanData.plan,
+      id: null,
+      dmpId: "https://doi.org/123/123",
+      registered: null,
+      title: null,
+      status: null
+    };
+
+    (usePlanQuery as jest.Mock).mockReturnValue({
+      data: { plan: updatedMockPlanData },
+      loading: false,
+      error: null,
+      refetch: jest.fn()
+    });
+
+    render(<PlanOverviewPage />);
+
+    // Check sidebar items
+    const sidebar = screen.getByTestId('sidebar-panel');
+    expect(sidebar).toBeInTheDocument();
+    const previewLink = within(sidebar).getByRole('link', { name: 'buttons.preview' });
+    expect(previewLink).toBeInTheDocument();
+    expect(previewLink).toHaveAttribute('href', 'http://localhost:3030/dmps/123/123/narrative.html?includeCoverSheet=false&includeResearchOutputs=false&includeRelatedWorks=false');
+  });
+
   it('should pass accessibility tests', async () => {
     const { container } = render(<PlanOverviewPage />);
     const results = await axe(container);

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
@@ -872,7 +872,7 @@ describe('PlanOverviewPage', () => {
     const updatedMockPlanData = {
       ...mockPlanData.plan,
       id: null,
-      dmpId: "https://doi.org/123/123",
+      dmpId: "https://doi.org/10.2312/123",
       registered: null,
       title: null,
       status: null
@@ -892,7 +892,34 @@ describe('PlanOverviewPage', () => {
     expect(sidebar).toBeInTheDocument();
     const previewLink = within(sidebar).getByRole('link', { name: 'buttons.preview' });
     expect(previewLink).toBeInTheDocument();
-    expect(previewLink).toHaveAttribute('href', 'http://localhost:3030/dmps/123/123/narrative.html?includeCoverSheet=false&includeResearchOutputs=false&includeRelatedWorks=false');
+    expect(previewLink).toHaveAttribute('href', 'http://localhost:3030/dmps/10.2312/123/narrative.html?includeCoverSheet=false&includeResearchOutputs=false&includeRelatedWorks=false');
+  });
+
+  it('should include correct link href for Preview button when DOI is not in a common format', async () => {
+    const updatedMockPlanData = {
+      ...mockPlanData.plan,
+      id: null,
+      dmpId: "doi:10.1234/abcd",
+      registered: null,
+      title: null,
+      status: null
+    };
+
+    (usePlanQuery as jest.Mock).mockReturnValue({
+      data: { plan: updatedMockPlanData },
+      loading: false,
+      error: null,
+      refetch: jest.fn()
+    });
+
+    render(<PlanOverviewPage />);
+
+    // Check sidebar items
+    const sidebar = screen.getByTestId('sidebar-panel');
+    expect(sidebar).toBeInTheDocument();
+    const previewLink = within(sidebar).getByRole('link', { name: 'buttons.preview' });
+    expect(previewLink).toBeInTheDocument();
+    expect(previewLink).toHaveAttribute('href', 'http://localhost:3030/dmps/10.1234/abcd/narrative.html?includeCoverSheet=false&includeResearchOutputs=false&includeRelatedWorks=false');
   });
 
   it('should pass accessibility tests', async () => {

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/__tests__/page.spec.tsx
@@ -129,7 +129,7 @@ describe('PlanOverviewPage', () => {
     // // Check sidebar items
     const sidebar = screen.getByTestId('sidebar-panel');
     expect(sidebar).toBeInTheDocument();
-    expect(within(sidebar).getByRole('button', { name: 'buttons.preview' })).toBeInTheDocument();
+    expect(within(sidebar).getByRole('link', { name: 'buttons.preview' })).toBeInTheDocument();
     expect(within(sidebar).getByRole('button', { name: 'buttons.publish' })).toBeInTheDocument();
     expect(within(sidebar).getByRole('heading', { name: 'status.feedback.title' })).toBeInTheDocument();
     expect(within(sidebar).getByRole('link', { name: 'links.request' })).toBeInTheDocument();
@@ -179,7 +179,7 @@ describe('PlanOverviewPage', () => {
     // Check sidebar items
     const sidebar = screen.getByTestId('sidebar-panel');
     expect(sidebar).toBeInTheDocument();
-    expect(within(sidebar).getByRole('button', { name: 'buttons.preview' })).toBeInTheDocument();
+    expect(within(sidebar).getByRole('link', { name: 'buttons.preview' })).toBeInTheDocument();
     expect(within(sidebar).getByRole('button', { name: 'buttons.publish' })).toBeInTheDocument();
     expect(within(sidebar).getByRole('heading', { name: 'status.feedback.title' })).toBeInTheDocument();
     expect(within(sidebar).getByRole('link', { name: 'links.request' })).toBeInTheDocument();

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
@@ -151,7 +151,7 @@ function extractDOI(value: string): string {
 const getNarrativeUrl = (dmpId: string) => {
   let narrativeUrl = '';
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-  const localBaseUrl = process.env.NEXT_PUBLIC_NARRATIVE_ENDPOINT;
+  const localBaseUrl = process.env.NEXT_PUBLIC_NARRATIVE_ENDPOINT || 'http://localhost:3030';
   const isLocalhost = baseUrl?.includes('localhost');
 
   narrativeUrl = isLocalhost ? localBaseUrl || '' : baseUrl || '';

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
@@ -141,10 +141,13 @@ const reducer = (state: State, action: Action): State => {
   }
 };
 
+// Extra the dmpId from the DOI URL
 function extractDOI(value: string): string {
   return value.replace('https://doi.org/', '');
 }
 
+// Construct the narrative URL based on environment
+// When running narrative generator locally, it uses port 3030, so we need a separate domain for that
 const getNarrativeUrl = (dmpId: string) => {
   let narrativeUrl = '';
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
@@ -48,6 +48,7 @@ import {
   PlanMember,
   PlanOverviewInterface,
 } from '@/app/types';
+import { DOI_REGEX } from '@/lib/constants';
 import styles from './PlanOverviewPage.module.scss';
 
 const PUBLISHED = 'Published';
@@ -143,7 +144,11 @@ const reducer = (state: State, action: Action): State => {
 
 // Extract the dmpId from the DOI URL
 function extractDOI(value: string): string {
-  return value.replace('https://doi.org/', '');
+  if (!value) return '';
+  // decode percent-encoding if someone passed a URL-encoded DOI
+  const decoded = decodeURIComponent(value.trim());
+  const match = DOI_REGEX.exec(decoded);
+  return match ? match[1] : '';
 }
 
 // Construct the narrative URL based on environment

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
@@ -149,12 +149,11 @@ const getNarrativeUrl = (dmpId: string) => {
   let narrativeUrl = '';
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
   const localBaseUrl = process.env.NEXT_PUBLIC_NARRATIVE_ENDPOINT;
-  const isLocalhost = baseUrl?.includes('localhost') || baseUrl?.includes('127.0.0.1');
+  const isLocalhost = baseUrl?.includes('localhost');
 
   narrativeUrl = isLocalhost ? localBaseUrl || '' : baseUrl || '';
-  const extension = isLocalhost ? '' : '.html';
 
-  return `${narrativeUrl}/dmps/${dmpId}/narrative${extension}?format=html&includeCoverSheet=false&includeResearchOutputs=false&includeRelatedWorks=false`;
+  return `${narrativeUrl}/dmps/${dmpId}/narrative.html?includeCoverSheet=false&includeResearchOutputs=false&includeRelatedWorks=false`;
 };
 
 

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
@@ -141,7 +141,7 @@ const reducer = (state: State, action: Action): State => {
   }
 };
 
-// Extra the dmpId from the DOI URL
+// Extract the dmpId from the DOI URL
 function extractDOI(value: string): string {
   return value.replace('https://doi.org/', '');
 }

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/page.tsx
@@ -141,6 +141,24 @@ const reducer = (state: State, action: Action): State => {
   }
 };
 
+function extractDOI(value: string): string {
+  return value.replace('https://doi.org/', '');
+}
+
+const getNarrativeUrl = (dmpId: string) => {
+  let narrativeUrl = '';
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const localBaseUrl = process.env.NEXT_PUBLIC_NARRATIVE_ENDPOINT;
+  const isLocalhost = baseUrl?.includes('localhost') || baseUrl?.includes('127.0.0.1');
+
+  narrativeUrl = isLocalhost ? localBaseUrl || '' : baseUrl || '';
+  const extension = isLocalhost ? '' : '.html';
+
+  return `${narrativeUrl}/dmps/${dmpId}/narrative${extension}?format=html&includeCoverSheet=false&includeResearchOutputs=false&includeRelatedWorks=false`;
+};
+
+
+
 const PlanOverviewPage: React.FC = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
@@ -416,7 +434,7 @@ const PlanOverviewPage: React.FC = () => {
         type: 'SET_PLAN_DATA',
         payload: {
           id: Number(data?.plan.id) ?? null,
-          dmpId: data?.plan.dmpId ?? '',
+          dmpId: extractDOI(data?.plan.dmpId ?? ''),
           registered: data?.plan.registered ?? '',
           title: data?.plan?.title ?? '',
           status: data?.plan?.status ?? '',
@@ -656,7 +674,9 @@ const PlanOverviewPage: React.FC = () => {
         <SidebarPanel>
           <div className={`statusPanelContent sidePanel`}>
             <div className={`buttonContainer withBorder  mb-5`}>
-              <Button className="secondary">{Global('buttons.preview')}</Button>
+              <Link href={getNarrativeUrl(state.planData.dmpId)} target="_blank" rel="noopener noreferrer" className="button-secondary">
+                {Global('buttons.preview')}
+              </Link>
               <Button
                 onPress={() => dispatch({ type: 'SET_IS_MODAL_OPEN', payload: true })}
               >

--- a/app/[locale]/styleguide/page.tsx
+++ b/app/[locale]/styleguide/page.tsx
@@ -14,6 +14,7 @@ import {
   Form,
   Input,
   Label,
+  Link,
   ListBox,
   ListBoxItem,
   Menu,
@@ -679,6 +680,11 @@ function Page() {
                 We should try to use Next Link e.g.
 
                 <code> {`<Link href="/about">About</Link>`} </code>
+              </div>
+
+              <div className="sg-button-list">
+                <Link>Standard link</Link>
+                <Link href="/" className="button-secondary">Button Link</Link>
               </div>
             </div>
 
@@ -1461,7 +1467,7 @@ function Page() {
 
             <h2>Button Sizes</h2>
             <p>
-              Button size can be changed by adding a size modifier class, for example:<br/> <code>{'<Button className="primary small">Small Primary</Button>'}</code>.
+              Button size can be changed by adding a size modifier class, for example:<br /> <code>{'<Button className="primary small">Small Primary</Button>'}</code>.
             </p>
 
             <Example>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,5 +16,7 @@ export const TEXT_FIELD_QUESTION_TYPE = "text";
 export const TEXT_QUESTION_TYPE = ["text", "textArea"];
 export const TYPEAHEAD_QUESTION_TYPE = "affiliationSearch";
 export const URL_QUESTION_TYPE = "url";
+export const DOI_REGEX = /(?:doi:\s*)?(10\.\d{4,9}\/[-._;()\/:A-Z0-9]+)/i;
+
 
 

--- a/styles/form/_button.scss
+++ b/styles/form/_button.scss
@@ -163,6 +163,17 @@
   }
 }
 
+a.button-secondary {
+  text-decoration: none !important;
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+  @include button-base;
+  @include button-secondary;
+}
+
 // Styles for both react-aria buttons and default HTML buttons
 .react-aria-Button,
 button,


### PR DESCRIPTION
## Description

- Replaced the previous Preview button on the Plan Overview page with a <Link> that goes to the `dmptool-narrative-generator` endpoint to load a new HTML page in another tab

Fixes # ([412](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/412))

## Type of change

- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually and with unit test


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screen recording
### Should open the plan in HTML page in a new tab


https://github.com/user-attachments/assets/af8adbe4-ee1d-4878-ac45-67788a22e505

