### PR TITLE
Fixed issue in Dockerfile.dev where package-lock.json was not being copied over and breaking build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Removed research outputs, including related pages and routes, from the demp overview [#764](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/764)
 
 ### Fixed
+- Fixed issue in `Dockerfile.dev` where `package-lock.json` was not being copied over and breaking build.
 - Moved `sanitize-html` to `dependencies` now that we're removing the devDependencies in build pipeline [#823]
 - Updated `package-lock.json` to fix an issue where `npm install` was broken due to newly `pegged` packages: [#823]
   - Ran `npm install @apollo/experimental-nextjs-app-support@0.12.2 react@19 react-dom@19` to fix

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,7 +15,7 @@ RUN apk add --no-cache bash curl
 
 # Copy package.json and package-lock.json
 # to the /app working directory
-COPY package.json ./
+COPY package*.json ./
 
 # Install dependencies in /app
 RUN npm ci


### PR DESCRIPTION

## Description

Error occurred in the docker build due to the recent change to use `npm ci` and not copying over `package-lock.json`.

- Updated `Dockerfile.dev` to copy package-lock.json

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
