### PR TITLE
Updated /template page to use new cursor pagination 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Added description to project search page [#761](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/761)
 
 ### Updated
+- Updated the `/template` page to use the new `cursor pagination` functionality, because it was only ever loading 20 results [#812]
 - Added a `beforeunload` event handler to the `PlanOverviewQuestionPage`, `CreateSectionPage`, `SectionUpdatePage` and `QuestionAdd` components to warn users when they are navigating away with unsaved changes [#758]
 - Updated `Commenting` logic on the `PlanOverviewQuestionPage` so that the `creator` or anybody with `role="OWN"` can delete anybody's comments [#321]
 - Updated to show disabled `Comment` button with a tooltip message when there is no `answer` yet. [#321]

--- a/app/[locale]/template/__mocks__/templateListPage.mocks.ts
+++ b/app/[locale]/template/__mocks__/templateListPage.mocks.ts
@@ -1,0 +1,1542 @@
+import { TemplatesDocument } from '@/generated/graphql';
+
+export const mocks = [
+  // Initial load mock
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        paginationOptions: {
+          limit: 5,
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 2,
+          nextCursor: null,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          }]
+        }
+      },
+    },
+  },
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        paginationOptions: {
+          limit: 5,
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 2,
+          nextCursor: null,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          }]
+        }
+      },
+    },
+  },
+  // Search mock for 'UCOP'
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'ucop',
+        paginationOptions: {
+          limit: 5,
+          type: "CURSOR",
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 2,
+          nextCursor: null,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [
+            {
+              name: 'UCOP',
+              description: 'University of California Office of the President',
+              modified: '2024-11-20 00:00:00',
+              modifiedByName: 'Test User',
+              latestPublishVisibility: 'ORGANIZATION',
+              latestPublishVersion: 'v1',
+              latestPublishDate: '2024-11-20 00:00:00',
+              id: 1,
+              ownerId: 'http://example.com/user/1',
+              ownerDisplayName: 'Test Affiliation',
+              modifiedById: 1,
+              isDirty: false,
+              bestPractice: false
+            }
+          ]
+        }
+      },
+    },
+  },
+  // with some data missing
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'missing',
+        paginationOptions: {
+          limit: 5,
+          type: 'CURSOR'
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: null,
+            description: 'University of California Office of the President',
+            modified: null,
+            modifiedByName: 'Test User',
+            latestPublishVisibility: null,
+            latestPublishVersion: 'v1',
+            latestPublishDate: null,
+            id: null,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: true,
+            bestPractice: false
+          }
+          ]
+        }
+      },
+    },
+  },
+  // Search mock for 'test'
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'test',
+        paginationOptions: {
+          limit: 5,
+          type: "CURSOR",
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 2,
+          nextCursor: null,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: []
+        }
+      },
+    },
+  },
+];
+
+
+export const multipleItemsMock = [
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        paginationOptions: {
+          limit: 5,
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 1',
+            description: 'Test Template 1 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 2',
+            description: 'Test Template 2 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 3',
+            description: 'Test Template 3 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          ]
+        }
+      },
+    },
+  },
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'template',
+        paginationOptions: {
+          limit: 5,
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 1',
+            description: 'Test Template 1 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 2',
+            description: 'Test Template 2 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 3',
+            description: 'Test Template 3 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 4',
+            description: 'Test Template 4 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 5',
+            description: 'Test Template 5 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+
+          ]
+        }
+      },
+    },
+  },
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        paginationOptions: {
+          type: "CURSOR",
+          cursor: 1,
+          limit: 5,
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 1',
+            description: 'Test Template 1 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 2',
+            description: 'Test Template 2 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 3',
+            description: 'Test Template 3 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 4',
+            description: 'Test Template 4 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 5',
+            description: 'Test Template 5 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          ]
+        }
+      },
+    },
+  },
+  // Search mock for 'template' returning multiple items
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'template',
+        paginationOptions: {
+          limit: 5,
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 1',
+            description: 'Test Template 1 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 2',
+            description: 'Test Template 2 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 3',
+            description: 'Test Template 3 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 4',
+            description: 'Test Template 4 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 5',
+            description: 'Test Template 5 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+
+          ]
+        }
+      },
+    },
+  },
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'template',
+        paginationOptions: {
+          limit: 5,
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 1',
+            description: 'Test Template 1 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 2',
+            description: 'Test Template 2 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 3',
+            description: 'Test Template 3 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 4',
+            description: 'Test Template 4 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 5',
+            description: 'Test Template 5 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+
+          ]
+        }
+      },
+    },
+  },
+  // data for loading more for search
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'template',
+        paginationOptions: {
+          limit: 5,
+          type: "CURSOR",
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 1',
+            description: 'Test Template 1 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 2',
+            description: 'Test Template 2 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 3',
+            description: 'Test Template 3 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 4',
+            description: 'Test Template 4 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 5',
+            description: 'Test Template 5 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+
+          ]
+        }
+      },
+    },
+  },
+  // data for loading more for search
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'template',
+        paginationOptions: {
+          limit: 5,
+          type: "CURSOR",
+          cursor: 1,
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 1',
+            description: 'Test Template 1 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 2',
+            description: 'Test Template 2 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 3',
+            description: 'Test Template 3 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 4',
+            description: 'Test Template 4 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 5',
+            description: 'Test Template 5 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+
+          ]
+        }
+      },
+    },
+  },
+];
+
+export const multipleItemsErrorMock = [
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        paginationOptions: {
+          limit: 5,
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 1',
+            description: 'Test Template 1 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 2',
+            description: 'Test Template 2 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 3',
+            description: 'Test Template 3 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 4',
+            description: 'Test Template 4 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 5',
+            description: 'Test Template 5 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+
+          ]
+        }
+      },
+    },
+  },
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'template',
+        paginationOptions: {
+          limit: 5,
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 1',
+            description: 'Test Template 1 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 2',
+            description: 'Test Template 2 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 3',
+            description: 'Test Template 3 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 4',
+            description: 'Test Template 4 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 5',
+            description: 'Test Template 5 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+
+          ]
+        }
+      },
+    },
+  },
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'template',
+        paginationOptions: {
+          limit: 5,
+          type: "CURSOR",
+        },
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 10,
+          nextCursor: 1,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 1',
+            description: 'Test Template 1 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 2',
+            description: 'Test Template 2 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 3',
+            description: 'Test Template 3 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 4',
+            description: 'Test Template 4 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'Test Template 5',
+            description: 'Test Template 5 Description',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+
+          ]
+        }
+      },
+    },
+  },
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        term: 'template',
+        paginationOptions: {
+          limit: 5,
+          type: "CURSOR",
+          cursor: 1
+        },
+      },
+    },
+    error: new Error('Network error'),
+  },
+];
+
+export const errorMock = [
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        paginationOptions: {
+          limit: 5,
+        },
+      },
+    },
+    error: new Error('Network error'),
+  },
+];

