### PR TITLE
Updated description text on 'template/[templateId]/access' page and visibility text on Publish modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Added description to project search page [#761](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/761)
 
 ### Updated
+- Updated description on `template/[templateId]/access` and visibility text on template publish modal [#482]
 - Updated `/signup` form so that the `email` field is grayed out on step 2, and added a `Back` button on step 2 [#769]
 - Updated the `/template/create` page to use the new `offset pagination` functionality for both template sections [#817]
 - Updated the `/template` page to use the new `cursor pagination` functionality, because it was only ever loading 20 results [#812]

--- a/app/[locale]/template/[templateId]/access/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/access/__tests__/page.spec.tsx
@@ -80,7 +80,6 @@ describe('TemplateAccessPage', () => {
 
   it('renders the main content', () => {
     render(<TemplateAccessPage />);
-    expect(screen.getByText('intro')).toBeInTheDocument();
     expect(screen.getByText('headings.h3OrgAccess')).toBeInTheDocument();
     expect(screen.getByText('paragraphs.orgAccessPara1')).toBeInTheDocument();
     expect(screen.getByText('paragraphs.orgAccessPara2')).toBeInTheDocument();

--- a/app/[locale]/template/[templateId]/access/page.tsx
+++ b/app/[locale]/template/[templateId]/access/page.tsx
@@ -246,7 +246,7 @@ const TemplateAccessPage: React.FC = () => {
     <div>
       <PageHeader
         title={AccessPage('title')}
-        description=""
+        description={AccessPage('intro', { orgName: organization?.name ?? '' })}
         showBackButton={false}
         breadcrumbs={
           <Breadcrumbs>
@@ -266,9 +266,6 @@ const TemplateAccessPage: React.FC = () => {
           <div className="template-editor-container" ref={errorRef}>
             <div className="main-content">
               <ErrorMessages errors={errorMessages} ref={errorRef} />
-              <p>
-                {AccessPage('intro', { orgName: organization?.name ?? '' })}
-              </p>
               <section className="sectionContainer"
                 aria-labelledby="org-access-heading">
                 <div className={`sectionHeader  mt-0`}>

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -75,8 +75,8 @@
     "radioBtn": {
       "public": "Public",
       "organizationOnly": "Organization only",
-      "publicHelpText": "This will be available and discoverable by plan builders.",
-      "orgOnlyHelpText": "Only your organization will be able to view and use this template."
+      "publicHelpText": "This template can be used by all plan writers.",
+      "orgOnlyHelpText": "Only plan writers from your organization will be able to view and use this template."
     },
     "descPublishedTemplate": "You can control who can use this published template.",
     "bullet": {
@@ -376,7 +376,7 @@
   },
   "TemplateAccessPage": {
     "title": "Manage access",
-    "intro": "This template is accessible to everyone at {orgName} with full view and edit permissions. It can also be shared with people outside your organization.",
+    "intro": "This template is editable by everyone at {orgName}. It can also be shared with people outside your organization to allow them edit access.",
     "headings": {
       "h3OrgAccess": "Within organization",
       "externalPeople": "External people",

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -75,8 +75,8 @@
     "radioBtn": {
       "public": "Público",
       "organizationOnly": "Apenas organização",
-      "publicHelpText": "Isto estará disponível e disponível pelos construtores do plano.",
-      "orgOnlyHelpText": "Somente sua organização poderá ver e usar esse modelo."
+      "publicHelpText": "Este modelo pode ser usado por todos os redatores de planos.",
+      "orgOnlyHelpText": "Somente redatores de planos de sua organização poderão ver e usar este modelo."
     },
     "descPublishedTemplate": "Você pode controlar quem pode usar este modelo publicado.",
     "bullet": {
@@ -376,7 +376,7 @@
   },
   "TemplateAccessPage": {
     "title": "Gerenciar acesso",
-    "intro": "Este modelo é acessível para todos no NSF com visualização completa e edição de permissões. Ele também pode ser compartilhado com pessoas fora da sua organização.",
+    "intro": "Este modelo pode ser editado por todos em {orgName}. Ele também pode ser compartilhado com pessoas fora da sua organização para permitir que elas tenham acesso de edição.",
     "headings": {
       "h3OrgAccess": "Dentro da organização",
       "externalPeople": "Pessoas externas",


### PR DESCRIPTION

## Description

Per the requirements:
- I updated the `description` text on the `Manage Access` page to `This template is editable by everyone at California Digital Library. It can also be shared with people outside your organization to allow them edit access.` and moved it from the main content to the page header.
- I updated the 'visibility' text for the template publish modal to `This template can be used by all plan writers.` for `Public` and `Only plan writers from your organization will be able to view and use this template.` for `Organization`.
- Updated a unit test

Fixes # ([482](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/482))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manual testing and testing with existing unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
