### PR TITLE
Updated ResearchDomainCascadingDropdown to not required research domain fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Removed research outputs, including related pages and routes, from the demp overview [#764](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/764)
 
 ### Fixed
+- Updated `ResearchDomainCascadingDropdown` to not require Research domain fields [#763] 
 - Added missing `relatedWorks` translation keys since it was breaking the pages when locale=pt-BR.
 - Returned changes that were initially part of PR `#816` related to `/template` pagination [#812]
 - Fixed issue in `Dockerfile.dev` where `package-lock.json` was not being copied over and breaking build.

--- a/components/ResearchDomainCascadingDropdown/index.tsx
+++ b/components/ResearchDomainCascadingDropdown/index.tsx
@@ -150,7 +150,6 @@ const ResearchDomainCascadingDropdown: React.FC<CascadingDropdownProps> = ({ pro
       <div className="form-group">
         <FormSelect
           label={ProjectDetail('labels.researchDomain')}
-          isRequired
           name="researchDomain"
           items={rDomains}
           selectClasses={styles.researchDomainSelect}
@@ -170,7 +169,6 @@ const ResearchDomainCascadingDropdown: React.FC<CascadingDropdownProps> = ({ pro
       <div className="form-group">
         <FormSelect
           label={(selectedParent && myResearchDomains?.topLevelResearchDomains) ? ProjectDetail('labels.childDomain', { name: selectedParentDomain?.description || '' }) : ProjectDetail('labels.item')}
-          isRequired
           isDisabled={isChildDisabled}
           name="childDomain"
           items={childOptionsList}


### PR DESCRIPTION

## Description

- Removed `isRequired` from the research domain fields since users should be able to submit the form without completing those fields.

Fixes # ([763](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/763))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested and tested with existing unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