--- a/app/[locale]/template/__tests__/page.spec.tsx
+++ b/app/[locale]/template/__tests__/page.spec.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { act, fireEvent, render, screen, within, waitFor } from '@/utils/test-utils';
+import { MockedProvider } from '@apollo/client/testing';
 import TemplateListPage from '../page';
 import { axe, toHaveNoViolations } from 'jest-axe';
-import { useTemplatesQuery, } from '@/generated/graphql';
 import { mockScrollIntoView } from '@/__mocks__/common';
+import {
+  mocks,
+  multipleItemsMock,
+  multipleItemsErrorMock,
+  errorMock
+} from '../__mocks__/templateListPage.mocks';
 
 expect.extend(toHaveNoViolations);
 
@@ -13,68 +19,6 @@ jest.mock('next-intl', () => ({
     dateTime: jest.fn(() => '01-01-2023'),
   })),
   useTranslations: jest.fn(() => jest.fn((key) => key)), // Mock `useTranslations`
-}));
-
-// Mock the GraphQL hook for getting templates
-jest.mock('@/generated/graphql', () => ({
-  useTemplatesQuery: jest.fn(),
-}));
-
-// Will pass this mock data back when query is made for templates
-const mockTemplateData = {
-  myTemplates: {
-    items: [{
-      name: 'UCOP',
-      description: 'University of California Office of the President',
-      modified: '2024-11-20 00:00:00',
-      modifiedByName: 'Test User',
-      latestPublishVisibility: 'ORGANIZATION',
-      publishStatus: 'PUBLISHED',
-      publishDate: '2024-11-20 00:00:00',
-      id: 1,
-      owner: null
-    },
-    {
-      name: 'CDL',
-      description: 'California Digital Library',
-      modified: '2024-11-20 00:00:00',
-      modifiedByName: 'Test User',
-      latestPublishVisibility: 'ORGANIZATION',
-      publishStatus: 'PUBLISHED',
-      publishDate: '2024-11-20 00:00:00',
-      id: 1,
-      owner: null
-    }]
-  }
-}
-
-// Helper function to cast to jest.Mock for TypeScript
-/* eslint-disable @typescript-eslint/no-explicit-any*/
-const mockHook = (hook: any) => hook as jest.Mock;
-
-const setupMocks = () => {
-  // Return mocked data when graphql query is called for templates
-  mockHook(useTemplatesQuery).mockReturnValue({ data: mockTemplateData, loading: false, error: undefined });
-};
-
-// mock the query response from client.query() for versionedTemplates
-jest.mock('@/lib/graphql/client/apollo-client', () => ({
-  createApolloClient: jest.fn(() => ({
-    query: jest.fn().mockResolvedValueOnce({
-      data: {
-        templateVersions: {
-          items: [
-            {
-              name: 'UCOP',
-              versionType: 'PUBLISHED',
-              id: 1,
-              modified: '1672531200000',
-            },
-          ],
-        }
-      },
-    }),
-  })),
 }));
 
 interface PageHeaderProps {
@@ -98,73 +42,97 @@ jest.mock('@/components/PageHeader', () => {
   };
 });
 
