### PR TITLE
Moved sanitize-html to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - Removed research outputs, including related pages and routes, from the demp overview [#764](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/764)
 
 ### Fixed
+- Moved `sanitize-html` to `dependencies` now that we're removing the devDependencies in build pipeline [#823]
 - Updated `package-lock.json` to fix an issue where `npm install` was broken due to newly `pegged` packages: [#823]
   - Ran `npm install @apollo/experimental-nextjs-app-support@0.12.2 react@19 react-dom@19` to fix
   - Removed unused `@fontsource/material-symbols-outlined`

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react": "19.1.1",
         "react-aria-components": "1.10.1",
         "react-dom": "19.1.1",
+        "sanitize-html": "2.17.0",
         "tinymce": "7.9.1",
         "zod": "3.24.4"
       },
@@ -65,7 +66,6 @@
         "jest-axe": "10.0.0",
         "jest-environment-jsdom": "30.0.0",
         "prettier": "3.6.2",
-        "sanitize-html": "2.17.0",
         "sass": "1.89.2",
         "ts-node": "10.9.2",
         "typescript": "5.8.3"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react": "19.1.1",
     "react-aria-components": "1.10.1",
     "react-dom": "19.1.1",
+    "sanitize-html": "2.17.0",
     "tinymce": "7.9.1",
     "zod": "3.24.4"
   },
@@ -80,7 +81,6 @@
     "jest-axe": "10.0.0",
     "jest-environment-jsdom": "30.0.0",
     "prettier": "3.6.2",
-    "sanitize-html": "2.17.0",
     "sass": "1.89.2",
     "ts-node": "10.9.2",
     "typescript": "5.8.3"


### PR DESCRIPTION
## Description

Now that we are no longer including devDependencies in our build, we got an error during the build that `sanitize-html` was missing.

- I moved `sanitize-html` to dependencies where it belongs

Fixes # ([823](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/823))

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Existing unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
