### PR TITLE
Update signup to gray out email field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Added description to project search page [#761](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/761)
 
 ### Updated
+- Updated `/signup` form so that the `email` field is grayed out on step 2, and added a `Back` button on step 2 [#769]
 - Updated the `/template/create` page to use the new `offset pagination` functionality for both template sections [#817]
 - Updated the `/template` page to use the new `cursor pagination` functionality, because it was only ever loading 20 results [#812]
 - Added Admin section translations to both English (`messages/en-US/global.json`) and Portuguese (`messages/pt-BR/global.json`) language files

--- a/app/[locale]/signup/page.tsx
+++ b/app/[locale]/signup/page.tsx
@@ -93,6 +93,11 @@ const SignUpPage: React.FC = () => {
   const [termsAccepted, setTermsAccepted] = useState<boolean>(false);
   const { suggestions, handleSearch } = useAffiliationSearch();
 
+
+  const returnToEmail = () => {
+    setStep("email");
+  };
+
   async function handleSignUp() {
     setIsWorking(true);
     setErrors([]);
@@ -322,6 +327,7 @@ const SignUpPage: React.FC = () => {
                 onChange={setEmail}
                 value={email}
                 isRequired
+                isDisabled={true}
               >
                 <Label>{t('emailAddress')}</Label>
                 <Input />
@@ -381,13 +387,18 @@ const SignUpPage: React.FC = () => {
             )}
 
             {(step === "profile") && (
-              <Button
-                type="submit"
-                isDisabled={(isWorking || !termsAccepted)}
-                data-testid="signup"
-              >
-                {isWorking ? t('signingUp') + ' ...' : t('submitSignup')}
-              </Button>
+              <>
+                <div className="button-container">
+                  <Button type="submit" className="secondary" onPress={returnToEmail}>{globalT('buttons.back')}</Button>
+                  <Button
+                    type="submit"
+                    isDisabled={(isWorking || !termsAccepted)}
+                    data-testid="signup"
+                  >
+                    {isWorking ? t('signingUp') + ' ...' : t('submitSignup')}
+                  </Button>
+                </div>
+              </>
             )}
           </ToolbarContainer>
 
@@ -399,7 +410,7 @@ const SignUpPage: React.FC = () => {
           )}
         </Form>
       </ContentContainer>
-    </LayoutContainer>
+    </LayoutContainer >
   );
 }
 

--- a/app/[locale]/signup/signup.module.scss
+++ b/app/[locale]/signup/signup.module.scss
@@ -1,4 +1,5 @@
 
+
 .signupPage {
   display: flex;
   flex-direction:column;

--- a/app/[locale]/template/__mocks__/templateListPage.mocks.ts
+++ b/app/[locale]/template/__mocks__/templateListPage.mocks.ts
@@ -108,6 +108,62 @@ export const mocks = [
       },
     },
   },
+  {
+    request: {
+      query: TemplatesDocument,
+      variables: {
+        paginationOptions: {
+          limit: 5,
+          type: "CURSOR",
+          cursor: 1,
+        },
+        term: 'missing',
+      },
+    },
+    result: {
+      data: {
+        myTemplates: {
+          totalCount: 2,
+          nextCursor: null,
+          availableSortFields: {},
+          currentOffset: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          limit: 5,
+          items: [{
+            name: 'UCOP',
+            description: 'University of California Office of the President',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          },
+          {
+            name: 'CDL',
+            description: 'California Digital Library',
+            modified: '2024-11-20 00:00:00',
+            modifiedByName: 'Test User',
+            latestPublishVisibility: 'ORGANIZATION',
+            latestPublishVersion: 'v1',
+            latestPublishDate: '2024-11-20 00:00:00',
+            id: 1,
+            ownerId: 'http://example.com/user/1',
+            ownerDisplayName: 'Test Affiliation',
+            modifiedById: 1,
+            isDirty: false,
+            bestPractice: false
+          }]
+        }
+      },
+    },
+  },
   // Search mock for 'UCOP'
   {
     request: {

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -328,7 +328,7 @@
         "placeholder": "Enter name"
       },
       "departmentAbbr": {
-        "label": "Abbreviated name", 
+        "label": "Abbreviated name",
         "placeholder": "Enter abbreviation"
       }
     },
@@ -434,7 +434,8 @@
       "close": "Close",
       "loadMore": "Load more",
       "addAnother": "Add another",
-      "goToProject": "Go to project"
+      "goToProject": "Go to project",
+      "back": "Back"
     },
     "labels": {
       "searchByKeyword": "Search by keyword",

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -327,7 +327,7 @@
         "placeholder": "Digite o nome do departamento"
       },
       "departmentAbbr": {
-        "label": "Nome abreviado do departamento", 
+        "label": "Nome abreviado do departamento",
         "placeholder": "Digite a abreviação"
       }
     },
@@ -431,7 +431,8 @@
       "preview": "Pré-visualizar",
       "publish": "Publicar",
       "close": "Fechar",
-      "loadMore": "Carregar mais"
+      "loadMore": "Carregar mais",
+      "back": "Voltar"
     },
     "labels": {
       "searchByKeyword": "Pesquisar por palavra-chave",

--- a/styles/form/_button.scss
+++ b/styles/form/_button.scss
@@ -266,14 +266,7 @@ button.small {
   // Button container for two buttons
   .button-container {
     display: flex;
-    gap: 8px; // Space between buttons
+    gap: 10px; // Space between buttons
     align-items: flex-start;
-    
-    // Mobile styles
-    margin-top: 8px;
-    align-self: flex-end; // Right-align on mobile
-    
-    @include r.device(md) {
-      margin-top: 24px; // Align with the input field's bottom
-    }
+  
   }

--- a/styles/form/_button.scss
+++ b/styles/form/_button.scss
@@ -1,3 +1,5 @@
+@use '@/styles/responsive' as r;
+
 @mixin button-base {
   display: inline-flex;
   padding: 8px 16px;
@@ -260,3 +262,18 @@ button.small {
   border-radius: 0.5rem;
   font-size: 0.75rem;
 }
+
+  // Button container for two buttons
+  .button-container {
+    display: flex;
+    gap: 8px; // Space between buttons
+    align-items: flex-start;
+    
+    // Mobile styles
+    margin-top: 8px;
+    align-self: flex-end; // Right-align on mobile
+    
+    @include r.device(md) {
+      margin-top: 24px; // Align with the input field's bottom
+    }
+  }


### PR DESCRIPTION
## Description

- Updated the `/signup` page to gray out/disable the `email` field on step 2, so that the email value doesn't inadvertently change when the user starts adding their first and last name.
- Added a `Back` button on step 2, so that a user has the ability to go back and change their email address
- Added unit tests
- Fixed console warning regarding missing mock in a unit test for `/template`

Fixes # ([769](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/769))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and tested with new unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screen recording
- Note that the email field is grayed out on the profile form
- Note the new `Back` button that will take user back to Step 1 to change their email address

https://github.com/user-attachments/assets/c57e2ee6-a329-48d3-bdac-aee0c3b4b310