-
 describe('TemplateListPage', () => {
   beforeEach(() => {
-    setupMocks();
     HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
   });
 
   it('should render the page header with correct title and description', async () => {
     await act(async () => {
       render(
-        <TemplateListPage />
+        <MockedProvider mocks={mocks}>
+          <TemplateListPage />
+        </MockedProvider>
       );
     });
 
-    const heading = screen.getByRole('heading', { level: 1 });
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      const heading = screen.getByRole('heading', { level: 1 });
+      expect(heading).toHaveTextContent('title');
+    });
 
-    expect(heading).toHaveTextContent('title');
     expect(screen.getByText('description')).toBeInTheDocument();
   });
 
   it('should render the create template link in header actions', async () => {
     await act(async () => {
       render(
-        <TemplateListPage />
+        <MockedProvider mocks={mocks}>
+          <TemplateListPage />
+        </MockedProvider>
       );
     });
 
-    const createLink = screen.getByText('actionCreate');
-    expect(createLink).toBeInTheDocument();
-    expect(createLink).toHaveAttribute('href', '/en-US/template/create');
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      const createLink = screen.getByText('actionCreate');
+      expect(createLink).toBeInTheDocument();
+      expect(createLink).toHaveAttribute('href', '/en-US/template/create');
+    });
   });
 
   it('should render the search field with correct label and help text', async () => {
     await act(async () => {
       render(
-        <TemplateListPage />
+        <MockedProvider mocks={mocks}>
+          <TemplateListPage />
+        </MockedProvider>
       );
     });
 
-    // Searching for translation keys since cannot run next-intl for unit tests
-    expect(screen.getByLabelText('searchLabel')).toBeInTheDocument();
-    expect(screen.getByText('searchHelpText')).toBeInTheDocument();
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      // Searching for translation keys since cannot run next-intl for unit tests
+      expect(screen.getByLabelText('searchLabel')).toBeInTheDocument();
+      expect(screen.getByText('searchHelpText')).toBeInTheDocument();
+    })
   });
 
   it('should render the template list with correct number of items', async () => {
     await act(async () => {
       render(
-        <TemplateListPage />
+        <MockedProvider mocks={mocks}>
+          <TemplateListPage />
+        </MockedProvider>
       );
     });
 
-    const templateItems = screen.getAllByTestId('template-list-item');
-    expect(templateItems).toHaveLength(2);
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      const templateItems = screen.getAllByTestId('template-list-item');
+      expect(templateItems).toHaveLength(2);
+    })
   });
 
   it('should render template items with correct titles', async () => {
     await act(async () => {
       render(
-        <TemplateListPage />
+        <MockedProvider mocks={mocks}>
+          <TemplateListPage />
+        </MockedProvider>
       );
     });
 
-    expect(screen.getByText('UCOP')).toBeInTheDocument();
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      expect(screen.getByText('UCOP')).toBeInTheDocument();
+    })
+
     const templateData = screen.getAllByTestId('template-metadata');
     const lastRevisedBy = within(templateData[0]).getByText(/lastRevisedBy.*Test User/);
     const lastUpdated = within(templateData[0]).getByText(/lastUpdated.*01-01-2023/);
-    const publishStatus = within(templateData[0]).getByText('Published');
+    const publishStatus = within(templateData[0]).getByText(/published/i);
     const visibility = within(templateData[0]).getByText(/visibility.*Organization/);
     expect(lastRevisedBy).toBeInTheDocument();
     expect(publishStatus).toBeInTheDocument();
@@ -175,63 +143,71 @@ describe('TemplateListPage', () => {
   it('should render the template list with correct ARIA role', async () => {
     await act(async () => {
       render(
-        <TemplateListPage />
+        <MockedProvider mocks={mocks}>
+          <TemplateListPage />
+        </MockedProvider>
       );
     });
 
-    const list = screen.getByRole('list', { name: 'Template list' });
-    expect(list).toHaveClass('template-list');
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      const list = screen.getByRole('list', { name: 'templateList' });
+      expect(list).toBeInTheDocument();
+      const listItems = within(list).getAllByRole('listitem');
+      expect(listItems).toHaveLength(2); // Expecting 2 items as per mock data
+    })
   });
 
   it('should render breadcrumbs with correct links', async () => {
     await act(async () => {
       render(
-        <TemplateListPage />
+        <MockedProvider mocks={mocks}>
+          <TemplateListPage />
+        </MockedProvider>
       );
     });
 
-    // Searching for translation keys since cannot run next-intl for unit tests
-    const homeLink = screen.getByRole('link', { name: 'breadcrumbs.home' });
-    const templatesLink = screen.getByRole('link', { name: 'breadcrumbs.templates' });
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      // Searching for translation keys since cannot run next-intl for unit tests
+      const homeLink = screen.getByRole('link', { name: 'breadcrumbs.home' });
+      const templatesLink = screen.getByRole('link', { name: 'breadcrumbs.templates' });
 
-    expect(homeLink).toHaveAttribute('href', '/en-US');
-    expect(templatesLink).toHaveAttribute('href', '/en-US/template');
+      expect(homeLink).toHaveAttribute('href', '/en-US');
+      expect(templatesLink).toHaveAttribute('href', '/en-US/template');
+    })
   });
 
-  it('should render errors', async () => {
-    // Clear previous mock and set up new mock specifically for this test
-    mockHook(useTemplatesQuery).mockClear();
-    mockHook(useTemplatesQuery).mockReturnValue({
-      data: undefined,
-      loading: false,
-      error: { message: 'There was an error.' },
-      refetch: jest.fn()
-    });
-
+  it('should render error when graphql query returns as error', async () => {
     await act(async () => {
       render(
-        <TemplateListPage />
+        <MockedProvider mocks={errorMock}>
+          <TemplateListPage />
+        </MockedProvider>
       );
     });
 
-    // Searching for translation key since cannot run next-intl for unit tests
-    const searchInput = screen.getByLabelText(/searchLabel/i);
-    expect(searchInput).toBeInTheDocument();
-
-    // enter findable search term
-    await act(async () => {
-      fireEvent.change(searchInput, { target: { value: 'testing' } });
-    });
-
-    expect(screen.getByText('somethingWentWrong')).toBeInTheDocument();
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    })
   });
 
 
-  it('should reset filters when user clicks on \'clear fitler\' ', async () => {
+  it('should reset filters when user clicks on \'clear filter\' ', async () => {
     await act(async () => {
       render(
-        <TemplateListPage />
+        <MockedProvider mocks={mocks}>
+          <TemplateListPage />
+        </MockedProvider>
       );
+    });
+
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      // Searching for translation keys since cannot run next-intl for unit tests
+      const homeLink = screen.getByRole('link', { name: 'breadcrumbs.home' });
+      expect(homeLink).toBeInTheDocument();
     });
 
     // Searching for translation key since cannot run next-intl for unit tests
@@ -244,101 +220,227 @@ describe('TemplateListPage', () => {
     });
 
     // Click the Search button
+    const searchButton = screen.getByRole('button', { name: /search/i });
+    fireEvent.click(searchButton);
+
+
     await waitFor(() => {
+      // Newly filtered list should only show UCOP
+      expect(screen.getByText('UCOP')).toBeInTheDocument();
+      expect(screen.queryByText('CDL')).not.toBeInTheDocument();
+    })
+
+    // Check that the clear filter button is present
+    const clearFilterButton = screen.getAllByText(/clearFilter/i);
+    expect(clearFilterButton).toHaveLength(1);
+
+    // Click the clear filter button
+    fireEvent.click(clearFilterButton[0]);
+
+    // Check that the search input is cleared
+    await waitFor(() => {
+      const searchInput = screen.getByLabelText(/searchLabel/i);
+      expect(searchInput).toHaveValue('');
+      // Check that both items are now visible again
+      expect(screen.getByText('UCOP')).toBeInTheDocument();
+      expect(screen.getByText('CDL')).toBeInTheDocument();
+    })
+
+  })
+
+  it('should show error message when we cannot find item anything matching search term', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={mocks}>
+          <TemplateListPage />
+        </MockedProvider>
+      );
+    });
+
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      const heading = screen.getByRole('heading', { level: 1 });
+      expect(heading).toHaveTextContent('title');
+    });
+
+
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      const searchInput = screen.getByLabelText(/searchLabel/i);
+      expect(searchInput).toBeInTheDocument();
+      fireEvent.change(searchInput, { target: { value: 'test' } });
+
+    });
+
+    await waitFor(() => {
+      const searchButton = screen.getByRole('button', { name: /search/i });
+      fireEvent.click(searchButton);
+
+      // Check that we can find list item for UCOP
+      const errorElement = screen.getByText('messaging.noItemsFound');
+      expect(errorElement).toBeInTheDocument();
+    })
+  })
+
+  it('should display correct load more and remaining text when doing a search', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={mocks}>
+          <TemplateListPage />
+        </MockedProvider>
+      );
+    });
+
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      // Searching for translation keys since cannot run next-intl for unit tests
+      const homeLink = screen.getByRole('link', { name: 'breadcrumbs.home' });
+      expect(homeLink).toBeInTheDocument();
+    });
+
+
+    await waitFor(() => {
+      // Searching for translation key since cannot run next-intl for unit tests
+      const searchInput = screen.getByLabelText(/searchLabel/i);
+      expect(searchInput).toBeInTheDocument();
+
+      // enter findable search term
+      fireEvent.change(searchInput, { target: { value: 'missing' } });
+
+      // Click the Search button
+      const searchButton = screen.getByRole('button', { name: /search/i });
+      fireEvent.click(searchButton);
+    })
+
+    await waitFor(() => {
+      const templateItems = screen.getAllByTestId('template-list-item');
+      expect(templateItems).toHaveLength(1);
+    });
+
+    const loadMoreButton = screen.getByRole('button', { name: /loadMore/i });
+    fireEvent.click(loadMoreButton);
+
+    await waitFor(() => {
+      const templateItems = screen.getAllByTestId('template-list-item');
+      expect(templateItems).toHaveLength(1);
+    })
+  });
+
+
+  it('should display correct load more and remaining text', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={multipleItemsMock}>
+          <TemplateListPage />
+        </MockedProvider>
+      );
+    });
+
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      const heading = screen.getByRole('heading', { level: 1 });
+      expect(heading).toHaveTextContent('title');
+      const templateItems = screen.getAllByTestId('template-list-item');
+      expect(templateItems).toHaveLength(5);
+    });
+
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /loadMore/i })).toBeInTheDocument();
+    })
+
+    const loadMoreButton = screen.getByRole('button', { name: /loadMore/i });
+    fireEvent.click(loadMoreButton);
+
+    await waitFor(() => {
+      const templateItems = screen.getAllByTestId('template-list-item');
+      expect(templateItems).toHaveLength(12);
+    })
+  });
+
+  it('should display correct load more and remaining text when doing a search', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={multipleItemsMock}>
+          <TemplateListPage />
+        </MockedProvider>
+      );
+    });
+
+    // MockedProvider requires await for requests to resolve
+    await waitFor(() => {
+      // Searching for translation keys since cannot run next-intl for unit tests
+      const homeLink = screen.getByRole('link', { name: 'breadcrumbs.home' });
+      expect(homeLink).toBeInTheDocument();
+    });
+
+
+    await waitFor(() => {
+      // Searching for translation key since cannot run next-intl for unit tests
+      const searchInput = screen.getByLabelText(/searchLabel/i);
+      expect(searchInput).toBeInTheDocument();
+
+      // enter findable search term
+      fireEvent.change(searchInput, { target: { value: 'template' } });
+
+      // Click the Search button
+      const searchButton = screen.getByRole('button', { name: /search/i });
+      fireEvent.click(searchButton);
+    })
+
+    await waitFor(() => {
+      const templateItems = screen.getAllByTestId('template-list-item');
+      expect(templateItems).toHaveLength(7);
+    });
+
+    const loadMoreButton = screen.getByRole('button', { name: /loadMore/i });
+    fireEvent.click(loadMoreButton);
+
+    await waitFor(() => {
+      const templateItems = screen.getAllByTestId('template-list-item');
+      expect(templateItems).toHaveLength(14);
+    })
+  });
+
+  it('should display error if loadMore fetch for search returns error', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={multipleItemsErrorMock}>
+          <TemplateListPage />
+        </MockedProvider>
+      );
+    });
+
+    // Simulate search
+    await waitFor(() => {
+      const searchInput = screen.getByLabelText(/searchLabel/i);
+      fireEvent.change(searchInput, { target: { value: 'template' } });
       const searchButton = screen.getByRole('button', { name: /search/i });
       fireEvent.click(searchButton);
     });
 
-    // Newly filtered list should only show UCOP
-    expect(screen.getByText('UCOP')).toBeInTheDocument();
-    expect(screen.queryByText('CDL')).not.toBeInTheDocument();
-    // Check that the clear filter button is present
-    const clearFilterButton = screen.getByText(/clearFilter/i);
-    expect(clearFilterButton).toBeInTheDocument();
-    // Click the clear filter button
-    fireEvent.click(clearFilterButton);
-    // Check that the search input is cleared
-    expect(searchInput).toHaveValue('');
-    // Check that both items are now visible again
-    expect(screen.getByText('UCOP')).toBeInTheDocument();
-    expect(screen.getByText('CDL')).toBeInTheDocument();
-  })
-
-  it('should show error message when we cannot find item that matches search term', async () => {
-    await act(async () => {
-      render(
-        <TemplateListPage />
-      );
+    // Wait for items to render, then click "Load more"
+    await waitFor(() => {
+      const templateItems = screen.getAllByTestId('template-list-item');
+      expect(templateItems.length).toBeGreaterThan(0);
+      const loadMoreButton = screen.getByRole('button', { name: /loadMore/i });
+      fireEvent.click(loadMoreButton);
     });
 
-    const searchInput = screen.getByLabelText(/searchLabel/i);
-    expect(searchInput).toBeInTheDocument();
+    expect(await screen.findByText('Network error')).toBeInTheDocument();
 
-    // enter search term that cannot be found
-    await act(async () => {
-      fireEvent.change(searchInput, { target: { value: 'test' } });
-    });
-
-
-    const searchButton = screen.getByRole('button', { name: /search/i });
-    fireEvent.click(searchButton);
-
-    // Check that we can find list item for UCOP
-    const errorElement = screen.getByText('noItemsFoundError');
-    expect(errorElement).toBeInTheDocument();
-  })
+  });
 
   it('should pass axe accessibility test', async () => {
     const { container } = render(
-      <TemplateListPage />
+      <MockedProvider mocks={mocks}>
+        <TemplateListPage />
+      </MockedProvider>
     );
 
     await act(async () => {
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
-
-  });
-
-  it('should display correct load more and remaining text', async () => {
-    // Five templates in mock
-    const mockTemplates = [
-      { name: 'A', id: 1 }, { name: 'B', id: 2 }, { name: 'C', id: 3 },
-      { name: 'D', id: 4 }, { name: 'E', id: 5 }
-    ].map((t) => ({
-      ...t,
-      description: '',
-      modified: '',
-      modifiedByName: '',
-      visibility: '',
-      publishStatus: '',
-      publishDate: '',
-      owner: null,
-      ownerDisplayName: '',
-      isDirty: false,
-    }));
-
-    mockHook(useTemplatesQuery).mockReturnValue({
-      data: { myTemplates: { items: mockTemplates } },
-      loading: false,
-      error: undefined
-    });
-
-    await act(async () => {
-      render(<TemplateListPage />);
-    });
-
-    // By default, visibleCount is 3, so loadMoreNumber = 2, currentlyDisplayed = 3, totalAvailable = 5
-    // The button should show the correct label (for 2 more)
-    expect(screen.getByRole('button', { name: /loadMore/i })).toBeInTheDocument();
-
-    const loadMoreButton = screen.getByRole('button', { name: /loadMore/i });
-    await act(async () => {
-      fireEvent.click(loadMoreButton);
-    }
-    );
-    const templateItems = screen.getAllByTestId('template-list-item');
-    expect(templateItems).toHaveLength(5);
-
   });
 });

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -758,8 +758,8 @@ export type Mutation = {
   addMetadataStandard?: Maybe<MetadataStandard>;
   /** Create a plan */
   addPlan?: Maybe<Plan>;
-  /** Add a Funding information to a Plan */
-  addPlanFunding?: Maybe<PlanFunding>;
+  /** Add Funding information to a Plan */
+  addPlanFunding?: Maybe<Array<Maybe<PlanFunding>>>;
   /** Add a Member to a Plan */
   addPlanMember?: Maybe<PlanMember>;
   /** Create a project */
@@ -986,7 +986,7 @@ export type MutationAddPlanArgs = {
 
 export type MutationAddPlanFundingArgs = {
   planId: Scalars['Int']['input'];
-  projectFundingId: Scalars['Int']['input'];
+  projectFundingIds: Array<Scalars['Int']['input']>;
 };
 
 
@@ -3793,7 +3793,7 @@ export type VersionedSectionSearchResults = PaginatedQueryResults & {
   hasNextPage?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a previous page */
   hasPreviousPage?: Maybe<Scalars['Boolean']['output']>;
-  /** The SectionSearchResults that match the search criteria */
+  /** The TemplateSearchResults that match the search criteria */
   items?: Maybe<Array<Maybe<VersionedSectionSearchResult>>>;
   /** The number of items returned */
   limit?: Maybe<Scalars['Int']['output']>;
@@ -4494,7 +4494,7 @@ export type TemplatesQueryVariables = Exact<{
 }>;
 
 
-export type TemplatesQuery = { __typename?: 'Query', myTemplates?: { __typename?: 'TemplateSearchResults', totalCount?: number | null, nextCursor?: string | null, items?: Array<{ __typename?: 'TemplateSearchResult', id?: number | null, name?: string | null, description?: string | null, latestPublishVisibility?: TemplateVisibility | null, isDirty?: boolean | null, latestPublishVersion?: string | null, latestPublishDate?: string | null, ownerId?: string | null, ownerDisplayName?: string | null, modified?: string | null, modifiedById?: number | null, modifiedByName?: string | null } | null> | null } | null };
+export type TemplatesQuery = { __typename?: 'Query', myTemplates?: { __typename?: 'TemplateSearchResults', totalCount?: number | null, nextCursor?: string | null, limit?: number | null, availableSortFields?: Array<string | null> | null, currentOffset?: number | null, hasNextPage?: boolean | null, hasPreviousPage?: boolean | null, items?: Array<{ __typename?: 'TemplateSearchResult', id?: number | null, name?: string | null, description?: string | null, latestPublishVisibility?: TemplateVisibility | null, isDirty?: boolean | null, latestPublishVersion?: string | null, latestPublishDate?: string | null, ownerId?: string | null, ownerDisplayName?: string | null, modified?: string | null, modifiedById?: number | null, modifiedByName?: string | null, bestPractice?: boolean | null } | null> | null } | null };
 
 export type TemplateQueryVariables = Exact<{
   templateId: Scalars['Int']['input'];
@@ -8384,6 +8384,11 @@ export const TemplatesDocument = gql`
   myTemplates(term: $term, paginationOptions: $paginationOptions) {
     totalCount
     nextCursor
+    limit
+    availableSortFields
+    currentOffset
+    hasNextPage
+    hasPreviousPage
     items {
       id
       name
@@ -8397,6 +8402,7 @@ export const TemplatesDocument = gql`
       modified
       modifiedById
       modifiedByName
+      bestPractice
     }
   }
 }

--- a/graphql/queries/templates.query.graphql
+++ b/graphql/queries/templates.query.graphql
@@ -2,6 +2,11 @@ query Templates($term: String, $paginationOptions: PaginationOptions) {
   myTemplates(term: $term, paginationOptions: $paginationOptions) {
     totalCount
     nextCursor
+    limit
+    availableSortFields
+    currentOffset
+    hasNextPage
+    hasPreviousPage
     items {
       id
       name
@@ -15,6 +20,7 @@ query Templates($term: String, $paginationOptions: PaginationOptions) {
       modified
       modifiedById
       modifiedByName
+      bestPractice
     }
   }
 }

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -245,7 +245,9 @@
       "noItemsFound": "No items found",
       "missingTemplateName": "Template name cannot be blank.",
       "loadingError": "Error loading templates. Please try again later."
-    }
+    },
+    "loadMoreTemplates": "Load more templates",
+    "loadMoreSearchResults": "Load more search results"
   },
   "TemplateSelectListItem": {
     "messages": {

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -14,7 +14,8 @@
     "linkExpand": "Expand",
     "linkCollapse": "Collapse",
     "details": "details",
-    "additionalInfo": "Additional information goes here..."
+    "additionalInfo": "Additional information goes here...",
+    "templateList": "List of templates"
   },
   "EditTemplates": {
     "title": "Edit template",


### PR DESCRIPTION
## Description

There are pages that are still only getting 20 results back since the backend started providing `paginationOptions`.

The `Org Templates` page is one page that needed to be updated.

- Updated `/template` page to use new `cursor pagination` because it was only ever getting `20` results.

Fixes # ([812](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/812))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested and tested with updated unit tests.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
