### PR TITLE
Ae 503 required field styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
 - Added missing `planId` from the `PlanFundings` errors [#322](https://github.com/CDLUC3/dmsp_backend_prototype/issues/322)
 - Added descriptive text to the funding-search page [#760](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/760)
 - Added description to project search page [#761](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/761)
+- Required field indicators to FormInput, FormTextArea, FormSelect, RadioGroup, CheckboxGroup, and TypeAheadWithOther components [#503]
+- Added test suites for CheckboxGroup and RadioGroup components that seemed to be missing [#503]
+- Interactive form examples to the styleguide showing required and non-required
+  states [#503]
+
 
 ### Updated
 - Updated description on `template/[templateId]/access` and visibility text on template publish modal [#482]

--- a/app/[locale]/account/profile/page.tsx
+++ b/app/[locale]/account/profile/page.tsx
@@ -455,7 +455,7 @@ const ProfilePage: React.FC = () => {
                             label={t('institution')}
                             fieldName="institution"
                             setOtherField={setOtherField}
-                            required={true}
+                            isRequired={true}
                             error={errors['affiliationId'] ?? ''}
                             helpText={t('helpTextSearchForInstitution')}
                             updateFormData={updateAffiliationFormData}

--- a/app/[locale]/admin/organization-details/__tests__/page.spec.tsx
+++ b/app/[locale]/admin/organization-details/__tests__/page.spec.tsx
@@ -76,10 +76,10 @@ describe('OrganizationDetailsPage', () => {
     render(<OrganizationDetailsPage />);
 
     // Check that required form inputs are present
-    expect(screen.getByLabelText('fields.organizationName.label')).toBeInTheDocument();
-    expect(screen.getByLabelText('fields.organizationAbbr.label')).toBeInTheDocument();
-    expect(screen.getByLabelText('fields.contactEmail.label')).toBeInTheDocument();
-    expect(screen.getByLabelText('fields.linkText.label')).toBeInTheDocument();
+    expect(screen.getByLabelText(/fields.organizationName.label/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/fields.organizationAbbr.label/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/fields.contactEmail.label/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/fields.linkText.label/)).toBeInTheDocument();
   });
 
   it('should render disabled identifier fields correctly', () => {
@@ -106,14 +106,14 @@ describe('OrganizationDetailsPage', () => {
   // Form Submission
   it('should have form element present', () => {
     render(<OrganizationDetailsPage />);
-    
+
     const form = document.querySelector('form');
     expect(form).toBeInTheDocument();
   });
 
   it('should have save button that submits the form', () => {
     render(<OrganizationDetailsPage />);
-    
+
     const saveButton = screen.getByRole('button', { name: 'buttons.save' });
     expect(saveButton).toBeInTheDocument();
     expect(saveButton).toHaveAttribute('type', 'submit');
@@ -121,14 +121,14 @@ describe('OrganizationDetailsPage', () => {
 
   it('should handle form submission when save button is clicked', () => {
     render(<OrganizationDetailsPage />);
-    
+
     const saveButton = screen.getByRole('button', { name: 'buttons.save' });
     const form = document.querySelector('form');
-    
+
     // Verify both form and button exist
     expect(form).toBeInTheDocument();
     expect(saveButton).toBeInTheDocument();
-    
+
     // Test that the button is properly configured
     expect(saveButton).toHaveAttribute('type', 'submit');
   });
@@ -136,31 +136,31 @@ describe('OrganizationDetailsPage', () => {
   // Form Interactions and State Changes
   it('should handle organization URL additions and removals', async () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Test adding URLs
     const addButton = screen.getByText('actions.addAnotherUrl');
     fireEvent.click(addButton);
-    
+
     // Should now have 2 URL fields
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(2);
-    
+
     // Test removing URLs
     const removeButtons = screen.getAllByText('actions.removeUrl');
     fireEvent.click(removeButtons[0]);
-    
+
     // Should be back to 1 URL field
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(1);
   });
 
   it('should handle URL field changes', async () => {
     render(<OrganizationDetailsPage />);
-    
+
     const urlInput = screen.getByLabelText('fields.url.label');
     const labelInput = screen.getByLabelText('fields.urlLinkText.label');
-    
+
     fireEvent.change(urlInput, { target: { value: 'https://example.com' } });
     fireEvent.change(labelInput, { target: { value: 'Example Site' } });
-    
+
     expect(urlInput).toHaveValue('https://example.com');
     expect(labelInput).toHaveValue('Example Site');
   });
@@ -168,37 +168,37 @@ describe('OrganizationDetailsPage', () => {
   // Edge Cases and Limits
   it('should not allow more than 5 URLs', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Start with 1 URL, add 4 more to reach limit of 5
     for (let i = 0; i < 4; i++) {
       const addButton = screen.getByText('actions.addAnotherUrl');
       expect(addButton).toBeInTheDocument(); // Button should exist before clicking
       fireEvent.click(addButton);
     }
-    
+
     // Should now have 5 URL fields
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(5);
-    
+
     // Should not be able to add more (button should disappear)
     expect(screen.queryByText('actions.addAnotherUrl')).not.toBeInTheDocument();
   });
 
   it('should not allow removing the last URL', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Should not show remove button when only 1 URL exists
     expect(screen.queryByText('actions.removeUrl')).not.toBeInTheDocument();
   });
 
   it('should show remove button only when multiple URLs exist', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Initially no remove button
     expect(screen.queryByText('actions.removeUrl')).not.toBeInTheDocument();
-    
+
     // Add a URL
     fireEvent.click(screen.getByText('actions.addAnotherUrl'));
-    
+
     // Now should show remove buttons
     expect(screen.getAllByText('actions.removeUrl')).toHaveLength(2);
   });
@@ -206,34 +206,34 @@ describe('OrganizationDetailsPage', () => {
   // State Management
   it('should update organization URLs state correctly', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Test initial state
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(1);
-    
+
     // Test state after adding URL
     const addButton = screen.getByText('actions.addAnotherUrl');
     fireEvent.click(addButton);
-    
+
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(2);
   });
 
   it('should maintain URL values when adding/removing', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Fill first URL
     const urlInput = screen.getByLabelText('fields.url.label');
     fireEvent.change(urlInput, { target: { value: 'https://first.com' } });
-    
+
     // Add second URL
     fireEvent.click(screen.getByText('actions.addAnotherUrl'));
-    
+
     // First URL should still have its value
     expect(urlInput).toHaveValue('https://first.com');
-    
+
     // Remove first URL
     const removeButtons = screen.getAllByText('actions.removeUrl');
     fireEvent.click(removeButtons[0]);
-    
+
     // Should still have one URL field
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(1);
   });
@@ -241,46 +241,46 @@ describe('OrganizationDetailsPage', () => {
   // Form Input Handling
   it('should handle all form input changes', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Organization details
-    const nameInput = screen.getByLabelText('fields.organizationName.label');
-    const abbrInput = screen.getByLabelText('fields.organizationAbbr.label');
-    
+    const nameInput = screen.getByLabelText(/fields.organizationName.label/);
+    const abbrInput = screen.getByLabelText(/fields.organizationAbbr.label/);
+
     fireEvent.change(nameInput, { target: { value: 'Test Organization' } });
     fireEvent.change(abbrInput, { target: { value: 'TO' } });
-    
+
     expect(nameInput).toHaveValue('Test Organization');
     expect(abbrInput).toHaveValue('TO');
-    
+
     // Contact details
-    const emailInput = screen.getByLabelText('fields.contactEmail.label');
-    const linkTextInput = screen.getByLabelText('fields.linkText.label');
-    
+    const emailInput = screen.getByLabelText(/fields.contactEmail.label/);
+    const linkTextInput = screen.getByLabelText(/fields.linkText.label/);
+
     fireEvent.change(emailInput, { target: { value: 'contact@test.org' } });
     fireEvent.change(linkTextInput, { target: { value: 'Contact Us' } });
-    
+
     expect(emailInput).toHaveValue('contact@test.org');
     expect(linkTextInput).toHaveValue('Contact Us');
   });
 
   it('should handle URL field changes for multiple URLs', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Add a second URL
     fireEvent.click(screen.getByText('actions.addAnotherUrl'));
-    
+
     // Get both URL inputs
-    const urlInputs = screen.getAllByLabelText('fields.url.label');
-    const labelInputs = screen.getAllByLabelText('fields.urlLinkText.label');
-    
+    const urlInputs = screen.getAllByLabelText(/fields.url.label/);
+    const labelInputs = screen.getAllByLabelText(/fields.urlLinkText.label/);
+
     // Change first URL
     fireEvent.change(urlInputs[0], { target: { value: 'https://first.com' } });
     fireEvent.change(labelInputs[0], { target: { value: 'First Site' } });
-    
+
     // Change second URL
     fireEvent.change(urlInputs[1], { target: { value: 'https://second.com' } });
     fireEvent.change(labelInputs[1], { target: { value: 'Second Site' } });
-    
+
     expect(urlInputs[0]).toHaveValue('https://first.com');
     expect(labelInputs[0]).toHaveValue('First Site');
     expect(urlInputs[1]).toHaveValue('https://second.com');
@@ -290,28 +290,28 @@ describe('OrganizationDetailsPage', () => {
   // File Handling (Basic)
   it('should handle file drop events', () => {
     render(<OrganizationDetailsPage />);
-    
+
     const dropZone = screen.getByLabelText('upload.dropZone.ariaLabel');
     expect(dropZone).toBeInTheDocument();
-    
+
     // Test that the drop zone is properly configured
     expect(dropZone).toHaveAttribute('aria-label');
-    
+
     // Note: Testing actual file drop behavior with React Aria components
     // requires more complex mocking. This test verifies the component is rendered.
   });
 
   it('should handle file selection via FileTrigger', () => {
     render(<OrganizationDetailsPage />);
-    
+
     const browseButton = screen.getByText('upload.browseButton');
-    
+
     // Test that the button is present and clickable
     expect(browseButton).toBeInTheDocument();
-    
+
     // Test button click (FileTrigger behavior is complex to mock in tests)
     fireEvent.click(browseButton);
-    
+
     // Verify the button is still functional
     expect(browseButton).toBeInTheDocument();
   });
@@ -319,7 +319,7 @@ describe('OrganizationDetailsPage', () => {
   // Component Behavior
   it('should render all form sections correctly', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Check all sections are present
     expect(screen.getByText('sections.organizationDetails.title')).toBeInTheDocument();
     expect(screen.getByText('sections.administratorContact.title')).toBeInTheDocument();
@@ -330,7 +330,7 @@ describe('OrganizationDetailsPage', () => {
 
   it('should show correct number of URL fields initially', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Should start with 1 URL field
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(1);
     expect(screen.getAllByLabelText('fields.urlLinkText.label')).toHaveLength(1);
@@ -338,27 +338,27 @@ describe('OrganizationDetailsPage', () => {
 
   it('should handle URL removal correctly', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Add a URL first
     fireEvent.click(screen.getByText('actions.addAnotherUrl'));
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(2);
-    
+
     // Remove the first URL
     const removeButtons = screen.getAllByText('actions.removeUrl');
     fireEvent.click(removeButtons[0]);
-    
+
     // Should be back to 1 URL
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(1);
   });
 
-  
+
   it('should render upload section with all elements', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Check upload section elements
     expect(screen.getByText('upload.fileTypes')).toBeInTheDocument();
     expect(screen.getByText('upload.browseButton')).toBeInTheDocument();
-    
+
     // Check SVG icon is present
     const uploadIcon = document.querySelector('svg');
     expect(uploadIcon).toBeInTheDocument();
@@ -366,17 +366,17 @@ describe('OrganizationDetailsPage', () => {
 
   it('should render request change buttons for identifiers', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Check all request change buttons are present
     // There are 5 total: 1 in organization type (Link) + 4 in identifiers (Buttons)
     const requestChangeButtons = screen.getAllByText('actions.requestChange');
     expect(requestChangeButtons).toHaveLength(5);
-    
+
     // The Link component doesn't have aria-label, but the Button components do
     // Let's check that the identifiers section buttons (which should be the last 4) have aria-labels
     const buttonElements = requestChangeButtons.filter(el => el.tagName === 'BUTTON');
     expect(buttonElements).toHaveLength(4);
-    
+
     // Verify that all button elements have aria-label attributes
     buttonElements.forEach(button => {
       expect(button).toHaveAttribute('aria-label');
@@ -385,63 +385,63 @@ describe('OrganizationDetailsPage', () => {
 
   it('should handle multiple URL additions and removals', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Add multiple URLs (but not more than 5)
     fireEvent.click(screen.getByText('actions.addAnotherUrl')); // 2 total
     fireEvent.click(screen.getByText('actions.addAnotherUrl')); // 3 total
     fireEvent.click(screen.getByText('actions.addAnotherUrl')); // 4 total
-    
+
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(4);
-    
+
     // Remove some URLs
     const removeButtons = screen.getAllByText('actions.removeUrl');
     expect(removeButtons).toHaveLength(4); // Should have 4 remove buttons for 4 URLs
-    
+
     // Remove first URL
     fireEvent.click(removeButtons[0]);
-    
+
     // Check that we now have 3 URLs (4 - 1 = 3)
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(3);
-    
+
     // Remove another URL
     const remainingRemoveButtons = screen.getAllByText('actions.removeUrl');
     fireEvent.click(remainingRemoveButtons[0]);
-    
+
     // Check that we now have 2 URLs (3 - 1 = 2)
     expect(screen.getAllByLabelText('fields.url.label')).toHaveLength(2);
   });
 
   it('should maintain form state across all input types', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Test organization name input
-    const nameInput = screen.getByLabelText('fields.organizationName.label');
+    const nameInput = screen.getByLabelText(/fields.organizationName.label/);
     fireEvent.change(nameInput, { target: { value: 'Test Org' } });
     expect(nameInput).toHaveValue('Test Org');
-    
+
     // Test abbreviation input
-    const abbrInput = screen.getByLabelText('fields.organizationAbbr.label');
+    const abbrInput = screen.getByLabelText(/fields.organizationAbbr.label/);
     fireEvent.change(abbrInput, { target: { value: 'TO' } });
     expect(abbrInput).toHaveValue('TO');
-    
+
     // Test email input
-    const emailInput = screen.getByLabelText('fields.contactEmail.label');
+    const emailInput = screen.getByLabelText(/fields.contactEmail.label/);
     fireEvent.change(emailInput, { target: { value: 'test@org.com' } });
     expect(emailInput).toHaveValue('test@org.com');
-    
+
     // Test link text input
-    const linkTextInput = screen.getByLabelText('fields.linkText.label');
+    const linkTextInput = screen.getByLabelText(/fields.linkText.label/);
     fireEvent.change(linkTextInput, { target: { value: 'Contact' } });
     expect(linkTextInput).toHaveValue('Contact');
   });
 
   it('should render all form inputs with correct attributes', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Check required inputs have proper attributes
-    const nameInput = screen.getByLabelText('fields.organizationName.label');
-    const emailInput = screen.getByLabelText('fields.contactEmail.label');
-    
+    const nameInput = screen.getByLabelText(/fields.organizationName.label/);
+    const emailInput = screen.getByLabelText(/fields.contactEmail.label/);
+
     expect(nameInput).toHaveAttribute('placeholder');
     expect(emailInput).toHaveAttribute('type', 'email');
     expect(emailInput).toHaveAttribute('placeholder');
@@ -449,22 +449,22 @@ describe('OrganizationDetailsPage', () => {
 
   it('should handle edge case of URL field with empty values', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Add a URL
     fireEvent.click(screen.getByText('actions.addAnotherUrl'));
-    
+
     // Get the new URL fields
     const urlInputs = screen.getAllByLabelText('fields.url.label');
     const labelInputs = screen.getAllByLabelText('fields.urlLinkText.label');
-    
+
     // Test that new fields start empty
     expect(urlInputs[1]).toHaveValue('');
     expect(labelInputs[1]).toHaveValue('');
-    
+
     // Fill them with values
     fireEvent.change(urlInputs[1], { target: { value: 'https://test.com' } });
     fireEvent.change(labelInputs[1], { target: { value: 'Test Site' } });
-    
+
     // Verify values are set
     expect(urlInputs[1]).toHaveValue('https://test.com');
     expect(labelInputs[1]).toHaveValue('Test Site');
@@ -472,19 +472,19 @@ describe('OrganizationDetailsPage', () => {
 
   it('should render sidebar panel', () => {
     render(<OrganizationDetailsPage />);
-    
+
     // Check sidebar is present (even if empty)
     // Look for the SidebarPanel component by checking if it's rendered
-    const sidebar = document.querySelector('[class*="SidebarPanel"]') || 
+    const sidebar = document.querySelector('[class*="SidebarPanel"]') ||
                    document.querySelector('[class*="sidebar"]') ||
                    document.querySelector('aside');
-    
+
     // If we can't find it by class, check if the component structure exists
     if (!sidebar) {
       // Check if the layout structure exists
       const contentContainer = document.querySelector('[class*="ContentContainer"]');
       expect(contentContainer).toBeInTheDocument();
-      
+
       // Check if there's a form (which means the main content is there)
       const form = document.querySelector('form');
       expect(form).toBeInTheDocument();

--- a/app/[locale]/projects/[projectId]/collaboration/invite/page.tsx
+++ b/app/[locale]/projects/[projectId]/collaboration/invite/page.tsx
@@ -247,7 +247,7 @@ const ProjectsProjectCollaborationInvite = () => {
                   type="email"
                   value={state.email}
                   onChange={handleInputChange}
-                  aria-required="true"
+                  isRequired={true}
                   label={t('formLabels.email')}
                   placeholder={t('placeHolders.email')}
                   isInvalid={!state.emailError ? false : true}
@@ -340,4 +340,3 @@ const ProjectsProjectCollaborationInvite = () => {
 };
 
 export default ProjectsProjectCollaborationInvite;
-

--- a/app/[locale]/projects/[projectId]/fundings/[projectFundingId]/edit/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/[projectFundingId]/edit/__tests__/page.spec.tsx
@@ -87,7 +87,7 @@ describe('ProjectsProjectFundingEdit', () => {
     });
 
     expect(screen.getByLabelText('labels.funderName')).toBeInTheDocument();
-    expect(screen.getByLabelText('labels.fundingStatus')).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.fundingStatus/)).toBeInTheDocument();
     // Find the "denied" text within a <span> element
     const deniedSpan = screen.getByText((content, element) => {
       return element?.tagName.toLowerCase() === 'span' && content === 'denied';
@@ -109,8 +109,8 @@ describe('ProjectsProjectFundingEdit', () => {
     expect(options[3]).toHaveTextContent('granted');
 
     expect(screen.getByText('labels.grantNumber')).toBeInTheDocument();
-    expect(screen.getByLabelText('labels.projectNumber')).toBeInTheDocument();
-    expect(screen.getByLabelText('labels.opportunity')).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.projectNumber/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.opportunity/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /buttons.saveChanges/i })).toBeInTheDocument();
 
     // breadcrumbs
@@ -153,7 +153,7 @@ describe('ProjectsProjectFundingEdit', () => {
       );
     });
 
-    const fundingStatusSelect = screen.getByLabelText('labels.fundingStatus');
+    const fundingStatusSelect = screen.getByLabelText(/labels.fundingStatus/);
     fireEvent.change(fundingStatusSelect, { target: { value: 'GRANTED' } });
 
     expect(fundingStatusSelect).toHaveValue('GRANTED');
@@ -171,7 +171,7 @@ describe('ProjectsProjectFundingEdit', () => {
       );
     });
 
-    const grantNumberInput = screen.getByLabelText('labels.grantNumber');
+    const grantNumberInput = screen.getByLabelText(/labels.grantNumber/);
     fireEvent.change(grantNumberInput, { target: { value: 'New-grantNumber-123' } });
 
     expect(grantNumberInput).toHaveValue('New-grantNumber-123');
@@ -189,7 +189,7 @@ describe('ProjectsProjectFundingEdit', () => {
       );
     });
 
-    const projectNumberInput = screen.getByLabelText('labels.projectNumber');
+    const projectNumberInput = screen.getByLabelText(/labels.projectNumber/);
     fireEvent.change(projectNumberInput, { target: { value: 'New-projectNumber-123' } });
 
     expect(projectNumberInput).toHaveValue('New-projectNumber-123');
@@ -208,7 +208,7 @@ describe('ProjectsProjectFundingEdit', () => {
       );
     });
 
-    const opportunityInput = screen.getByLabelText('labels.opportunity');
+    const opportunityInput = screen.getByLabelText(/labels.opportunity/);
     fireEvent.change(opportunityInput, { target: { value: 'New-opportunity-123' } });
 
     expect(opportunityInput).toHaveValue('New-opportunity-123');
@@ -365,7 +365,7 @@ describe('ProjectsProjectFundingEdit', () => {
       );
     });
 
-    const input = screen.getByLabelText("labels.funderName");
+    const input = screen.getByLabelText(/labels.funderName/);
     expect(input).toBeDisabled();
   });
 

--- a/app/[locale]/projects/[projectId]/fundings/add/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/add/page.tsx
@@ -329,7 +329,7 @@ const AddProjectFunderManually = () => {
               label={addFunding('labels.funderName')}
               fieldName="funderName"
               setOtherField={setOtherField}
-              required={true}
+              isRequired={true}
               error={fieldErrors.affiliationId}
               updateFormData={updateAffiliationFormData}
               value={fundingData.affiliationName}

--- a/app/[locale]/projects/[projectId]/project/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/project/__tests__/page.spec.tsx
@@ -94,11 +94,11 @@ describe('ProjectsProjectDetail', () => {
     ]);
     render(<ProjectsProjectDetail />);
 
-    expect(screen.getByLabelText('labels.projectName')).toBeInTheDocument();
-    expect(screen.getByLabelText('labels.projectAbstract')).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.projectName/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.projectAbstract/)).toBeInTheDocument();
     expect(screen.getByText('labels.startDate')).toBeInTheDocument();
     expect(screen.getByText('labels.endDate')).toBeInTheDocument();
-    expect(screen.getByLabelText('labels.researchDomain')).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.researchDomain/)).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 1, name: /title/i })).toBeInTheDocument();
   });
 
@@ -129,7 +129,7 @@ describe('ProjectsProjectDetail', () => {
       { loading: false, error: { message: 'There was an error' } },
     ]);
     render(<ProjectsProjectDetail />);
-    fireEvent.change(screen.getByLabelText('labels.projectName'), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText(/labels.projectName/), { target: { value: '' } });
     fireEvent.submit(screen.getByRole('button', { name: /save/i }));
     const alert = await screen.findByRole('alert');
     expect(alert).toBeInTheDocument();
@@ -149,7 +149,7 @@ describe('ProjectsProjectDetail', () => {
 
 
     render(<ProjectsProjectDetail />);
-    fireEvent.change(screen.getByLabelText('labels.projectName'), { target: { value: 'Updated Project' } });
+    fireEvent.change(screen.getByLabelText(/labels.projectName/), { target: { value: 'Updated Project' } });
     fireEvent.submit(screen.getByRole('button', { name: /save/i }));
 
     expect(mockUpdateProjectMutation).toHaveBeenCalledWith({
@@ -175,7 +175,7 @@ describe('ProjectsProjectDetail', () => {
 
 
     render(<ProjectsProjectDetail />);
-    fireEvent.change(screen.getByLabelText('labels.projectName'), { target: { value: 'Updated Project' } });
+    fireEvent.change(screen.getByLabelText(/labels.projectName/), { target: { value: 'Updated Project' } });
     fireEvent.submit(screen.getByRole('button', { name: /save/i }));
 
     // //Check that error logged
@@ -213,7 +213,7 @@ describe('ProjectsProjectDetail', () => {
     render(<ProjectsProjectDetail />);
 
     act(() => {
-      fireEvent.change(screen.getByLabelText('labels.projectName'), { target: { value: 'Updated Project' } });
+      fireEvent.change(screen.getByLabelText(/labels.projectName/), { target: { value: 'Updated Project' } });
       fireEvent.submit(screen.getByRole('button', { name: /save/i }));
     })
 
@@ -241,7 +241,7 @@ describe('ProjectsProjectDetail', () => {
 
 
     render(<ProjectsProjectDetail />);
-    fireEvent.change(screen.getByLabelText('labels.projectName'), { target: { value: 'Updated Project' } });
+    fireEvent.change(screen.getByLabelText(/labels.projectName/), { target: { value: 'Updated Project' } });
     fireEvent.submit(screen.getByRole('button', { name: /save/i }));
 
     // Assert that refetch was called

--- a/app/[locale]/projects/create-project/page.tsx
+++ b/app/[locale]/projects/create-project/page.tsx
@@ -223,8 +223,7 @@ const ProjectsCreateProject = () => {
               value={formData.projectName}
               label={CreateProject('form.projectTitle')}
               helpMessage={CreateProject('form.projectTitleHelpText')}
-              isRequired={false}
-              ariaRequired={true}
+              isRequiredVisualOnly={true}
               onChange={handleInputChange}
               isInvalid={(!formData.projectName || !!fieldErrors.projectName) && formSubmitted}
               errorMessage={fieldErrors.projectName.length > 0 ? fieldErrors.projectName : CreateProject('messages.errors.title')}

--- a/app/[locale]/projects/create-project/page.tsx
+++ b/app/[locale]/projects/create-project/page.tsx
@@ -223,7 +223,7 @@ const ProjectsCreateProject = () => {
               value={formData.projectName}
               label={CreateProject('form.projectTitle')}
               helpMessage={CreateProject('form.projectTitleHelpText')}
-              isRequiredVisualOnly={true}
+              isRequired={true}
               onChange={handleInputChange}
               isInvalid={(!formData.projectName || !!fieldErrors.projectName) && formSubmitted}
               errorMessage={fieldErrors.projectName.length > 0 ? fieldErrors.projectName : CreateProject('messages.errors.title')}

--- a/app/[locale]/projects/create-project/page.tsx
+++ b/app/[locale]/projects/create-project/page.tsx
@@ -223,7 +223,7 @@ const ProjectsCreateProject = () => {
               value={formData.projectName}
               label={CreateProject('form.projectTitle')}
               helpMessage={CreateProject('form.projectTitleHelpText')}
-              isRequired={true}
+              isRequiredVisualOnly={true}
               onChange={handleInputChange}
               isInvalid={(!formData.projectName || !!fieldErrors.projectName) && formSubmitted}
               errorMessage={fieldErrors.projectName.length > 0 ? fieldErrors.projectName : CreateProject('messages.errors.title')}

--- a/app/[locale]/signup/page.tsx
+++ b/app/[locale]/signup/page.tsx
@@ -296,7 +296,7 @@ const SignUpPage: React.FC = () => {
               <TypeAheadWithOther
                 className={styles.typeAhead}
                 label={t('institution')}
-                required={true}
+                isRequired={true}
                 fieldName="institution"
                 setOtherField={setOtherField}
                 helpText={t('institutionHelp')}

--- a/app/[locale]/styleguide/page.tsx
+++ b/app/[locale]/styleguide/page.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   Cell,
   Checkbox,
-  CheckboxGroup,
   Column,
   Dialog,
   DialogTrigger,
@@ -77,9 +76,11 @@ import TooltipWithDialog from "@/components/TooltipWithDialog";
 import { ModalOverlayComponent } from '@/components/ModalOverlayComponent';
 import ButtonWithImage from '@/components/ButtonWithImage';
 import { useToast } from '@/context/ToastContext';
+import CheckboxGroupComponent from '@/components/Form/CheckboxGroup';
 
 import QuestionPreview from '@/components/QuestionPreview';
 import FunderSearch from '@/components/FunderSearch';
+
 
 function Page() {
   const [otherField, setOtherField] = useState(false);
@@ -1507,37 +1508,7 @@ function Page() {
                 </TextField>
 
 
-                <h3>
-                  Checkboxes
-                </h3>
-
-                <CheckboxGroup>
-                  <Label>Favorite sports</Label>
-                  <Text slot="description" className="help">This is help
-                    text</Text>
-                  <Checkbox value="soccer">
-                    <div className="checkbox">
-                      <svg viewBox="0 0 18 18" aria-hidden="true">
-                        <polyline points="1 9 7 14 15 4" />
-                      </svg>
-                    </div>
-                    Test
-                  </Checkbox>
-                  <Checkbox value="test">
-                    <div className="checkbox">
-                      <svg viewBox="0 0 18 18" aria-hidden="true">
-                        <polyline points="1 9 7 14 15 4" />
-                      </svg>
-                    </div>
-                    Test
-                  </Checkbox>
-
-                </CheckboxGroup>
-
-
-                <h3>
-                  Checkbox
-                </h3>
+                <h3>Checkbox</h3>
                 <Checkbox>
                   <div className="checkbox">
                     <svg viewBox="0 0 18 18" aria-hidden="true">
@@ -1547,9 +1518,82 @@ function Page() {
                   Unsubscribe
                 </Checkbox>
 
-                <h3>
-                  Radio
-                </h3>
+                <h3>CheckboxGroupComponent</h3>
+                <Form>
+                  <CheckboxGroupComponent
+                    checkboxGroupLabel="Favorite sprots"
+                    checkboxGroupDescription="This is help text"
+                  >
+                    <Checkbox value="soccer">
+                      <div className="checkbox">
+                        <svg viewBox="0 0 18 18" aria-hidden="true">
+                          <polyline points="1 9 7 14 15 4" />
+                        </svg>
+                      </div>
+                      Test
+                    </Checkbox>
+                    <Checkbox value="test">
+                      <div className="checkbox">
+                        <svg viewBox="0 0 18 18" aria-hidden="true">
+                          <polyline points="1 9 7 14 15 4" />
+                        </svg>
+                      </div>
+                      Test
+                    </Checkbox>
+                  </CheckboxGroupComponent>
+
+                  <p>The following checkox group is required.</p>
+
+                  <CheckboxGroupComponent
+                    checkboxGroupLabel="Favorite sprots"
+                    checkboxGroupDescription="This is help text"
+                    isRequired={true}
+                  >
+                    <Checkbox value="soccer">
+                      <div className="checkbox">
+                        <svg viewBox="0 0 18 18" aria-hidden="true">
+                          <polyline points="1 9 7 14 15 4" />
+                        </svg>
+                      </div>
+                      Test
+                    </Checkbox>
+                    <Checkbox value="test">
+                      <div className="checkbox">
+                        <svg viewBox="0 0 18 18" aria-hidden="true">
+                          <polyline points="1 9 7 14 15 4" />
+                        </svg>
+                      </div>
+                      Test
+                    </Checkbox>
+                  </CheckboxGroupComponent>
+
+                  <p>The following checkox group is not required, but we still prefer the user set it.</p>
+
+                  <CheckboxGroupComponent
+                    checkboxGroupLabel="Favorite sprots"
+                    checkboxGroupDescription="This is help text"
+                    isRequiredVisualOnly={true}
+                  >
+                    <Checkbox value="soccer">
+                      <div className="checkbox">
+                        <svg viewBox="0 0 18 18" aria-hidden="true">
+                          <polyline points="1 9 7 14 15 4" />
+                        </svg>
+                      </div>
+                      Test
+                    </Checkbox>
+                    <Checkbox value="test">
+                      <div className="checkbox">
+                        <svg viewBox="0 0 18 18" aria-hidden="true">
+                          <polyline points="1 9 7 14 15 4" />
+                        </svg>
+                      </div>
+                      Test
+                    </Checkbox>
+                  </CheckboxGroupComponent>
+                </Form>
+
+                <h3>Radio</h3>
                 <RadioGroup>
                   <Label>Favorite pet</Label>
                   <Text slot="description" className="help">This is help

--- a/app/[locale]/styleguide/page.tsx
+++ b/app/[locale]/styleguide/page.tsx
@@ -76,10 +76,14 @@ import TooltipWithDialog from "@/components/TooltipWithDialog";
 import { ModalOverlayComponent } from '@/components/ModalOverlayComponent';
 import ButtonWithImage from '@/components/ButtonWithImage';
 import { useToast } from '@/context/ToastContext';
-import CheckboxGroupComponent from '@/components/Form/CheckboxGroup';
 
 import QuestionPreview from '@/components/QuestionPreview';
 import FunderSearch from '@/components/FunderSearch';
+import FormInput from '@/components/Form/FormInput';
+import FormTextArea from '@/components/Form/FormTextArea';
+import { FormSelect, MyItem } from '@/components/Form/FormSelect';
+import RadioGroupComponent from '@/components/Form/RadioGroup';
+import CheckboxGroupComponent from '@/components/Form/CheckboxGroup';
 
 
 function Page() {
@@ -87,6 +91,57 @@ function Page() {
   const { suggestions, handleSearch } = useAffiliationSearch();
   const toastState = useToast(); // Access the toast state from context
   const router = useRouter();
+
+  // Form state for styleguide examples
+  const [formData, setFormData] = useState({
+    givenName: '',
+    description: '',
+    notes: '',
+    researchDomain: '1',
+    secondaryDomain: '',
+    dataSharing: 'public',
+    notificationPreference: 'email',
+    dataTypes: ['tabular', 'images'],
+    optionalFeatures: [],
+    institution: '',
+    collaboratingInstitution: ''
+  });
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleCheckboxChange = (field: string, value: string[]) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  function radioOptions(data) {
+    return (
+      <>
+        {data.map((item, i) => (
+          <Radio key={i} value={item.value}>{item.label}</Radio>
+        ))}
+      </>
+    );
+  }
+
+  function checkboxOptions(data) {
+    return (
+      <>
+        {data.map((item, i) => (
+          <Checkbox key={i} value={item.value}>
+            <div className="checkbox">
+              <svg viewBox="0 0 18 18" aria-hidden="true">
+                <polyline points="1 9 7 14 15 4" />
+              </svg>
+            </div>
+            {item.label}
+          </Checkbox>
+        ))}
+      </>
+    );
+  }
+
 
   // NOTE: This text is just for testing the richtext editors
   const html = String.raw;
@@ -1414,6 +1469,161 @@ function Page() {
               </TextField>
             </Example>
 
+            <h3>
+              Using FormInput
+            </h3>
+            <FormInput
+              name="givenName"
+              type="text"
+              label="First name"
+              description="Enter your first name(s), this is how we will address you"
+              placeholder="Your first name"
+              value={formData.givenName}
+              onChange={(e) => handleInputChange('givenName', e.target.value)}
+              isRequired={true}
+            />
+
+            <h3>
+              Using FormTextArea
+            </h3>
+            <FormTextArea
+              name="description"
+              label="Project Description"
+              description="Provide a detailed description of your research project"
+              placeholder="Enter your project description here..."
+              value={formData.description}
+              onChange={(value) => handleInputChange('description', value)}
+              isRequired={true}
+            />
+
+            <FormTextArea
+              name="notes"
+              label="Additional Notes"
+              description="Optional notes or comments about your project"
+              placeholder="Any additional information..."
+              value={formData.notes}
+              onChange={(value) => handleInputChange('notes', value)}
+              isRequired={false}
+            />
+
+            <h3>
+              Using FormSelect
+            </h3>
+            <FormSelect
+              label="Research Domain"
+              items={[
+                { id: '1', name: 'Computer Science' },
+                { id: '2', name: 'Biology' },
+                { id: '3', name: 'Chemistry' },
+                { id: '4', name: 'Physics' }
+              ]}
+              selectedKey={formData.researchDomain}
+              onSelectionChange={(key) => handleInputChange('researchDomain', key as string)}
+              isRequired={true}
+            >
+              {(item) => <MyItem key={item.id}>{item.name}</MyItem>}
+            </FormSelect>
+
+            <FormSelect
+              label="Secondary Domain"
+              items={[
+                { id: '1', name: 'Computer Science' },
+                { id: '2', name: 'Biology' },
+                { id: '3', name: 'Chemistry' },
+                { id: '4', name: 'Physics' }
+              ]}
+              selectedKey={formData.secondaryDomain}
+              onSelectionChange={(key) => handleInputChange('secondaryDomain', key as string)}
+              isRequired={false}
+            >
+              {(item) => <MyItem key={item.id}>{item.name}</MyItem>}
+            </FormSelect>
+
+            <h3>
+              Using RadioGroup
+            </h3>
+            <RadioGroupComponent
+              name="dataSharing"
+              radioGroupLabel="Data Sharing Preference"
+              value={formData.dataSharing}
+              isRequired={true}
+              onChange={(value) => handleInputChange('dataSharing', value)}
+            >
+              {radioOptions([
+                { value: 'public', label: 'Public - Data will be publicly available' },
+                { value: 'restricted', label: 'Restricted - Data access requires approval' },
+                { value: 'private', label: 'Private - Data will remain private' }
+              ])}
+            </RadioGroupComponent>
+
+            <RadioGroupComponent
+              name="notificationPreference"
+              radioGroupLabel="Notification Preference"
+              value={formData.notificationPreference}
+              onChange={(value) => handleInputChange('notificationPreference', value)}
+            >
+              {radioOptions([
+                { value: 'email', label: 'Email notifications'},
+                { value: 'sms', label: 'SMS notifications'},
+                { value: 'none', label: 'No notifications'},
+              ])}
+            </RadioGroupComponent>
+
+            <h3>
+              Using CheckboxGroup
+            </h3>
+
+            <CheckboxGroupComponent
+              name="dataTypes"
+              checkboxGroupLabel="Data Types to be Collected"
+              value={formData.dataTypes}
+              isRequired={true}
+              onChange={(value) => handleCheckboxChange('dataTypes', value)}
+            >
+              {checkboxOptions([
+                { value: 'tabular', label: 'Tabular Data', description: 'Spreadsheets, databases' },
+                { value: 'images', label: 'Images', description: 'Photos, diagrams, charts' },
+                { value: 'documents', label: 'Documents', description: 'Reports, manuscripts' },
+                { value: 'code', label: 'Software Code', description: 'Scripts, applications' }
+              ])}
+            </CheckboxGroupComponent>
+
+            <CheckboxGroupComponent
+              name="optionalFeatures"
+              checkboxGroupLabel="Optional Features"
+              value={formData.optionalFeatures}
+              isRequired={false}
+              onChange={(value) => handleCheckboxChange('optionalFeatures', value)}
+            >
+              {checkboxOptions([
+                { value: 'analytics', label: 'Analytics Dashboard', description: 'Advanced reporting features' },
+                { value: 'export', label: 'Export Options', description: 'Multiple export formats' },
+                { value: 'api', label: 'API Access', description: 'Programmatic access to data' }
+              ])}
+            </CheckboxGroupComponent>
+
+            <h3>
+              Using TypeAheadWithOther
+            </h3>
+            <TypeAheadWithOther
+              label="Institution"
+              fieldName="institution"
+              setOtherField={setOtherField}
+              required={true}
+              helpText="Search for your primary institution"
+              updateFormData={(id, value) => handleInputChange('institution', value)}
+              value={formData.institution}
+            />
+
+            <TypeAheadWithOther
+              label="Collaborating Institution"
+              fieldName="collaboratingInstitution"
+              setOtherField={setOtherField}
+              required={false}
+              helpText="Search for any collaborating institutions (optional)"
+              updateFormData={(id, value) => handleInputChange('collaboratingInstitution', value)}
+              value={formData.collaboratingInstitution}
+            />
 
             <h3>
               Email
@@ -1508,7 +1718,38 @@ function Page() {
                 </TextField>
 
 
-                <h3>Checkbox</h3>
+                <h3>
+                  Checkboxes
+                </h3>
+
+                <CheckboxGroupComponent>
+                  <Label>Favorite sports</Label>
+                  <Text slot="description" className="help">This is help
+                    text</Text>
+                  <Checkbox value="soccer">
+                    <div className="checkbox">
+                      <svg viewBox="0 0 18 18" aria-hidden="true">
+                        <polyline points="1 9 7 14 15 4" />
+                      </svg>
+                    </div>
+                    Test
+                  </Checkbox>
+                  <Checkbox value="test">
+                    <div className="checkbox">
+                      <svg viewBox="0 0 18 18" aria-hidden="true">
+                        <polyline points="1 9 7 14 15 4" />
+                      </svg>
+                    </div>
+                    Test
+                  </Checkbox>
+
+                </CheckboxGroupComponent>
+
+
+                <h3>
+                  Checkbox
+                </h3>
+
                 <Checkbox>
                   <div className="checkbox">
                     <svg viewBox="0 0 18 18" aria-hidden="true">
@@ -1519,81 +1760,32 @@ function Page() {
                 </Checkbox>
 
                 <h3>CheckboxGroupComponent</h3>
-                <Form>
-                  <CheckboxGroupComponent
-                    checkboxGroupLabel="Favorite sprots"
-                    checkboxGroupDescription="This is help text"
-                  >
-                    <Checkbox value="soccer">
-                      <div className="checkbox">
-                        <svg viewBox="0 0 18 18" aria-hidden="true">
-                          <polyline points="1 9 7 14 15 4" />
-                        </svg>
-                      </div>
-                      Test
-                    </Checkbox>
-                    <Checkbox value="test">
-                      <div className="checkbox">
-                        <svg viewBox="0 0 18 18" aria-hidden="true">
-                          <polyline points="1 9 7 14 15 4" />
-                        </svg>
-                      </div>
-                      Test
-                    </Checkbox>
-                  </CheckboxGroupComponent>
 
-                  <p>The following checkox group is required.</p>
+                <CheckboxGroupComponent
+                  checkboxGroupLabel="Favorite sprots"
+                  checkboxGroupDescription="This is help text"
+                >
+                  <Checkbox value="soccer">
+                    <div className="checkbox">
+                      <svg viewBox="0 0 18 18" aria-hidden="true">
+                        <polyline points="1 9 7 14 15 4" />
+                      </svg>
+                    </div>
+                    Test
+                  </Checkbox>
+                  <Checkbox value="test">
+                    <div className="checkbox">
+                      <svg viewBox="0 0 18 18" aria-hidden="true">
+                        <polyline points="1 9 7 14 15 4" />
+                      </svg>
+                    </div>
+                    Test
+                  </Checkbox>
+                </CheckboxGroupComponent>
 
-                  <CheckboxGroupComponent
-                    checkboxGroupLabel="Favorite sprots"
-                    checkboxGroupDescription="This is help text"
-                    isRequired={true}
-                  >
-                    <Checkbox value="soccer">
-                      <div className="checkbox">
-                        <svg viewBox="0 0 18 18" aria-hidden="true">
-                          <polyline points="1 9 7 14 15 4" />
-                        </svg>
-                      </div>
-                      Test
-                    </Checkbox>
-                    <Checkbox value="test">
-                      <div className="checkbox">
-                        <svg viewBox="0 0 18 18" aria-hidden="true">
-                          <polyline points="1 9 7 14 15 4" />
-                        </svg>
-                      </div>
-                      Test
-                    </Checkbox>
-                  </CheckboxGroupComponent>
-
-                  <p>The following checkox group is not required, but we still prefer the user set it.</p>
-
-                  <CheckboxGroupComponent
-                    checkboxGroupLabel="Favorite sprots"
-                    checkboxGroupDescription="This is help text"
-                    isRequiredVisualOnly={true}
-                  >
-                    <Checkbox value="soccer">
-                      <div className="checkbox">
-                        <svg viewBox="0 0 18 18" aria-hidden="true">
-                          <polyline points="1 9 7 14 15 4" />
-                        </svg>
-                      </div>
-                      Test
-                    </Checkbox>
-                    <Checkbox value="test">
-                      <div className="checkbox">
-                        <svg viewBox="0 0 18 18" aria-hidden="true">
-                          <polyline points="1 9 7 14 15 4" />
-                        </svg>
-                      </div>
-                      Test
-                    </Checkbox>
-                  </CheckboxGroupComponent>
-                </Form>
-
-                <h3>Radio</h3>
+                <h3>
+                  Radio
+                </h3>
                 <RadioGroup>
                   <Label>Favorite pet</Label>
                   <Text slot="description" className="help">This is help

--- a/app/[locale]/styleguide/page.tsx
+++ b/app/[locale]/styleguide/page.tsx
@@ -81,7 +81,7 @@ import QuestionPreview from '@/components/QuestionPreview';
 import FunderSearch from '@/components/FunderSearch';
 import FormInput from '@/components/Form/FormInput';
 import FormTextArea from '@/components/Form/FormTextArea';
-import { FormSelect, MyItem } from '@/components/Form/FormSelect';
+import { FormSelect } from '@/components/Form/FormSelect';
 import RadioGroupComponent from '@/components/Form/RadioGroup';
 import CheckboxGroupComponent from '@/components/Form/CheckboxGroup';
 
@@ -115,20 +115,26 @@ function Page() {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
-  function radioOptions(data) {
+  type optionData = {
+    value: string;
+    label: string;
+    description?: string;
+  };
+
+  function radioOptions(data: optionData[]) {
     return (
       <>
-        {data.map((item, i) => (
+        {data.map((item: optionData, i: number) => (
           <Radio key={i} value={item.value}>{item.label}</Radio>
         ))}
       </>
     );
   }
 
-  function checkboxOptions(data) {
+  function checkboxOptions(data: optionData[]) {
     return (
       <>
-        {data.map((item, i) => (
+        {data.map((item: optionData, i: number) => (
           <Checkbox key={i} value={item.value}>
             <div className="checkbox">
               <svg viewBox="0 0 18 18" aria-hidden="true">
@@ -1520,9 +1526,7 @@ function Page() {
               selectedKey={formData.researchDomain}
               onSelectionChange={(key) => handleInputChange('researchDomain', key as string)}
               isRequired={true}
-            >
-              {(item) => <MyItem key={item.id}>{item.name}</MyItem>}
-            </FormSelect>
+            />
 
             <FormSelect
               label="Secondary Domain"
@@ -1535,9 +1539,7 @@ function Page() {
               selectedKey={formData.secondaryDomain}
               onSelectionChange={(key) => handleInputChange('secondaryDomain', key as string)}
               isRequired={false}
-            >
-              {(item) => <MyItem key={item.id}>{item.name}</MyItem>}
-            </FormSelect>
+            />
 
             <h3>
               Using RadioGroup
@@ -1613,6 +1615,8 @@ function Page() {
               helpText="Search for your primary institution"
               updateFormData={(id, value) => handleInputChange('institution', value)}
               value={formData.institution}
+              suggestions={suggestions}
+              onSearch={handleSearch}
             />
 
             <TypeAheadWithOther
@@ -1623,6 +1627,8 @@ function Page() {
               helpText="Search for any collaborating institutions (optional)"
               updateFormData={(id, value) => handleInputChange('collaboratingInstitution', value)}
               value={formData.collaboratingInstitution}
+              suggestions={suggestions}
+              onSearch={handleSearch}
             />
 
             <h3>

--- a/app/[locale]/styleguide/page.tsx
+++ b/app/[locale]/styleguide/page.tsx
@@ -1611,7 +1611,7 @@ function Page() {
               label="Institution"
               fieldName="institution"
               setOtherField={setOtherField}
-              required={true}
+              isRequired={true}
               helpText="Search for your primary institution"
               updateFormData={(id, value) => handleInputChange('institution', value)}
               value={formData.institution}
@@ -1623,7 +1623,6 @@ function Page() {
               label="Collaborating Institution"
               fieldName="collaboratingInstitution"
               setOtherField={setOtherField}
-              required={false}
               helpText="Search for any collaborating institutions (optional)"
               updateFormData={(id, value) => handleInputChange('collaboratingInstitution', value)}
               value={formData.collaboratingInstitution}
@@ -1948,7 +1947,7 @@ function Page() {
                 label="Institution"
                 fieldName="institution"
                 setOtherField={setOtherField}
-                required={true}
+                isRequired={true}
                 helpText="Search for your institution"
                 updateFormData={() => console.log('updating form')}
                 value="UCOP"

--- a/app/[locale]/template/[templateId]/access/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/access/__tests__/page.spec.tsx
@@ -100,7 +100,7 @@ describe('TemplateAccessPage', () => {
 
   it('should handle form submission', async () => {
     render(<TemplateAccessPage />);
-    const emailInput = screen.getByLabelText('labels.email');
+    const emailInput = screen.getByLabelText(/labels.email/);
     const inviteButton = screen.getByText('buttons.invite');
 
     fireEvent.change(emailInput, { target: { value: 'newuser@example.com' } });

--- a/app/[locale]/template/[templateId]/access/page.tsx
+++ b/app/[locale]/template/[templateId]/access/page.tsx
@@ -308,7 +308,6 @@ const TemplateAccessPage: React.FC = () => {
                         value={addCollaboratorEmail}
                         onChange={handleEmailChange}
                         isRequired={true}
-                        aria-required="true"
                         label={AccessPage('labels.email')}
                         isInvalid={!isValidEmail(addCollaboratorEmail) && addCollaboratorEmail !== ''}
                         errorMessage="Please enter a valid email address"

--- a/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
@@ -248,8 +248,8 @@ describe("QuestionEditPage", () => {
     });
 
     // Get the radio buttons by their role and value
-    const yesRadio = screen.getByRole('radio', { name: /form.yesLabel/i });
-    const noRadio = screen.getByRole('radio', { name: /form.noLabel/i });
+    const yesRadio = screen.getByRole('radio', { name: 'form.yesLabel' });
+    const noRadio = screen.getByRole('radio', { name: 'form.noLabel' });
 
     expect(yesRadio).toBeChecked();
     // Click the radio button
@@ -310,7 +310,7 @@ describe("QuestionEditPage", () => {
     });
 
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/i);
 
     // Set value to empty
     fireEvent.change(input, { target: { value: '' } });
@@ -390,7 +390,7 @@ describe("QuestionEditPage", () => {
       );
     });
 
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/i);
 
     // Set required QuestionType value
     fireEvent.change(input, { target: { value: 'Testing' } });
@@ -560,7 +560,7 @@ describe("QuestionEditPage", () => {
       );
     });
     // Find the input rendered by RangeComponent
-    const rangeStartInput = screen.getByLabelText('range start');
+    const rangeStartInput = screen.getByLabelText(/range start/i);
 
     // Simulate user typing
     fireEvent.change(rangeStartInput, { target: { value: 'New Range Label' } });
@@ -604,7 +604,7 @@ describe("QuestionEditPage", () => {
       );
     });
     // Find the input rendered by RangeComponent
-    const rangeStartInput = screen.getByLabelText('range start');
+    const rangeStartInput = screen.getByLabelText(/range start/i);
 
     // Simulate user typing
     fireEvent.change(rangeStartInput, { target: { value: '2' } });
@@ -737,7 +737,7 @@ describe("QuestionEditPage", () => {
       );
     });
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/i);
 
     // Set value to 'New Question'
     fireEvent.change(input, { target: { value: 'New Question' } });
@@ -1400,7 +1400,7 @@ describe('Options questions', () => {
     const allRows = screen.queryAllByLabelText('Text');
     expect(allRows.length).toBe(3);
 
-    // Enter the label text for new radio button 
+    // Enter the label text for new radio button
     fireEvent.change(allRows[2], { target: { value: 'Maybe' } });
 
     // Get the save button and save
@@ -1475,7 +1475,7 @@ describe('Options questions', () => {
     const allRows = screen.queryAllByLabelText('Text');
     expect(allRows.length).toBe(3);
 
-    // Enter the label text for new radio button 
+    // Enter the label text for new radio button
     fireEvent.change(allRows[2], { target: { value: 'Maybe' } });
 
     // Wait for state update

--- a/app/[locale]/template/[templateId]/section/[section_slug]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/section/[section_slug]/__tests__/page.spec.tsx
@@ -213,7 +213,7 @@ describe("SectionUpdatePage", () => {
     expect(editOptionsTab).toBeInTheDocument();
     const editLogicTab = screen.getByRole('tab', { name: 'tabs.logic' });
     expect(editLogicTab).toBeInTheDocument();
-    const sectionNameInput = screen.getByLabelText('labels.sectionName');
+    const sectionNameInput = screen.getByLabelText(/labels.sectionName/);
     expect(sectionNameInput).toBeInTheDocument();
     const sectionIntroductionLabel = screen.getByLabelText(/sectionIntroduction/i);
     expect(sectionIntroductionLabel).toBeInTheDocument();

--- a/app/[locale]/template/[templateId]/section/[section_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/section/[section_slug]/page.tsx
@@ -380,7 +380,7 @@ const SectionUpdatePage: React.FC = () => {
                       name="sectionName"
                       id="sectionName"
                       type="text"
-                      isRequired={true}
+                      isRequiredVisualOnly={true}
                       label={Section('labels.sectionName')}
                       value={sectionData.sectionName ? sectionData.sectionName : ''}
                       onChange={(e) => handleSectionNameChange({

--- a/app/[locale]/template/[templateId]/section/[section_slug]/page.tsx
+++ b/app/[locale]/template/[templateId]/section/[section_slug]/page.tsx
@@ -380,8 +380,7 @@ const SectionUpdatePage: React.FC = () => {
                       name="sectionName"
                       id="sectionName"
                       type="text"
-                      isRequired={false}
-                      aria-required={true}
+                      isRequired={true}
                       label={Section('labels.sectionName')}
                       value={sectionData.sectionName ? sectionData.sectionName : ''}
                       onChange={(e) => handleSectionNameChange({

--- a/app/[locale]/template/[templateId]/section/create/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/section/create/__tests__/page.spec.tsx
@@ -161,7 +161,7 @@ describe("CreateSectionPage", () => {
     expect(editOptionsTab).toBeInTheDocument();
     const editLogicTab = screen.getByRole('tab', { name: 'tabs.logic' });
     expect(editLogicTab).toBeInTheDocument();
-    const sectionNameInput = screen.getByLabelText('labels.sectionName');
+    const sectionNameInput = screen.getByLabelText(/labels.sectionName/);
     expect(sectionNameInput).toBeInTheDocument();
     const sectionIntroductionLabel = screen.getByLabelText(/sectionIntroduction/i);
     expect(sectionIntroductionLabel).toBeInTheDocument();

--- a/app/[locale]/template/[templateId]/section/create/page.tsx
+++ b/app/[locale]/template/[templateId]/section/create/page.tsx
@@ -367,7 +367,7 @@ const CreateSectionPage: React.FC = () => {
                       name="sectionName"
                       id="sectionName"
                       type="text"
-                      isRequired={true}
+                      isRequiredVisualOnly={true}
                       label={Section('labels.sectionName')}
                       value={formData.sectionName}
                       onChange={e => {

--- a/app/[locale]/template/[templateId]/section/create/page.tsx
+++ b/app/[locale]/template/[templateId]/section/create/page.tsx
@@ -367,7 +367,7 @@ const CreateSectionPage: React.FC = () => {
                       name="sectionName"
                       id="sectionName"
                       type="text"
-                      aria-required={true}
+                      isRequired={true}
                       label={Section('labels.sectionName')}
                       value={formData.sectionName}
                       onChange={e => {

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -277,30 +277,19 @@ export interface RadioButtonInterface {
   label: string;
   description?: string | ReactNode;
 }
-export interface RadioButtonProps {
-  name: string;
-  description?: string | ReactNode;
-  classes?: string;
-  radioGroupLabel?: string;
-  radioButtonData: RadioButtonInterface[];
-  value: string;
-  isInvalid?: boolean;
-  errorMessage?: string;
-  onChange?: (value: string) => void;
-}
 
 export interface RadioGroupProps {
-  name?: string;
+  name: string;
   value?: string;
   classes?: string;
-  description?: ReactNode;
+  description?: string | ReactNode;
   radioGroupLabel?: string;
   isInvalid?: boolean;
   errorMessage?: string;
   onChange?: (value: string) => void;
   isRequired?: boolean;
   isRequiredVisualOnly?: boolean;
-  children: ReactNode; // allow any Radio buttons or JSX
+  children?: ReactNode; // allow any Radio buttons or JSX
 }
 
 export interface CheckboxInterface {
@@ -319,7 +308,7 @@ export interface CheckboxGroupProps {
   onChange?: ((value: string[]) => void),
   isRequired?: boolean;
   isRequiredVisualOnly?: boolean;
-  children: ReactNode; // allow any Checkboxes or JSX
+  children?: ReactNode; // allow any Checkboxes or JSX
 }
 
 export interface ProjectMemberErrorInterface {

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -289,11 +289,26 @@ export interface RadioButtonProps {
   onChange?: (value: string) => void;
 }
 
+export interface RadioGroupProps {
+  name?: string;
+  value?: string;
+  classes?: string;
+  description?: ReactNode;
+  radioGroupLabel?: string;
+  isInvalid?: boolean;
+  errorMessage?: string;
+  onChange?: (value: string) => void;
+  isRequired?: boolean;
+  isRequiredVisualOnly?: boolean;
+  children: ReactNode; // allow any Radio buttons or JSX
+}
+
 export interface CheckboxInterface {
   value: string;
   label: string;
   description?: string;
 }
+
 export interface CheckboxGroupProps {
   name?: string;
   checkboxGroupLabel?: string;
@@ -303,6 +318,8 @@ export interface CheckboxGroupProps {
   errorMessage?: string;
   onChange?: ((value: string[]) => void),
   isRequired?: boolean;
+  ariaRequired?: boolean;
+  isRequiredVisualOnly?: boolean;
   children: ReactNode; // allow any Checkboxes or JSX
 }
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -318,7 +318,6 @@ export interface CheckboxGroupProps {
   errorMessage?: string;
   onChange?: ((value: string[]) => void),
   isRequired?: boolean;
-  ariaRequired?: boolean;
   isRequiredVisualOnly?: boolean;
   children: ReactNode; // allow any Checkboxes or JSX
 }

--- a/components/Form/AffiliationSearch/__tests__/index.spec.tsx
+++ b/components/Form/AffiliationSearch/__tests__/index.spec.tsx
@@ -18,29 +18,29 @@ describe('TypeAheadSearch', () => {
 
   it('should render both FormInput fields with correct labels and placeholders', () => {
     render(<TypeAheadSearch {...defaultProps} />);
-    expect(screen.getByLabelText('Search label')).toBeInTheDocument();
-    expect(screen.getByLabelText('Help text')).toBeInTheDocument();
+    expect(screen.getByLabelText(/search label/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/help text/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Enter search label')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Enter the help text you want to display')).toBeInTheDocument();
   });
 
   it('should call handleTypeAheadSearchLabelChange when search label input changes', () => {
     render(<TypeAheadSearch {...defaultProps} />);
-    const searchLabelInput = screen.getByLabelText('Search label');
+    const searchLabelInput = screen.getByLabelText(/search label/i);
     fireEvent.change(searchLabelInput, { target: { value: 'New Label' } });
     expect(mockLabelChange).toHaveBeenCalledWith('New Label');
   });
 
   it('should call handleTypeAheadHelpTextChange when help text input changes', () => {
     render(<TypeAheadSearch {...defaultProps} />);
-    const helpTextInput = screen.getByLabelText('Help text');
+    const helpTextInput = screen.getByLabelText(/help text/i);
     fireEvent.change(helpTextInput, { target: { value: 'New Help' } });
     expect(mockHelpTextChange).toHaveBeenCalledWith('New Help');
   });
 
   it('should show the correct values in the input fields', () => {
     render(<TypeAheadSearch {...defaultProps} />);
-    expect(screen.getByLabelText('Search label')).toHaveValue('Initial Label');
-    expect(screen.getByLabelText('Help text')).toHaveValue('Initial Help');
+    expect(screen.getByLabelText(/search label/i)).toHaveValue('Initial Label');
+    expect(screen.getByLabelText(/help text/i)).toHaveValue('Initial Help');
   });
 });

--- a/components/Form/CheckboxGroup/__tests__/index.spec.tsx
+++ b/components/Form/CheckboxGroup/__tests__/index.spec.tsx
@@ -9,148 +9,54 @@ import { Checkbox } from "react-aria-components";
 expect.extend(toHaveNoViolations);
 
 
+const defaultProps: RadioButtonProps = {
+  name: "test-radio",
+  value: 'option1',
+  checkboxGroupLabel: "Test Checkbox Group",
+};
+
+const choices = (
+  <>
+    <Checkbox value="option1"> Option 1 </Checkbox>
+    <Checkbox value="option2"> Option 2 </Checkbox>
+  </>
+);
+
+
 describe('CheckboxGroupComponent', () => {
-  const onChange = jest.fn();
-
-  /**
-    * A wrapper to simulate how the component is used, and so that we can
-    * simulate some the events and state changes.
-    */
-  function TestWrapper({testType="basic"}) {
-    const [val, setVal] = useState<String>("option1");
-
-    const groupLabel = "Test Checkbox Group";
-    const groupDescription = "This is the group help text";
-
-    const children = (
-      <>
-        <Checkbox value="option1">
-          <div className="checkbox">
-            <svg viewBox="0 0 18 18" aria-hidden="true">
-              <polyline points="1 9 7 14 15 4" />
-            </svg>
-          </div>
-          Option 1
-        </Checkbox>
-        <Checkbox value="option2">
-          <div className="checkbox">
-            <svg viewBox="0 0 18 18" aria-hidden="true">
-              <polyline points="1 9 7 14 15 4" />
-            </svg>
-          </div>
-          Option 2
-        </Checkbox>
-      </>
-    );
-
-    switch (testType) {
-      case "basic":
-        return (
-          <CheckboxGroupComponent
-            name="test-checkbox"
-            checkboxGroupLabel={groupLabel}
-            value={val}
-            onChange={onChange}
-          >
-            {children}
-          </CheckboxGroupComponent>
-        )
-        break;
-
-      case "with-description":
-        return (
-          <CheckboxGroupComponent
-            name="test-checkbox"
-            checkboxGroupLabel={groupLabel}
-            checkboxGroupDescription={groupDescription}
-          >
-            {children}
-          </CheckboxGroupComponent>
-        )
-        break;
-
-      case "invalid":
-        return (
-          <CheckboxGroupComponent
-            name="test-checkbox"
-            checkboxGroupLabel={groupLabel}
-            isInvalid={true}
-            errorMessage="This field is required"
-          >
-            {children}
-          </CheckboxGroupComponent>
-        )
-        break;
-
-      case "required":
-        return (
-          <CheckboxGroupComponent
-            name="test-checkbox"
-            checkboxGroupLabel={groupLabel}
-            isRequired={true}
-          >
-            {children}
-          </CheckboxGroupComponent>
-        )
-        break;
-
-      case "kinda-required":
-        return (
-          <CheckboxGroupComponent
-            name="test-checkbox"
-            checkboxGroupLabel={groupLabel}
-            isRequiredVisualOnly={true}
-          >
-            {children}
-          </CheckboxGroupComponent>
-        )
-        break;
-
-      case "multi-required":
-        return (
-          <CheckboxGroupComponent
-            name="test-checkbox"
-            checkboxGroupLabel={groupLabel}
-            isRequired={true}
-            isRequiredVisualOnly={true}
-          >
-            {children}
-          </CheckboxGroupComponent>
-        )
-        break;
-
-      case "axe":
-        return (
-          <CheckboxGroupComponent
-            name="test-checkbox"
-            checkboxGroupLabel={groupLabel}
-            checkboxGroupDescription={groupDescription}
-            isRequired={true}
-            isRequiredVisualOnly={true}
-          >
-            {children}
-          </CheckboxGroupComponent>
-        )
-        break;
-    }
-  }
-
   it('should render the component correctly', () => {
-    render(<TestWrapper />);
+    render(
+      <CheckboxGroupComponent {...defaultProps}>
+        {choices}
+      </CheckboxGroupComponent>
+    );
 
     expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
     expect(screen.queryByText('This is the group help text')).not.toBeInTheDocument();
     expect(screen.getByText('Option 1')).toBeInTheDocument();
     expect(screen.getByText('Option 2')).toBeInTheDocument();
+    expect(screen.queryByText(/\(required\)/)).not.toBeInTheDocument();
   });
 
   it('should render the help text if provided', () => {
-    render(<TestWrapper testType="with-description" />);
+    render(
+      <CheckboxGroupComponent {...defaultProps}
+        checkboxGroupDescription="This is the group help text"
+      >
+        {choices}
+      </CheckboxGroupComponent>
+    );
     expect(screen.getByText('This is the group help text')).toBeInTheDocument();
   });
 
   it('should call onChange when a checkbox is selected', () => {
-    render(<TestWrapper />);
+    const onChange = jest.fn();
+
+    render(
+      <CheckboxGroupComponent {...defaultProps} onChange={onChange}>
+        {choices}
+      </CheckboxGroupComponent>
+    );
 
     // Find the checkbox input by its value attribute
     const checkbox = screen.getByRole('checkbox', { name: /Option 2/ });
@@ -160,27 +66,35 @@ describe('CheckboxGroupComponent', () => {
   });
 
   it('should handle invalid state correctly', () => {
-    render(<TestWrapper testType="invalid" />);
+    render(
+      <CheckboxGroupComponent {...defaultProps}
+        isInvalid={true}
+        errorMessage="This field is required"
+      >
+        {choices}
+      </CheckboxGroupComponent>
+    );
     expect(screen.getByText('This field is required')).toBeInTheDocument();
   });
 
   it('should display "(required)" text when field is required', () => {
-    render(<TestWrapper testType="required" />);
+    render(
+      <CheckboxGroupComponent {...defaultProps} isRequired={true}>
+        {choices}
+      </CheckboxGroupComponent>
+    );
 
     expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
     expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
     expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
   });
 
-  it('should not display "(required)" text when field is not required', () => {
-    render(<TestWrapper />);
-    expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
-    expect(screen.queryByText(/\(required\)/)).not.toBeInTheDocument();
-  });
-
-  // Test isRequiredVisualOnly functionality
   it('should display "(required)" and aria-required false when isRequiredVisualOnly is true', () => {
-    render(<TestWrapper testType="kinda-required" />);
+    render(
+      <CheckboxGroupComponent {...defaultProps} isRequiredVisualOnly={true}>
+        {choices}
+      </CheckboxGroupComponent>
+    );
 
     // Check for "(required)" text in label
     expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
@@ -193,7 +107,14 @@ describe('CheckboxGroupComponent', () => {
   });
 
   it('should display "(required)" text when multiple required props are set', () => {
-    render(<TestWrapper testType="multi-required" />);
+    render(
+      <CheckboxGroupComponent {...defaultProps}
+        isRequired={true}
+        isRequiredVisualOnly={true}
+      >
+        {choices}
+      </CheckboxGroupComponent>
+    );
 
     expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
     expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
@@ -201,7 +122,11 @@ describe('CheckboxGroupComponent', () => {
   });
 
   it('should pass axe accessibility test', async () => {
-    const { container } = render(<TestWrapper testType="axe" />);
+    const { container } = render(
+      <CheckboxGroupComponent {...defaultProps}>
+        {choices}
+      </CheckboxGroupComponent>
+    );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/components/Form/CheckboxGroup/__tests__/index.spec.tsx
+++ b/components/Form/CheckboxGroup/__tests__/index.spec.tsx
@@ -106,18 +106,6 @@ describe('CheckboxGroupComponent', () => {
         )
         break;
 
-      case "aria-required":
-        return (
-          <CheckboxGroupComponent
-            name="test-checkbox"
-            checkboxGroupLabel={groupLabel}
-            ariaRequired={true}
-          >
-            {children}
-          </CheckboxGroupComponent>
-        )
-        break;
-
       case "multi-required":
         return (
           <CheckboxGroupComponent
@@ -125,7 +113,6 @@ describe('CheckboxGroupComponent', () => {
             checkboxGroupLabel={groupLabel}
             isRequired={true}
             isRequiredVisualOnly={true}
-            ariaRequired={true}
           >
             {children}
           </CheckboxGroupComponent>
@@ -140,7 +127,6 @@ describe('CheckboxGroupComponent', () => {
             checkboxGroupDescription={groupDescription}
             isRequired={true}
             isRequiredVisualOnly={true}
-            ariaRequired={true}
           >
             {children}
           </CheckboxGroupComponent>
@@ -193,7 +179,7 @@ describe('CheckboxGroupComponent', () => {
   });
 
   // Test isRequiredVisualOnly functionality
-  it('should display "(required)" without setting required true when isRequiredVisualOnly is true', () => {
+  it('should display "(required)" and aria-required false when isRequiredVisualOnly is true', () => {
     render(<TestWrapper testType="kinda-required" />);
 
     // Check for "(required)" text in label
@@ -204,15 +190,6 @@ describe('CheckboxGroupComponent', () => {
     // Check that aria-required is set on the checkbox group
     const checkboxGroup = screen.getByRole('group');
     expect(checkboxGroup).toBeInTheDocument();
-    expect(checkboxGroup).not.toHaveAttribute('aria-required', 'true');
-  });
-
-  it('should display "(required)" text when aria-required attribute is passed', () => {
-    render(<TestWrapper testType="aria-required" />);
-
-    expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
-    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
-    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
   });
 
   it('should display "(required)" text when multiple required props are set', () => {

--- a/components/Form/CheckboxGroup/__tests__/index.spec.tsx
+++ b/components/Form/CheckboxGroup/__tests__/index.spec.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import CheckboxGroupComponent from '@/components/Form/CheckboxGroup';
@@ -9,9 +9,9 @@ import { Checkbox } from "react-aria-components";
 expect.extend(toHaveNoViolations);
 
 
-const defaultProps: RadioButtonProps = {
+const defaultProps: CheckboxGroupProps = {
   name: "test-radio",
-  value: 'option1',
+  value: ['option1'],
   checkboxGroupLabel: "Test Checkbox Group",
 };
 

--- a/components/Form/CheckboxGroup/__tests__/index.spec.tsx
+++ b/components/Form/CheckboxGroup/__tests__/index.spec.tsx
@@ -1,0 +1,231 @@
+import React, { useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import CheckboxGroupComponent from '@/components/Form/CheckboxGroup';
+import { CheckboxGroupProps } from '@/app/types';
+import { Checkbox } from "react-aria-components";
+
+
+expect.extend(toHaveNoViolations);
+
+
+describe('CheckboxGroupComponent', () => {
+  const onChange = jest.fn();
+
+  /**
+    * A wrapper to simulate how the component is used, and so that we can
+    * simulate some the events and state changes.
+    */
+  function TestWrapper({testType="basic"}) {
+    const [val, setVal] = useState<String>("option1");
+
+    const groupLabel = "Test Checkbox Group";
+    const groupDescription = "This is the group help text";
+
+    const children = (
+      <>
+        <Checkbox value="option1">
+          <div className="checkbox">
+            <svg viewBox="0 0 18 18" aria-hidden="true">
+              <polyline points="1 9 7 14 15 4" />
+            </svg>
+          </div>
+          Option 1
+        </Checkbox>
+        <Checkbox value="option2">
+          <div className="checkbox">
+            <svg viewBox="0 0 18 18" aria-hidden="true">
+              <polyline points="1 9 7 14 15 4" />
+            </svg>
+          </div>
+          Option 2
+        </Checkbox>
+      </>
+    );
+
+    switch (testType) {
+      case "basic":
+        return (
+          <CheckboxGroupComponent
+            name="test-checkbox"
+            checkboxGroupLabel={groupLabel}
+            value={val}
+            onChange={onChange}
+          >
+            {children}
+          </CheckboxGroupComponent>
+        )
+        break;
+
+      case "with-description":
+        return (
+          <CheckboxGroupComponent
+            name="test-checkbox"
+            checkboxGroupLabel={groupLabel}
+            checkboxGroupDescription={groupDescription}
+          >
+            {children}
+          </CheckboxGroupComponent>
+        )
+        break;
+
+      case "invalid":
+        return (
+          <CheckboxGroupComponent
+            name="test-checkbox"
+            checkboxGroupLabel={groupLabel}
+            isInvalid={true}
+            errorMessage="This field is required"
+          >
+            {children}
+          </CheckboxGroupComponent>
+        )
+        break;
+
+      case "required":
+        return (
+          <CheckboxGroupComponent
+            name="test-checkbox"
+            checkboxGroupLabel={groupLabel}
+            isRequired={true}
+          >
+            {children}
+          </CheckboxGroupComponent>
+        )
+        break;
+
+      case "kinda-required":
+        return (
+          <CheckboxGroupComponent
+            name="test-checkbox"
+            checkboxGroupLabel={groupLabel}
+            isRequiredVisualOnly={true}
+          >
+            {children}
+          </CheckboxGroupComponent>
+        )
+        break;
+
+      case "aria-required":
+        return (
+          <CheckboxGroupComponent
+            name="test-checkbox"
+            checkboxGroupLabel={groupLabel}
+            ariaRequired={true}
+          >
+            {children}
+          </CheckboxGroupComponent>
+        )
+        break;
+
+      case "multi-required":
+        return (
+          <CheckboxGroupComponent
+            name="test-checkbox"
+            checkboxGroupLabel={groupLabel}
+            isRequired={true}
+            isRequiredVisualOnly={true}
+            ariaRequired={true}
+          >
+            {children}
+          </CheckboxGroupComponent>
+        )
+        break;
+
+      case "axe":
+        return (
+          <CheckboxGroupComponent
+            name="test-checkbox"
+            checkboxGroupLabel={groupLabel}
+            checkboxGroupDescription={groupDescription}
+            isRequired={true}
+            isRequiredVisualOnly={true}
+            ariaRequired={true}
+          >
+            {children}
+          </CheckboxGroupComponent>
+        )
+        break;
+    }
+  }
+
+  it('should render the component correctly', () => {
+    render(<TestWrapper />);
+
+    expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
+    expect(screen.queryByText('This is the group help text')).not.toBeInTheDocument();
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+  });
+
+  it('should render the help text if provided', () => {
+    render(<TestWrapper testType="with-description" />);
+    expect(screen.getByText('This is the group help text')).toBeInTheDocument();
+  });
+
+  it('should call onChange when a checkbox is selected', () => {
+    render(<TestWrapper />);
+
+    // Find the checkbox input by its value attribute
+    const checkbox = screen.getByRole('checkbox', { name: /Option 2/ });
+    fireEvent.click(checkbox);
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('should handle invalid state correctly', () => {
+    render(<TestWrapper testType="invalid" />);
+    expect(screen.getByText('This field is required')).toBeInTheDocument();
+  });
+
+  it('should display "(required)" text when field is required', () => {
+    render(<TestWrapper testType="required" />);
+
+    expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+  });
+
+  it('should not display "(required)" text when field is not required', () => {
+    render(<TestWrapper />);
+    expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
+    expect(screen.queryByText(/\(required\)/)).not.toBeInTheDocument();
+  });
+
+  // Test isRequiredVisualOnly functionality
+  it('should display "(required)" without setting required true when isRequiredVisualOnly is true', () => {
+    render(<TestWrapper testType="kinda-required" />);
+
+    // Check for "(required)" text in label
+    expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+
+    // Check that aria-required is set on the checkbox group
+    const checkboxGroup = screen.getByRole('group');
+    expect(checkboxGroup).toBeInTheDocument();
+    expect(checkboxGroup).not.toHaveAttribute('aria-required', 'true');
+  });
+
+  it('should display "(required)" text when aria-required attribute is passed', () => {
+    render(<TestWrapper testType="aria-required" />);
+
+    expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+  });
+
+  it('should display "(required)" text when multiple required props are set', () => {
+    render(<TestWrapper testType="multi-required" />);
+
+    expect(screen.getByText('Test Checkbox Group')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+  });
+
+  it('should pass axe accessibility test', async () => {
+    const { container } = render(<TestWrapper testType="axe" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/Form/CheckboxGroup/index.tsx
+++ b/components/Form/CheckboxGroup/index.tsx
@@ -18,10 +18,9 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
   onChange,
   isRequired = false,
   isRequiredVisualOnly = false,
-  ariaRequired = false,
   children,
 }) => {
-  const showRequired = isRequired || ariaRequired || isRequiredVisualOnly;
+  const showRequired = isRequired || isRequiredVisualOnly;
 
   return (
     <>
@@ -33,7 +32,7 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
         onChange={onChange}
         isRequired={isRequired}
         isInvalid={isInvalid}
-        aria-required={ariaRequired}
+        aria-required={isRequired}
       >
         <Label>
           {checkboxGroupLabel}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}

--- a/components/Form/CheckboxGroup/index.tsx
+++ b/components/Form/CheckboxGroup/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslations } from "next-intl";
 import {
   CheckboxGroup,
   FieldError,
@@ -21,6 +22,7 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
   children,
 }) => {
   const showRequired = isRequired || isRequiredVisualOnly;
+  const t = useTranslations('Global.labels');
 
   return (
     <>
@@ -35,7 +37,7 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
         aria-required={isRequired}
       >
         <Label>
-          {checkboxGroupLabel}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+          {checkboxGroupLabel}{showRequired && <span className="is-required" aria-hidden="true"> ({t('required')})</span>}
         </Label>
         {isInvalid && <FieldError className='error-message'>{errorMessage}</FieldError>}
 

--- a/components/Form/CheckboxGroup/index.tsx
+++ b/components/Form/CheckboxGroup/index.tsx
@@ -17,8 +17,12 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
   errorMessage,
   onChange,
   isRequired = false,
-  children
+  isRequiredVisualOnly = false,
+  ariaRequired = false,
+  children,
 }) => {
+  const showRequired = isRequired || ariaRequired || isRequiredVisualOnly;
+
   return (
     <>
       <CheckboxGroup
@@ -28,8 +32,12 @@ const CheckboxGroupComponent: React.FC<CheckboxGroupProps> = ({
         data-testid="checkbox-group"
         onChange={onChange}
         isRequired={isRequired}
+        isInvalid={isInvalid}
+        aria-required={ariaRequired}
       >
-        <Label>{checkboxGroupLabel}</Label>
+        <Label>
+          {checkboxGroupLabel}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+        </Label>
         {isInvalid && <FieldError className='error-message'>{errorMessage}</FieldError>}
 
         {checkboxGroupDescription && (

--- a/components/Form/FormInput/__tests__/index.spec.tsx
+++ b/components/Form/FormInput/__tests__/index.spec.tsx
@@ -147,26 +147,6 @@ describe('FormInput', () => {
     expect(input).toHaveAttribute('aria-required', 'false');
   });
 
-  it('should display "(required)" text when multiple required props are set', () => {
-    render(
-      <FormInput
-        name="email"
-        type="email"
-        label="Email"
-        isRequired={true}
-        isRequiredVisualOnly={true}
-        ariaRequired="true"
-      />
-    );
-
-    expect(screen.getByText('Email')).toBeInTheDocument();
-    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
-    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
-
-    const input = screen.getByRole('textbox', { name: 'Email' });
-    expect(input).toHaveAttribute('aria-required', 'true');
-  });
-
   it('should not show required when neither isRequired, isRequiredVisualOnly, nor aria-required are set', () => {
     render(
       <FormInput

--- a/components/Form/FormInput/__tests__/index.spec.tsx
+++ b/components/Form/FormInput/__tests__/index.spec.tsx
@@ -78,5 +78,126 @@ describe('FormInput', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
-  })
+  });
+
+  it('should display "(required)" text when field is required', () => {
+    render(
+      <FormInput
+        name="email"
+        type="email"
+        label="Email"
+        isRequired={true}
+      />
+    );
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+  });
+
+  it('should not display "(required)" text when field is not required', () => {
+    render(
+      <FormInput
+        name="email"
+        type="email"
+        label="Email"
+        isRequired={false}
+      />
+    );
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.queryByText(/\(required\)/)).not.toBeInTheDocument();
+  });
+
+  // New tests for isRequiredVisualOnly functionality
+  it('should display "(required)" text and set aria-required when isRequiredVisualOnly is true', () => {
+    render(
+      <FormInput
+        name="email"
+        type="email"
+        label="Email"
+        isRequiredVisualOnly={true}
+      />
+    );
+
+    // Check for "(required)" text in label
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+
+    // Check that aria-required is set on the input
+    const input = screen.getByRole('textbox', { name: 'Email' });
+    expect(input).toHaveAttribute('aria-required', 'false');
+  });
+
+  it('should not display "(required)" text or set aria-required when isRequiredVisualOnly is false', () => {
+    render(
+      <FormInput
+        name="email"
+        type="email"
+        label="Email"
+        isRequiredVisualOnly={false}
+      />
+    );
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.queryByText(/\(required\)/)).not.toBeInTheDocument();
+
+    const input = screen.getByRole('textbox', { name: 'Email' });
+    expect(input).toHaveAttribute('aria-required', 'false');
+  });
+
+  it('should display "(required)" text when ariaRequired attribute is passed', () => {
+    render(
+      <FormInput
+        name="email"
+        type="email"
+        label="Email"
+        ariaRequired={true}
+      />
+    );
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+
+    const input = screen.getByRole('textbox', { name: 'Email' });
+    expect(input).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('should display "(required)" text when multiple required props are set', () => {
+    render(
+      <FormInput
+        name="email"
+        type="email"
+        label="Email"
+        isRequired={true}
+        isRequiredVisualOnly={true}
+        ariaRequired="true"
+      />
+    );
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+
+    const input = screen.getByRole('textbox', { name: 'Email' });
+    expect(input).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('should not show required when neither isRequired, isRequiredVisualOnly, nor aria-required are set', () => {
+    render(
+      <FormInput
+        name="email"
+        type="email"
+        label="Email"
+      />
+    );
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.queryByText(/\(required\)/)).not.toBeInTheDocument();
+
+    const input = screen.getByRole('textbox', { name: 'Email' });
+    expect(input).toHaveAttribute('aria-required', 'false');
+  });
 });

--- a/components/Form/FormInput/__tests__/index.spec.tsx
+++ b/components/Form/FormInput/__tests__/index.spec.tsx
@@ -147,24 +147,6 @@ describe('FormInput', () => {
     expect(input).toHaveAttribute('aria-required', 'false');
   });
 
-  it('should display "(required)" text when ariaRequired attribute is passed', () => {
-    render(
-      <FormInput
-        name="email"
-        type="email"
-        label="Email"
-        ariaRequired={true}
-      />
-    );
-
-    expect(screen.getByText('Email')).toBeInTheDocument();
-    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
-    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
-
-    const input = screen.getByRole('textbox', { name: 'Email' });
-    expect(input).toHaveAttribute('aria-required', 'true');
-  });
-
   it('should display "(required)" text when multiple required props are set', () => {
     render(
       <FormInput

--- a/components/Form/FormInput/index.tsx
+++ b/components/Form/FormInput/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslations } from "next-intl";
 import {
   FieldError,
   Input,
@@ -58,6 +59,7 @@ const FormInput = React.forwardRef<HTMLInputElement, InputProps & React.InputHTM
   ...rest
 }, ref) => {
   const showRequired = isRequired || isRequiredVisualOnly;
+  const t = useTranslations('Global.labels');
 
   return (
     <>
@@ -70,7 +72,7 @@ const FormInput = React.forwardRef<HTMLInputElement, InputProps & React.InputHTM
         data-testid="field-wrapper"
       >
         <Label htmlFor={id} className={labelClasses}>
-          {label}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+        {label}{showRequired && <span className="is-required" aria-hidden="true"> ({t('required')})</span>}
         </Label>
         <Text slot="description" className="help">
           {description}

--- a/components/Form/FormInput/index.tsx
+++ b/components/Form/FormInput/index.tsx
@@ -24,6 +24,7 @@ interface InputProps {
   disabled?: boolean;
   isRequired?: boolean;
   ariaRequired?: boolean;
+  isRequiredVisualOnly?: boolean;
   isInvalid?: boolean;
   errorMessage?: string;
   helpMessage?: string;
@@ -49,6 +50,7 @@ const FormInput = React.forwardRef<HTMLInputElement, InputProps & React.InputHTM
   disabled = false,
   isRequired = false,
   ariaRequired = false,
+  isRequiredVisualOnly = false,
   isInvalid = false,
   errorMessage = '',
   helpMessage = '',
@@ -57,6 +59,7 @@ const FormInput = React.forwardRef<HTMLInputElement, InputProps & React.InputHTM
   pattern,
   ...rest
 }, ref) => {
+  const showRequired = isRequired || ariaRequired || isRequiredVisualOnly;
 
   return (
     <>
@@ -68,7 +71,9 @@ const FormInput = React.forwardRef<HTMLInputElement, InputProps & React.InputHTM
         isInvalid={isInvalid}
         data-testid="field-wrapper"
       >
-        <Label htmlFor={id} className={labelClasses}>{label}</Label>
+        <Label htmlFor={id} className={labelClasses}>
+          {label}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+        </Label>
         <Text slot="description" className="help">
           {description}
         </Text>

--- a/components/Form/FormInput/index.tsx
+++ b/components/Form/FormInput/index.tsx
@@ -23,7 +23,6 @@ interface InputProps {
   inputClasses?: string;
   disabled?: boolean;
   isRequired?: boolean;
-  ariaRequired?: boolean;
   isRequiredVisualOnly?: boolean;
   isInvalid?: boolean;
   errorMessage?: string;
@@ -49,7 +48,6 @@ const FormInput = React.forwardRef<HTMLInputElement, InputProps & React.InputHTM
   inputClasses = '',
   disabled = false,
   isRequired = false,
-  ariaRequired = false,
   isRequiredVisualOnly = false,
   isInvalid = false,
   errorMessage = '',
@@ -59,7 +57,7 @@ const FormInput = React.forwardRef<HTMLInputElement, InputProps & React.InputHTM
   pattern,
   ...rest
 }, ref) => {
-  const showRequired = isRequired || ariaRequired || isRequiredVisualOnly;
+  const showRequired = isRequired || isRequiredVisualOnly;
 
   return (
     <>
@@ -92,7 +90,7 @@ const FormInput = React.forwardRef<HTMLInputElement, InputProps & React.InputHTM
           minLength={minLength}
           maxLength={maxLength}
           pattern={pattern}
-          aria-required={ariaRequired}
+          aria-required={isRequired}
           {...rest}
         />
 

--- a/components/Form/FormSelect/__tests__/index.spec.tsx
+++ b/components/Form/FormSelect/__tests__/index.spec.tsx
@@ -1,82 +1,23 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { FormSelect, MyItem } from '@/components/Form/FormSelect';
+import { FormSelect } from '@/components/Form/FormSelect';
 
-const sampleItems = [
-  { id: '1', name: 'Option 1' },
-  { id: '2', name: 'Option 2' },
-  { id: '3', name: 'Option 3' },
-];
 
 describe('FormSelect', () => {
   const onSelectionChange = jest.fn();
-
-  function TestWrapper({testType="basic"}) {
-    switch (testType) {
-      case "basic":
-        return (
-          <FormSelect
-            label="Select an option"
-            items={sampleItems}
-            selectedKey="1"
-          >
-          </FormSelect>
-        );
-        break;
-
-      case "on-change":
-        return (
-          <FormSelect
-            label="Select an option"
-            items={sampleItems}
-            selectedKey="1"
-            onChange={onSelectionChange}
-          >
-          </FormSelect>
-        );
-        break;
-
-      case "with-help":
-        return (
-          <FormSelect
-            label="Select an option"
-            items={sampleItems}
-            selectedKey="1"
-            helpMessage="Choose from the available options"
-          >
-          </FormSelect>
-        );
-        break;
-
-      case "required":
-        return (
-          <FormSelect
-            label="Select an option"
-            items={sampleItems}
-            selectedKey="1"
-            isRequired={true}
-          >
-          </FormSelect>
-        )
-        break;
-
-      case "kinda-required":
-        return (
-          <FormSelect
-            label="Select an option"
-            items={sampleItems}
-            selectedKey="1"
-            isRequiredVisualOnly={false}
-          >
-          </FormSelect>
-        );
-        break;
-    }
-  }
+  const defaultProps = {
+    label: "Select an option",
+    items: [
+      { id: '1', name: 'Option 1' },
+      { id: '2', name: 'Option 2' },
+      { id: '3', name: 'Option 3' },
+    ],
+    selectedKey: "1",
+  };
 
   it('should render the component correctly', () => {
-    const { getByTestId } = render(<TestWrapper />);
+    const { getByTestId } = render(<FormSelect {...defaultProps} />);
     const container = getByTestId('hidden-select-container');
     const select = container.querySelector('select')!;
 
@@ -85,11 +26,12 @@ describe('FormSelect', () => {
 
     expect(option).toBeTruthy();
     expect(option?.value).toBe('1');
-
   });
 
   it('should open the popover and selects an option', async () => {
-    render(<TestWrapper testType="on-change" />);
+    render(
+      <FormSelect {...defaultProps} onChange={onSelectionChange} />
+    );
 
     // Click the button to open the popover
     const button = screen.getByRole('button');
@@ -104,13 +46,18 @@ describe('FormSelect', () => {
   });
 
   it('should render the helpMessage', () => {
-    render(<TestWrapper testType="with-help" />);
+    render(
+      <FormSelect
+        {...defaultProps}
+        helpMessage="Choose from the available options"
+      />
+    );
     const helpText = screen.getAllByText('Choose from the available options');
     expect(helpText).toHaveLength(2);
   });
 
   it('should display "(required)" text when field is required', () => {
-    render(<TestWrapper testType="required" />);
+    render(<FormSelect {...defaultProps} isRequired={true} />);
 
     expect(screen.getByText('Select an option')).toBeInTheDocument();
     expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
@@ -118,9 +65,9 @@ describe('FormSelect', () => {
   });
 
   it('should allow for requiredVisualOnly', () => {
-    render(<TestWrapper testType="kinda-required" />);
+    render(<FormSelect {...defaultProps} isRequiredVisualOnly={true} />);
 
     expect(screen.getByText('Select an option')).toBeInTheDocument();
-    expect(screen.queryByText(/\(required\)/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\(required\)/)).toBeInTheDocument();
   });
 });

--- a/components/Form/FormSelect/__tests__/index.spec.tsx
+++ b/components/Form/FormSelect/__tests__/index.spec.tsx
@@ -10,16 +10,73 @@ const sampleItems = [
 ];
 
 describe('FormSelect', () => {
+  const onSelectionChange = jest.fn();
+
+  function TestWrapper({testType="basic"}) {
+    switch (testType) {
+      case "basic":
+        return (
+          <FormSelect
+            label="Select an option"
+            items={sampleItems}
+            selectedKey="1"
+          >
+          </FormSelect>
+        );
+        break;
+
+      case "on-change":
+        return (
+          <FormSelect
+            label="Select an option"
+            items={sampleItems}
+            selectedKey="1"
+            onChange={onSelectionChange}
+          >
+          </FormSelect>
+        );
+        break;
+
+      case "with-help":
+        return (
+          <FormSelect
+            label="Select an option"
+            items={sampleItems}
+            selectedKey="1"
+            helpMessage="Choose from the available options"
+          >
+          </FormSelect>
+        );
+        break;
+
+      case "required":
+        return (
+          <FormSelect
+            label="Select an option"
+            items={sampleItems}
+            selectedKey="1"
+            isRequired={true}
+          >
+          </FormSelect>
+        )
+        break;
+
+      case "kinda-required":
+        return (
+          <FormSelect
+            label="Select an option"
+            items={sampleItems}
+            selectedKey="1"
+            isRequiredVisualOnly={false}
+          >
+          </FormSelect>
+        );
+        break;
+    }
+  }
 
   it('should render the component correctly', () => {
-
-    const { getByTestId } = render(<FormSelect
-      label="Select an option"
-      items={sampleItems}
-      selectedKey="1"
-    >
-      {(item) => <MyItem key={item.id}>{item.name}</MyItem>}
-    </FormSelect>);
+    const { getByTestId } = render(<TestWrapper />);
     const container = getByTestId('hidden-select-container');
     const select = container.querySelector('select')!;
 
@@ -32,18 +89,7 @@ describe('FormSelect', () => {
   });
 
   it('should open the popover and selects an option', async () => {
-    const onSelectionChange = jest.fn();
-
-    render(
-      <FormSelect
-        label="Select an option"
-        items={sampleItems}
-        selectedKey="1"
-        onChange={onSelectionChange}
-      >
-        {(item) => <MyItem key={item.id}>{item.name}</MyItem>}
-      </FormSelect>
-    );
+    render(<TestWrapper testType="on-change" />);
 
     // Click the button to open the popover
     const button = screen.getByRole('button');
@@ -58,18 +104,23 @@ describe('FormSelect', () => {
   });
 
   it('should render the helpMessage', () => {
-    render(
-      <FormSelect
-        label="Select an option"
-        items={sampleItems}
-        selectedKey="1"
-        helpMessage="Choose from the available options"
-      >
-        {(item) => <MyItem key={item.id}>{item.name}</MyItem>}
-      </FormSelect>
-    );
-
+    render(<TestWrapper testType="with-help" />);
     const helpText = screen.getAllByText('Choose from the available options');
     expect(helpText).toHaveLength(2);
+  });
+
+  it('should display "(required)" text when field is required', () => {
+    render(<TestWrapper testType="required" />);
+
+    expect(screen.getByText('Select an option')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+  });
+
+  it('should allow for requiredVisualOnly', () => {
+    render(<TestWrapper testType="kinda-required" />);
+
+    expect(screen.getByText('Select an option')).toBeInTheDocument();
+    expect(screen.queryByText(/\(required\)/)).not.toBeInTheDocument();
   });
 });

--- a/components/Form/FormSelect/index.tsx
+++ b/components/Form/FormSelect/index.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, Key } from 'react';
+import { useTranslations } from "next-intl";
 import type {
   SelectProps,
   ValidationResult
@@ -52,6 +53,7 @@ export const FormSelect = forwardRef<HTMLButtonElement, MySelectProps<SelectItem
     ...rest
   } = props;
   const showRequired = isRequired || isRequiredVisualOnly;
+  const t = useTranslations('Global.labels');
 
   const handleSelectionChange = (key: Key | null) => {
     if (onChange) {
@@ -74,7 +76,7 @@ export const FormSelect = forwardRef<HTMLButtonElement, MySelectProps<SelectItem
       {(state) => (
         <>
           <Label>
-            {label}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+            {label}{showRequired && <span className="is-required" aria-hidden="true"> ({t('required')})</span>}
           </Label>
           <Text slot="description" className="help">
             {description}</Text>

--- a/components/Form/FormSelect/index.tsx
+++ b/components/Form/FormSelect/index.tsx
@@ -29,6 +29,8 @@ interface MySelectProps<T extends SelectItem>
   helpMessage?: string;
   description?: string;
   selectClasses?: string;
+  isRequired?: boolean;
+  isRequiredVisualOnly?: boolean;
   onChange?: (value: string) => void;
   items?: T[];
   placeHolder?: string;
@@ -43,11 +45,14 @@ export const FormSelect = forwardRef<HTMLButtonElement, MySelectProps<SelectItem
     helpMessage,
     description,
     selectClasses,
+    isRequired = false,
+    isRequiredVisualOnly = false,
     onChange,
     items,
     placeholder,
     ...rest
   } = props;
+  const showRequired = isRequired || isRequiredVisualOnly;
 
   const handleSelectionChange = (key: Key | null) => {
     if (onChange) {
@@ -63,12 +68,15 @@ export const FormSelect = forwardRef<HTMLButtonElement, MySelectProps<SelectItem
       data-invalid={errorMessage}
       className={`${selectClasses} ${styles.mySelect} react-aria-Select`}
       aria-label={ariaLabel}
+      aria-required={isRequired}
       onSelectionChange={handleSelectionChange}
       placeholder={placeholder}
     >
       {(state) => (
         <>
-          <Label>{label}</Label>
+          <Label>
+            {label}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+          </Label>
           <Text slot="description" className="help">
             {description}</Text>
           <Button className='react-aria-Button' ref={ref} data-testid="select-button">
@@ -107,13 +115,3 @@ export const FormSelect = forwardRef<HTMLButtonElement, MySelectProps<SelectItem
 });
 
 FormSelect.displayName = 'FormSelect';
-
-
-export function MyItem(props: ListBoxItemProps) {
-  return (
-    <ListBoxItem
-      {...props}
-    />
-  );
-}
-

--- a/components/Form/FormSelect/index.tsx
+++ b/components/Form/FormSelect/index.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, Key } from 'react';
 import type {
-  ListBoxItemProps,
   SelectProps,
   ValidationResult
 } from 'react-aria-components';
@@ -34,7 +33,7 @@ interface MySelectProps<T extends SelectItem>
   onChange?: (value: string) => void;
   items?: T[];
   placeHolder?: string;
-  children: React.ReactNode | ((item: T) => React.ReactNode);
+  children?: React.ReactNode | ((item: T) => React.ReactNode);
 }
 
 export const FormSelect = forwardRef<HTMLButtonElement, MySelectProps<SelectItem>>((props, ref) => {

--- a/components/Form/FormTextArea/__tests__/index.spec.tsx
+++ b/components/Form/FormTextArea/__tests__/index.spec.tsx
@@ -13,12 +13,22 @@ describe('FormTextArea', () => {
         label="Name"
         placeholder="Enter your name"
         value="John Doe"
-        onChange={jest.fn()}
       />
     );
 
     expect(screen.getByLabelText('Name')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Enter your name')).toHaveValue('John Doe');
+  });
+
+  it('should render the help message if provided', () => {
+    render(
+      <FormTextArea
+        name="phone"
+        label="Phone"
+        helpMessage="Please enter your phone number in the format xxx-xxx-xxxx"
+      />
+    );
+    expect(screen.getByText('Please enter your phone number in the format xxx-xxx-xxxx')).toBeInTheDocument();
   });
 
   it('should handle invalid state correctly', () => {
@@ -36,9 +46,9 @@ describe('FormTextArea', () => {
     expect(screen.getByText('Please enter a valid email address')).toBeInTheDocument();
   });
 
-
   it('should call the onChange handler when the input value changes', () => {
     const onChange = jest.fn();
+
     render(
       <FormTextArea
         name="password"
@@ -52,27 +62,50 @@ describe('FormTextArea', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
-  it('should render the help message if provided', () => {
-    render(
-      <FormTextArea
-        name="phone"
-        label="Phone"
-        helpMessage="Please enter your phone number in the format xxx-xxx-xxxx"
-      />
-    );
-
-    expect(screen.getByText('Please enter your phone number in the format xxx-xxx-xxxx')).toBeInTheDocument();
-  });
-
   it('should pass axe accessibility test', async () => {
     const { container } = render(
       <FormTextArea
         name="phone"
         label="Phone"
+        isRequired={true}
+        isRequiredVisualOnly={true}
         helpMessage="Please enter your phone number in the format xxx-xxx-xxxx"
       />
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
-  })
+  });
+
+  it('should display "(required)" text when field is required', () => {
+    render(
+      <FormTextArea
+        name="email"
+        label="Email"
+        isRequired={true}
+      />
+    );
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+  });
+
+  it('should support isRequiredVisualOnly', () => {
+    render(
+      <FormTextArea
+        name="email"
+        label="Email"
+        isRequiredVisualOnly={true}
+      />
+    );
+
+    // Check for "(required)" text in label
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+
+    // Check that aria-required is FALSE on the textarea
+    const textarea = screen.getByRole('textbox', { name: 'Email' });
+    expect(textarea).toHaveAttribute('aria-required', 'false');
+  });
 });

--- a/components/Form/FormTextArea/index.tsx
+++ b/components/Form/FormTextArea/index.tsx
@@ -27,6 +27,7 @@ interface FormTextInputAreaProps {
 
   disabled?: boolean;
   isRequired?: boolean;
+  isRequiredVisualOnly?: boolean;
   isInvalid?: boolean;
   errorMessage?: string;
   helpMessage?: string;
@@ -48,12 +49,13 @@ const FormTextInputArea: React.FC<FormTextInputAreaProps> = ({
   editorWrapperClasses = '',
   disabled = false,
   isRequired = false,
+  isRequiredVisualOnly = false,
   isInvalid = false,
   errorMessage = '',
   helpMessage = '',
   richText = false,
 }) => {
-
+  const showRequired = isRequired || isRequiredVisualOnly;
   const sanitizeId = (id: string) => id.replace(/[^a-zA-Z0-9-_]/g, ''); // Remove invalid characters
 
   // Generate unique IDs for accessibility. SanitizeId removes invalid characters that cannot be used with
@@ -83,7 +85,9 @@ const FormTextInputArea: React.FC<FormTextInputAreaProps> = ({
       isDisabled={disabled}
       data-testid="field-wrapper"
     >
-      <Label id={labelId} className={labelClasses}>{label}</Label>
+      <Label id={labelId} className={labelClasses}>
+        {label}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+      </Label>
 
       {description && (
         <Text slot="description" className="help-text">
@@ -115,6 +119,7 @@ const FormTextInputArea: React.FC<FormTextInputAreaProps> = ({
           value={value}
           disabled={disabled}
           aria-describedby={helpMessage ? `${inputId}-help` : undefined}
+          aria-required={isRequired}
         />
       )}
 

--- a/components/Form/FormTextArea/index.tsx
+++ b/components/Form/FormTextArea/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react'; // Import useCallback
+import { useTranslations } from "next-intl";
 import {
   FieldError,
   Label,
@@ -56,6 +57,7 @@ const FormTextInputArea: React.FC<FormTextInputAreaProps> = ({
   richText = false,
 }) => {
   const showRequired = isRequired || isRequiredVisualOnly;
+  const t = useTranslations('Global.labels');
   const sanitizeId = (id: string) => id.replace(/[^a-zA-Z0-9-_]/g, ''); // Remove invalid characters
 
   // Generate unique IDs for accessibility. SanitizeId removes invalid characters that cannot be used with
@@ -86,7 +88,7 @@ const FormTextInputArea: React.FC<FormTextInputAreaProps> = ({
       data-testid="field-wrapper"
     >
       <Label id={labelId} className={labelClasses}>
-        {label}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+        {label}{showRequired && <span className="is-required" aria-hidden="true"> ({t('required')})</span>}
       </Label>
 
       {description && (

--- a/components/Form/QuestionComponents/AffiliationSearchQuestionComponent/index.tsx
+++ b/components/Form/QuestionComponents/AffiliationSearchQuestionComponent/index.tsx
@@ -23,7 +23,7 @@ const AffiliationSearchQuestionComponent: React.FC<AffiliationSearchQuestionProp
         label={parsedQuestion?.attributes?.label || Signup('institution')}
         fieldName="institution"
         setOtherField={setOtherField}
-        required={true}
+        isRequired={true}
         error=""
         helpText={parsedQuestion?.attributes?.help || Signup('institutionHelp')}
         updateFormData={handleAffiliationChange}

--- a/components/Form/QuestionOptionsComponent/__tests__/index.spec.tsx
+++ b/components/Form/QuestionOptionsComponent/__tests__/index.spec.tsx
@@ -53,8 +53,8 @@ describe('QuestionOptionsComponent', () => {
       setFormSubmitted={jest.fn()}
     />);
 
-    expect(screen.getByLabelText('labels.order')).toBeInTheDocument();
-    expect(screen.getByLabelText('labels.text')).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.order/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.text/)).toBeInTheDocument();
     expect(screen.getByLabelText('labels.default')).toBeInTheDocument();
   });
 
@@ -83,7 +83,7 @@ describe('QuestionOptionsComponent', () => {
       setFormSubmitted={jest.fn()}
     />);
 
-    const textInput = screen.getByLabelText('labels.text');
+    const textInput = screen.getByLabelText(/labels.text/);
     fireEvent.change(textInput, { target: { value: 'Updated Option' } });
 
     expect(setRows).toHaveBeenCalledWith([{ id: 1, isSelected: false, text: "Updated Option" }]);
@@ -99,7 +99,7 @@ describe('QuestionOptionsComponent', () => {
       setFormSubmitted={jest.fn()}
     />);
 
-    const textInput = screen.getByLabelText('labels.text');
+    const textInput = screen.getByLabelText(/labels.text/);
     fireEvent.change(textInput, { target: { value: 'Updated Option' } });
 
     expect(setRows).toHaveBeenCalledWith([{ id: 1, isSelected: false, text: "Updated Option" }]);
@@ -142,7 +142,7 @@ describe('QuestionOptionsComponent', () => {
 
     render(<Wrapper />);
 
-    const textInput = screen.getByLabelText('labels.text');
+    const textInput = screen.getByLabelText(/labels.text/);
     fireEvent.change(textInput, { target: { value: 'Option 1' } });
 
     const defaultCheckbox = screen.getByTestId('default-1');

--- a/components/Form/RadioGroup/__tests__/index.spec.tsx
+++ b/components/Form/RadioGroup/__tests__/index.spec.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import RadioGroupComponent from '@/components/Form/RadioGroup';
-import { RadioButtonProps } from '@/app/types';
+import { RadioGroupProps } from '@/app/types';
 import { Radio } from "react-aria-components";
 
 expect.extend(toHaveNoViolations);
 
-const defaultProps: RadioButtonProps = {
+const defaultProps: RadioGroupProps = {
   name: "test-radio",
   value: 'option1',
   radioGroupLabel: "Test Radio Group",
@@ -67,7 +67,9 @@ describe('RadioGroupComponent', () => {
         {...defaultProps}
         isInvalid={true}
         errorMessage="This field is required"
-      />
+      >
+        {options}
+      </RadioGroupComponent>
     );
 
     expect(screen.getByText('This field is required')).toBeInTheDocument();
@@ -78,7 +80,9 @@ describe('RadioGroupComponent', () => {
       <RadioGroupComponent
         {...defaultProps}
         isRequired={true}
-      />
+      >
+        {options}
+      </RadioGroupComponent>
     );
 
     expect(screen.getByText('Test Radio Group')).toBeInTheDocument();
@@ -91,7 +95,9 @@ describe('RadioGroupComponent', () => {
       <RadioGroupComponent
         {...defaultProps}
         isRequiredVisualOnly={true}
-      />
+      >
+        {options}
+      </RadioGroupComponent>
     );
 
     expect(screen.getByText('Test Radio Group')).toBeInTheDocument();
@@ -104,7 +110,9 @@ describe('RadioGroupComponent', () => {
       <RadioGroupComponent
         {...defaultProps}
         description="Please select your preference"
-      />
+      >
+        {options}
+      </RadioGroupComponent>
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/components/Form/RadioGroup/__tests__/index.spec.tsx
+++ b/components/Form/RadioGroup/__tests__/index.spec.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import RadioGroupComponent from '@/components/Form/RadioGroup';
+import { RadioButtonProps } from '@/app/types';
+import { Radio } from "react-aria-components";
+
+expect.extend(toHaveNoViolations);
+
+const defaultProps: RadioButtonProps = {
+  name: "test-radio",
+  value: 'option1',
+  radioGroupLabel: "Test Radio Group",
+};
+
+const options = (
+  <>
+    <Radio value="option1"> Option 1 </Radio>
+    <Radio value="option2"> Option 2 </Radio>
+  </>
+);
+
+describe('RadioGroupComponent', () => {
+  it('should render the component correctly', () => {
+    render(
+      <RadioGroupComponent {...defaultProps}>
+        {options}
+      </RadioGroupComponent>
+    );
+
+    expect(screen.getByText('Test Radio Group')).toBeInTheDocument();
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+    expect(screen.queryByText(/\(required\)/)).not.toBeInTheDocument();
+  });
+
+  it('should call onChange when a radio option is selected', () => {
+    const onChange = jest.fn();
+
+    render(
+      <RadioGroupComponent {...defaultProps} onChange={onChange}>
+        {options}
+      </RadioGroupComponent>
+    );
+
+    const option2 = screen.getByLabelText('Option 2');
+    fireEvent.click(option2);
+    expect(onChange).toHaveBeenCalledWith('option2');
+  });
+
+  it('should render the help text if provided', () => {
+    render(
+      <RadioGroupComponent
+        {...defaultProps}
+        description="Please select your preference"
+      >
+        {options}
+      </RadioGroupComponent>
+    );
+
+    expect(screen.getByText('Please select your preference')).toBeInTheDocument();
+  });
+
+  it('should handle invalid state correctly', () => {
+    render(
+      <RadioGroupComponent
+        {...defaultProps}
+        isInvalid={true}
+        errorMessage="This field is required"
+      />
+    );
+
+    expect(screen.getByText('This field is required')).toBeInTheDocument();
+  });
+
+  it('should display "(required)" text when field is required', () => {
+    render(
+      <RadioGroupComponent
+        {...defaultProps}
+        isRequired={true}
+      />
+    );
+
+    expect(screen.getByText('Test Radio Group')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+  });
+
+  it('should isRequiredVisualOnly option', () => {
+    render(
+      <RadioGroupComponent
+        {...defaultProps}
+        isRequiredVisualOnly={true}
+      />
+    );
+
+    expect(screen.getByText('Test Radio Group')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+  });
+
+  it('should pass axe accessibility test', async () => {
+    const { container } = render(
+      <RadioGroupComponent
+        {...defaultProps}
+        description="Please select your preference"
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/Form/RadioGroup/index.tsx
+++ b/components/Form/RadioGroup/index.tsx
@@ -6,19 +6,9 @@ import {
   Text,
 } from "react-aria-components";
 
-interface RadioGroupComponentProps {
-  name: string;
-  value: string;
-  classes?: string;
-  description?: ReactNode;
-  radioGroupLabel: string;
-  isInvalid?: boolean;
-  errorMessage?: string;
-  onChange: (value: string) => void;
-  children: ReactNode; // allow any Radio buttons or JSX
-}
+import { RadioGroupProps } from '@/app/types';
 
-const RadioGroupComponent: React.FC<React.PropsWithChildren<RadioGroupComponentProps>> = ({
+const RadioGroupComponent: React.FC<RadioGroupProps> = ({
   name,
   value,
   classes,
@@ -27,27 +17,48 @@ const RadioGroupComponent: React.FC<React.PropsWithChildren<RadioGroupComponentP
   isInvalid,
   errorMessage,
   onChange,
+  isRequired = false,
+  isRequiredVisualOnly = false,
   children,
 }) => {
+  // Show "(required)" if isRequired OR aria-required attribute is present OR isRequiredVisualOnly is true
+  const shouldShowRequired = isRequired || ariaRequiredFromProps || isRequiredVisualOnly;
+
+  // Determine aria-required value for the RadioGroup
+  const groupAriaRequired = ariaRequiredFromProps || isRequiredVisualOnly;
+
+  const renderDescription = (desc: string | ReactNode) => {
+    // If it's a string, just render it directly
+    // If it's a ReactNode, it will be rendered as JSX
+    return desc;
+  };
+
   return (
-    <RadioGroup
-      name={name}
-      value={value}
-      className={classes}
-      onChange={onChange}
-      aria-label={radioGroupLabel || 'Radio Group'}
-    >
-      <Label>{radioGroupLabel}</Label>
-      {description && (
-        <Text slot="description" className="help">
-          {description}
-        </Text>
-      )}
-      {children}
-      {isInvalid && (
-        <FieldError className="error-message">{errorMessage}</FieldError>
-      )}
-    </RadioGroup>
+    <>
+      <RadioGroup
+        name={name}
+        value={value}
+        className={classes}
+        onChange={onChange}
+        aria-label={radioGroupLabel || 'Radio Group'}
+        isRequired={isRequired}
+        isInvalid={isInvalid}
+        {...(groupAriaRequired && { 'aria-required': true })}
+      >
+        <Label>
+          {radioGroupLabel}{shouldShowRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+        </Label>
+        {description && (
+          <Text slot="description" className="help">
+            {description}
+          </Text>
+        )}
+        {children}
+        {isInvalid && (
+          <FieldError className="error-message">{errorMessage}</FieldError>
+        )}
+      </RadioGroup>
+    </>
   );
 };
 

--- a/components/Form/RadioGroup/index.tsx
+++ b/components/Form/RadioGroup/index.tsx
@@ -21,17 +21,7 @@ const RadioGroupComponent: React.FC<RadioGroupProps> = ({
   isRequiredVisualOnly = false,
   children,
 }) => {
-  // Show "(required)" if isRequired OR aria-required attribute is present OR isRequiredVisualOnly is true
-  const shouldShowRequired = isRequired || ariaRequiredFromProps || isRequiredVisualOnly;
-
-  // Determine aria-required value for the RadioGroup
-  const groupAriaRequired = ariaRequiredFromProps || isRequiredVisualOnly;
-
-  const renderDescription = (desc: string | ReactNode) => {
-    // If it's a string, just render it directly
-    // If it's a ReactNode, it will be rendered as JSX
-    return desc;
-  };
+  const showRequired = isRequired || isRequiredVisualOnly;
 
   return (
     <>
@@ -40,13 +30,13 @@ const RadioGroupComponent: React.FC<RadioGroupProps> = ({
         value={value}
         className={classes}
         onChange={onChange}
-        aria-label={radioGroupLabel || 'Radio Group'}
+        aria-label={radioGroupLabel}
         isRequired={isRequired}
         isInvalid={isInvalid}
-        {...(groupAriaRequired && { 'aria-required': true })}
+        aria-required={isRequired}
       >
         <Label>
-          {radioGroupLabel}{shouldShowRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+          {radioGroupLabel}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
         </Label>
         {description && (
           <Text slot="description" className="help">

--- a/components/Form/RadioGroup/index.tsx
+++ b/components/Form/RadioGroup/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslations } from "next-intl";
 import {
   FieldError,
   Label,
@@ -22,6 +23,7 @@ const RadioGroupComponent: React.FC<RadioGroupProps> = ({
   children,
 }) => {
   const showRequired = isRequired || isRequiredVisualOnly;
+  const t = useTranslations('Global.labels');
 
   return (
     <>
@@ -36,7 +38,7 @@ const RadioGroupComponent: React.FC<RadioGroupProps> = ({
         aria-required={isRequired}
       >
         <Label>
-          {radioGroupLabel}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+          {radioGroupLabel}{showRequired && <span className="is-required" aria-hidden="true"> ({t('required')})</span>}
         </Label>
         {description && (
           <Text slot="description" className="help">

--- a/components/Form/RadioGroup/index.tsx
+++ b/components/Form/RadioGroup/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import {
   FieldError,
   Label,

--- a/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
+++ b/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
@@ -20,8 +20,8 @@ export type TypeAheadInputProps = {
   helpText?: string;
   setOtherField: (value: boolean) => void;
   fieldName: string;
-  required: boolean;
-  requiredVisualOnly?: boolean;
+  isRequired?: boolean;
+  isRequiredVisualOnly?: boolean;
   error?: string;
   updateFormData: (id: string, value: string) => void; //Function to update the typeahead field value in the parent form data
   value?: string;
@@ -43,13 +43,17 @@ const TypeAheadWithOther = ({
   className,
   suggestions,
   onSearch,
-  required=false,
-  requiredVisualOnly=false,
+  isRequired=false,
+  isRequiredVisualOnly=false,
   otherText = "Other",
 }: TypeAheadInputProps) => {
 
-  const t = useTranslations('Global.labels');
-  const showRequired = required || requiredVisualOnly;
+  const showRequired = isRequired || isRequiredVisualOnly;
+
+  // TODO::FIXME:: For some reason the useTranslations function below returns
+  // undefined (or something else)
+  // const Global = useTranslations('Global.labels');
+
   const [inputValue, setInputValue] = useState<string>(value ?? "");
   const [showSuggestionSpinner, setShowSuggestionSpinner] = useState(false);
   const [currentListItemFocused, setCurrentListItemFocused] = useState(-1);
@@ -205,7 +209,7 @@ const TypeAheadWithOther = ({
       >
         <Label>
           {label}
-          {showRequired && <span className="is-required" aria-hidden="true">({t('required')})</span>}
+          {showRequired && <span className="is-required" aria-hidden="true">(required{/*Global('required')*/})</span>}
         </Label>
         <Input
           name={fieldName}

--- a/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
+++ b/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
@@ -202,7 +202,8 @@ const TypeAheadWithOther = ({
         isInvalid={!!error}
       >
         <Label>
-          {label}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+          {label}
+          {showRequired && <span className="is-required" aria-hidden="true">(required)</span>}
         </Label>
         <Input
           name={fieldName}
@@ -211,7 +212,6 @@ const TypeAheadWithOther = ({
           role="textbox"
           aria-controls="results"
           aria-activedescendant={activeDescendentId}
-          aria-required={required}
           className={classNames('react-aria-Input', styles.searchInput)}
           onChange={handleUpdate}
           onClick={handleInputClick}

--- a/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
+++ b/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
@@ -20,6 +20,7 @@ export type TypeAheadInputProps = {
   setOtherField: (value: boolean) => void;
   fieldName: string;
   required: boolean;
+  requiredVisualOnly?: boolean;
   error?: string;
   updateFormData: (id: string, value: string) => void; //Function to update the typeahead field value in the parent form data
   value?: string;
@@ -41,9 +42,12 @@ const TypeAheadWithOther = ({
   className,
   suggestions,
   onSearch,
+  required=false,
+  requiredVisualOnly=false,
   otherText = "Other",
 }: TypeAheadInputProps) => {
 
+  const showRequired = required || requiredVisualOnly;
   const [inputValue, setInputValue] = useState<string>(value ?? "");
   const [showSuggestionSpinner, setShowSuggestionSpinner] = useState(false);
   const [currentListItemFocused, setCurrentListItemFocused] = useState(-1);
@@ -197,7 +201,9 @@ const TypeAheadWithOther = ({
         className={(!!error) ? styles.fieldError : ''}
         isInvalid={!!error}
       >
-        <Label>{label}</Label>
+        <Label>
+          {label}{showRequired && <span className="is-required" aria-hidden="true"> (required)</span>}
+        </Label>
         <Input
           name={fieldName}
           type="text"
@@ -205,6 +211,7 @@ const TypeAheadWithOther = ({
           role="textbox"
           aria-controls="results"
           aria-activedescendant={activeDescendentId}
+          aria-required={required}
           className={classNames('react-aria-Input', styles.searchInput)}
           onChange={handleUpdate}
           onClick={handleInputClick}

--- a/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
+++ b/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
@@ -11,7 +11,7 @@ import Spinner from '@/components/Spinner';
 import { SuggestionInterface } from '@/app/types';
 import classNames from 'classnames';
 import styles from './typeaheadWithOther.module.scss';
-import { useTranslations } from "next-intl";
+// import { useTranslations } from "next-intl";
 
 
 export type TypeAheadInputProps = {
@@ -52,6 +52,9 @@ const TypeAheadWithOther = ({
 
   // TODO::FIXME:: For some reason the useTranslations function below returns
   // undefined (or something else)
+  // When we use it anywhere in the code we get "Global is not a function"
+  // NOTE:: I ucommented this line, the import at the top and the tranlation
+  // call in the <Label> to hide the linting errors for now.
   // const Global = useTranslations('Global.labels');
 
   const [inputValue, setInputValue] = useState<string>(value ?? "");

--- a/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
+++ b/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
@@ -11,6 +11,7 @@ import Spinner from '@/components/Spinner';
 import { SuggestionInterface } from '@/app/types';
 import classNames from 'classnames';
 import styles from './typeaheadWithOther.module.scss';
+import { useTranslations } from "next-intl";
 
 
 export type TypeAheadInputProps = {
@@ -47,6 +48,7 @@ const TypeAheadWithOther = ({
   otherText = "Other",
 }: TypeAheadInputProps) => {
 
+  const t = useTranslations('Global.labels');
   const showRequired = required || requiredVisualOnly;
   const [inputValue, setInputValue] = useState<string>(value ?? "");
   const [showSuggestionSpinner, setShowSuggestionSpinner] = useState(false);
@@ -203,7 +205,7 @@ const TypeAheadWithOther = ({
       >
         <Label>
           {label}
-          {showRequired && <span className="is-required" aria-hidden="true">(required)</span>}
+          {showRequired && <span className="is-required" aria-hidden="true">({t('required')})</span>}
         </Label>
         <Input
           name={fieldName}

--- a/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
+++ b/components/Form/TypeAheadWithOther/TypeAheadWithOther.tsx
@@ -11,7 +11,7 @@ import Spinner from '@/components/Spinner';
 import { SuggestionInterface } from '@/app/types';
 import classNames from 'classnames';
 import styles from './typeaheadWithOther.module.scss';
-// import { useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 
 
 export type TypeAheadInputProps = {
@@ -49,13 +49,7 @@ const TypeAheadWithOther = ({
 }: TypeAheadInputProps) => {
 
   const showRequired = isRequired || isRequiredVisualOnly;
-
-  // TODO::FIXME:: For some reason the useTranslations function below returns
-  // undefined (or something else)
-  // When we use it anywhere in the code we get "Global is not a function"
-  // NOTE:: I ucommented this line, the import at the top and the tranlation
-  // call in the <Label> to hide the linting errors for now.
-  // const Global = useTranslations('Global.labels');
+  const Global = useTranslations('Global.labels');
 
   const [inputValue, setInputValue] = useState<string>(value ?? "");
   const [showSuggestionSpinner, setShowSuggestionSpinner] = useState(false);
@@ -212,7 +206,7 @@ const TypeAheadWithOther = ({
       >
         <Label>
           {label}
-          {showRequired && <span className="is-required" aria-hidden="true">(required{/*Global('required')*/})</span>}
+          {showRequired && <span className="is-required" aria-hidden="true">({Global('required')})</span>}
         </Label>
         <Input
           name={fieldName}

--- a/components/Form/TypeAheadWithOther/__tests__/TypeAheadWithOther.spec.tsx
+++ b/components/Form/TypeAheadWithOther/__tests__/TypeAheadWithOther.spec.tsx
@@ -370,7 +370,6 @@ describe('TypeAheadWithOther', () => {
         helpText="Search for an institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
         error=""
         updateFormData={() => true}
         value="input value"

--- a/components/Form/TypeAheadWithOther/__tests__/TypeAheadWithOther.spec.tsx
+++ b/components/Form/TypeAheadWithOther/__tests__/TypeAheadWithOther.spec.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
-import "@testing-library/jest-dom";
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { render, screen, fireEvent, waitFor, act } from '@/utils/test-utils';
 import { axe, toHaveNoViolations } from 'jest-axe';
 
 import { TypeAheadWithOther } from '@/components/Form/TypeAheadWithOther';
 import mocksAffiliations from '@/__mocks__/common/mockAffiliations.json';
+
+
+expect.extend(toHaveNoViolations);
+
 
 jest.mock('@/lib/graphql/client/apollo-client');
 jest.mock('@/utils/clientLogger', () => ({
@@ -12,12 +16,11 @@ jest.mock('@/utils/clientLogger', () => ({
   default: jest.fn(),
 }));
 
-expect.extend(toHaveNoViolations);
 const mockSetOtherField = jest.fn();
 const mockOnSearch = jest.fn();
 
-describe('TypeAheadWithOther', () => {
 
+describe('TypeAheadWithOther', () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -34,7 +37,6 @@ describe('TypeAheadWithOther', () => {
         helpText="Search for an institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
         error=""
         updateFormData={() => true}
         value="text"
@@ -43,7 +45,7 @@ describe('TypeAheadWithOther', () => {
       />
     );
 
-    expect(screen.getByLabelText('Institution')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Institution/)).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Type to search...')).toBeInTheDocument();
     expect(screen.getByText('Search for an institution')).toBeInTheDocument();
   });
@@ -55,7 +57,6 @@ describe('TypeAheadWithOther', () => {
         helpText="Search for an institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
         error=""
         updateFormData={() => true}
         value="input value"
@@ -76,7 +77,6 @@ describe('TypeAheadWithOther', () => {
         helpText="Search for an institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
         error=""
         updateFormData={() => true}
         value="input value"
@@ -85,7 +85,7 @@ describe('TypeAheadWithOther', () => {
       />
     );
 
-    const input = screen.getByLabelText('Institution');
+    const input = screen.getByLabelText(/Institution/);
 
     act(() => { //make sure all updates related to React are completed
       fireEvent.change(input, { target: { value: 'Test' } });
@@ -109,7 +109,7 @@ describe('TypeAheadWithOther', () => {
         helpText="Search for an institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
+        isRequired={true}
         error="Institution field is required"
         updateFormData={() => true}
         value="input value"
@@ -118,7 +118,7 @@ describe('TypeAheadWithOther', () => {
       />
     );
 
-    const input = screen.getByLabelText('Institution');
+    const input = screen.getByLabelText(/Institution/);
 
     act(() => { //make sure all updates related to React are completed
       fireEvent.change(input, { target: { value: '  ' } });
@@ -139,7 +139,6 @@ describe('TypeAheadWithOther', () => {
         helpText="Search for an institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
         error=""
         updateFormData={mockUpdateFormData}
         value="Initial Value" // Start with a value
@@ -175,7 +174,6 @@ describe('TypeAheadWithOther', () => {
         label="Institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
         updateFormData={mockUpdateFormData}
         suggestions={mocksAffiliations}
         onSearch={mockOnSearch}
@@ -202,7 +200,6 @@ describe('TypeAheadWithOther', () => {
         label="Institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
         updateFormData={mockUpdateFormData}
         suggestions={mocksAffiliations}
         onSearch={mockOnSearch}
@@ -246,7 +243,6 @@ describe('TypeAheadWithOther', () => {
         helpText="Search for an institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
         error=""
         updateFormData={mockUpdateFormData}
         value="input value"
@@ -284,7 +280,6 @@ describe('TypeAheadWithOther', () => {
         helpText="Search for an institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
         error=""
         updateFormData={() => true}
         otherText="Other(organization not listed)"
@@ -324,7 +319,6 @@ describe('TypeAheadWithOther', () => {
           helpText="Search for an institution"
           setOtherField={mockSetOtherField}
           fieldName="test"
-          required={false}
           error=""
           updateFormData={() => true}
           value="input value"
@@ -375,13 +369,13 @@ describe('TypeAheadWithOther', () => {
         value="input value"
         suggestions={mocksAffiliations}
         onSearch={mockOnSearch}
-        required={true}
+        isRequired={true}
       />
     );
 
     expect(screen.getByText('Institution')).toBeInTheDocument();
-    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
-    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+    expect(screen.getByText(/required/)).toBeInTheDocument();
+    expect(screen.getByText(/required/)).toHaveClass('is-required');
   });
 
   it('should allow for requiredVisualOnly', () => {
@@ -391,18 +385,17 @@ describe('TypeAheadWithOther', () => {
         helpText="Search for an institution"
         setOtherField={mockSetOtherField}
         fieldName="test"
-        required={false}
         error=""
         updateFormData={() => true}
         value="input value"
         suggestions={mocksAffiliations}
         onSearch={mockOnSearch}
-        requiredVisualOnly={true}
+        isRequiredVisualOnly={true}
       />
     );
 
     expect(screen.getByText('Institution')).toBeInTheDocument();
-    expect(screen.queryByText(/\(required\)/)).toBeInTheDocument();
-    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+    expect(screen.queryByText(/required/)).toBeInTheDocument();
+    expect(screen.getByText(/required/)).toHaveClass('is-required');
   });
 });

--- a/components/Form/TypeAheadWithOther/__tests__/TypeAheadWithOther.spec.tsx
+++ b/components/Form/TypeAheadWithOther/__tests__/TypeAheadWithOther.spec.tsx
@@ -26,7 +26,7 @@ describe('TypeAheadWithOther', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
     jest.useRealTimers();
   })
 

--- a/components/Form/TypeAheadWithOther/__tests__/TypeAheadWithOther.spec.tsx
+++ b/components/Form/TypeAheadWithOther/__tests__/TypeAheadWithOther.spec.tsx
@@ -362,4 +362,48 @@ describe('TypeAheadWithOther', () => {
 
     expect(input).toHaveValue('Test University');
   });
+
+  it('should display "(required)" text when field is required', () => {
+    render(
+      <TypeAheadWithOther
+        label="Institution"
+        helpText="Search for an institution"
+        setOtherField={mockSetOtherField}
+        fieldName="test"
+        required={false}
+        error=""
+        updateFormData={() => true}
+        value="input value"
+        suggestions={mocksAffiliations}
+        onSearch={mockOnSearch}
+        required={true}
+      />
+    );
+
+    expect(screen.getByText('Institution')).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+  });
+
+  it('should allow for requiredVisualOnly', () => {
+    render(
+      <TypeAheadWithOther
+        label="Institution"
+        helpText="Search for an institution"
+        setOtherField={mockSetOtherField}
+        fieldName="test"
+        required={false}
+        error=""
+        updateFormData={() => true}
+        value="input value"
+        suggestions={mocksAffiliations}
+        onSearch={mockOnSearch}
+        requiredVisualOnly={true}
+      />
+    );
+
+    expect(screen.getByText('Institution')).toBeInTheDocument();
+    expect(screen.queryByText(/\(required\)/)).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/)).toHaveClass('is-required');
+  });
 });

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -358,7 +358,7 @@ describe("QuestionAdd", () => {
     });
 
     // Get the question text input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // add text to question text field
     fireEvent.change(input, { target: { value: 'New Question' } });
@@ -438,7 +438,7 @@ describe("QuestionAdd", () => {
     });
 
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // Set value to 'New Question'
     fireEvent.change(input, { target: { value: 'New Question' } });
@@ -504,7 +504,7 @@ describe("QuestionAdd", () => {
     });
 
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // Set value to 'New Question'
     fireEvent.change(input, { target: { value: 'New Question' } });
@@ -573,7 +573,7 @@ describe("QuestionAdd", () => {
     });
 
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // Set value to 'New Question'
     fireEvent.change(input, { target: { value: 'New Question' } });
@@ -635,7 +635,7 @@ describe("QuestionAdd", () => {
     });
 
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // Set value to 'New Question'
     fireEvent.change(input, { target: { value: 'New Question' } });
@@ -698,7 +698,7 @@ describe("QuestionAdd", () => {
     });
 
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // Set value to 'New Question'
     fireEvent.change(input, { target: { value: 'New Question' } });
@@ -760,7 +760,7 @@ describe("QuestionAdd", () => {
     });
 
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // Set value to 'New Question'
     fireEvent.change(input, { target: { value: 'New Question' } });
@@ -823,9 +823,9 @@ describe("QuestionAdd", () => {
     });
 
     // Radio button info with order, text and checkbox should be in document
-    expect(screen.getByLabelText('labels.order')).toBeInTheDocument();
-    expect(screen.getByLabelText('labels.text')).toBeInTheDocument();
-    expect(screen.getByLabelText('labels.default')).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.order/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.text/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.default/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'buttons.addRow' })).toBeInTheDocument();
   })
 
@@ -847,12 +847,12 @@ describe("QuestionAdd", () => {
     });
 
     // Enter Question text
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // Set value to empty
     fireEvent.change(input, { target: { value: 'Testing adding new row' } });
 
-    const radioInput = screen.getByLabelText('labels.text');
+    const radioInput = screen.getByLabelText(/labels.text/);
     fireEvent.change(radioInput, { target: { value: 'Yes' } });
 
     const addButton = screen.getByRole('button', { name: /buttons.addRow/i });
@@ -1017,7 +1017,7 @@ describe("QuestionAdd", () => {
       />);
 
     // Find the input rendered by RangeComponent
-    const rangeStartInput = screen.getByLabelText('range start');
+    const rangeStartInput = screen.getByLabelText(/range start/);
 
     // Simulate user typing
     fireEvent.change(rangeStartInput, { target: { value: 'New Range Label' } });
@@ -1071,7 +1071,7 @@ describe("QuestionAdd", () => {
       />);
 
     // Find the input rendered by RangeComponent
-    const rangeStartInput = screen.getByLabelText('range start');
+    const rangeStartInput = screen.getByLabelText(/range start/);
 
     // Simulate user typing
     fireEvent.change(rangeStartInput, { target: { value: 'New Range Label' } });
@@ -1122,7 +1122,7 @@ describe("QuestionAdd", () => {
     });
 
     // Get the question text input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // add text to question text field
     fireEvent.change(input, { target: { value: 'New Question' } });
@@ -1471,7 +1471,7 @@ describe("Error handling", () => {
     });
 
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // Set value to empty
     fireEvent.change(input, { target: { value: '' } });
@@ -1517,7 +1517,7 @@ describe("Error handling", () => {
     });
 
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // Set value to 'New Question'
     fireEvent.change(input, { target: { value: 'New Question' } });
@@ -1658,7 +1658,7 @@ describe("Error handling", () => {
     });
 
     // Get the input
-    const input = screen.getByLabelText('labels.questionText');
+    const input = screen.getByLabelText(/labels.questionText/);
 
     // Set value to empty
     fireEvent.change(input, { target: { value: 'Test' } });

--- a/components/ResearchDomainCascadingDropdown/index.tsx
+++ b/components/ResearchDomainCascadingDropdown/index.tsx
@@ -128,7 +128,7 @@ const ResearchDomainCascadingDropdown: React.FC<CascadingDropdownProps> = ({ pro
   }, [myResearchDomains]);
 
 
-  // We need this useEffect to update the selectedParent and selectedChild data passed into component, 
+  // We need this useEffect to update the selectedParent and selectedChild data passed into component,
   // just on initial load
   useEffect(() => {
     if (initialLoadRef.current && projectData?.parentResearchDomainId && projectData?.researchDomainId) {
@@ -178,7 +178,7 @@ const ResearchDomainCascadingDropdown: React.FC<CascadingDropdownProps> = ({ pro
           selectedKey={selectedChild}
           aria-labelledby="child-label"
           aria-invalid={isChildDisabled}
-          aria-required="true"
+          isRequired={true}
           ref={childSelectRef}
           placeholder={ProjectDetail('placeholder.selectSubDomain')}
         >

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -481,8 +481,14 @@ export type AnswerCommentErrors = {
 /** The result of the findCollaborator query */
 export type CollaboratorSearchResult = {
   __typename?: 'CollaboratorSearchResult';
-  /** The collaborator's affiliation */
-  affiliation?: Maybe<Affiliation>;
+  /** The collaborator's affiliation name */
+  affiliationName?: Maybe<Scalars['String']['output']>;
+  /** The affiliation's ROR ID */
+  affiliationRORId?: Maybe<Scalars['String']['output']>;
+  /** The affiliation's ROR URL */
+  affiliationURL?: Maybe<Scalars['String']['output']>;
+  /** The collaborator's email */
+  email?: Maybe<Scalars['String']['output']>;
   /** The collaborator's first/given name */
   givenName?: Maybe<Scalars['String']['output']>;
   /** The unique identifier for the Object */
@@ -491,6 +497,26 @@ export type CollaboratorSearchResult = {
   orcid?: Maybe<Scalars['String']['output']>;
   /** The collaborator's last/sur name */
   surName?: Maybe<Scalars['String']['output']>;
+};
+
+export type CollaboratorSearchResults = PaginatedQueryResults & {
+  __typename?: 'CollaboratorSearchResults';
+  /** The sortFields that are available for this query (for standard offset pagination only!) */
+  availableSortFields?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  /** The current offset of the results (for standard offset pagination) */
+  currentOffset?: Maybe<Scalars['Int']['output']>;
+  /** Whether or not there is a next page */
+  hasNextPage?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether or not there is a previous page */
+  hasPreviousPage?: Maybe<Scalars['Boolean']['output']>;
+  /** The TemplateSearchResults that match the search criteria */
+  items?: Maybe<Array<Maybe<CollaboratorSearchResult>>>;
+  /** The number of items returned */
+  limit?: Maybe<Scalars['Int']['output']>;
+  /** The cursor to use for the next page of results (for infinite scroll/load more) */
+  nextCursor?: Maybe<Scalars['String']['output']>;
+  /** The total number of possible items */
+  totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 export type ExternalFunding = {
@@ -2259,7 +2285,7 @@ export type Query = {
   /** Get all of the research domains related to the specified top level domain (more nuanced ones) */
   childResearchDomains?: Maybe<Array<Maybe<ResearchDomain>>>;
   /** Search for a User to add as a collaborator */
-  findCollaborator?: Maybe<Array<Maybe<CollaboratorSearchResult>>>;
+  findCollaborator?: Maybe<CollaboratorSearchResults>;
   /** Get all of the supported Languages */
   languages?: Maybe<Array<Maybe<Language>>>;
   /** Fetch a specific license */
@@ -2415,7 +2441,8 @@ export type QueryChildResearchDomainsArgs = {
 
 
 export type QueryFindCollaboratorArgs = {
-  term?: InputMaybe<Scalars['String']['input']>;
+  options?: InputMaybe<PaginationOptions>;
+  term: Scalars['String']['input'];
 };
 
 
@@ -3793,7 +3820,7 @@ export type VersionedSectionSearchResults = PaginatedQueryResults & {
   hasNextPage?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a previous page */
   hasPreviousPage?: Maybe<Scalars['Boolean']['output']>;
-  /** The TemplateSearchResults that match the search criteria */
+  /** The SectionSearchResults that match the search criteria */
   items?: Maybe<Array<Maybe<VersionedSectionSearchResult>>>;
   /** The number of items returned */
   limit?: Maybe<Scalars['Int']['output']>;

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -466,6 +466,7 @@
       "back": "Back"
     },
     "labels": {
+      "required": "required",
       "searchByKeyword": "Search by keyword",
       "startDate": "Start date",
       "endDate": "End date",

--- a/messages/en-US/planBuilderProjectOverview.json
+++ b/messages/en-US/planBuilderProjectOverview.json
@@ -78,7 +78,7 @@
     "pageTitle": "Create a new project",
     "isThisMockProject": "Is this a mock project?",
     "form": {
-      "projectTitle": "What is the title for the project? (required)",
+      "projectTitle": "What is the title for the project?",
       "projectTitleHelpText": "You can change this at any time. If you already applied for funding, we recommend using the formal project title for consistency.",
       "checkboxGroupLabel": "This project is mock project for testing, practice, or educational purposes",
       "checkboxGroupHelpText": "This is a mock project intended solely for testing, practice, or educational purposes. It allows you to create a project and plans, but you will not be able to receive feedback or publish them.",

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -279,8 +279,8 @@
       "sampleText": "Plan creators will be able to copy the sample text into the field as a starting point, to speed up content entry."
     },
     "labels": {
-      "type": "Type (required)",
-      "questionText": "Question text (required)",
+      "type": "Type",
+      "questionText": "Question text",
       "requirementText": "Requirements plan writer must meet (optional but recommended)",
       "guidanceText": "Question guidance (optional but recommended)",
       "sampleText": "Sample text"
@@ -306,7 +306,7 @@
   "QuestionOptionsComponent": {
     "labels": {
       "order": "Order",
-      "text": "Text (required)",
+      "text": "Text",
       "default": "Default"
     },
     "buttons": {
@@ -339,10 +339,10 @@
     },
     "labels": {
       "order": "Order",
-      "text": "Text (required)",
+      "text": "Text",
       "default": "Default",
-      "type": "Type (required)",
-      "questionText": "Question text (required)",
+      "type": "Type",
+      "questionText": "Question text",
       "requirementText": "Requirements plan writer must meet (optional but recommended)",
       "guidanceText": "Question guidance (optional but recommended)",
       "sampleText": "Sample text"

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -424,6 +424,7 @@
       "questionDetails": "Detalhes da pergunta"
     },
     "form": {
+      "required": "obrigatório",
       "yesLabel": "Sim",
       "noLabel": "Não"
     },

--- a/messages/pt-BR/planBuilderProjectOverview.json
+++ b/messages/pt-BR/planBuilderProjectOverview.json
@@ -78,7 +78,7 @@
     "pageTitle": "Criar um novo blog",
     "isThisMockProject": "Este é um projeto simulado",
     "form": {
-      "projectTitle": "Qual é o título do projeto? (obrigatório)",
+      "projectTitle": "Qual é o título do projeto?",
       "projectTitleHelpText": "Você pode alterar isso a qualquer momento. Se você já solicitou financiamento, recomendamos usar o título formal do projeto para manter a consistência.",
       "checkboxGroupLabel": "Este projeto é uma simulação (mock, em inglês) para fins de teste, prática ou educacional",
       "checkboxGroupHelpText": "Este é um projeto simulado (mock, em inglês) destinado exclusivamente a testes, práticas ou propósitos educativos. Isso permite que você crie um projeto e planos, mas você não poderá receber comentários ou publicá-los.",

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -279,8 +279,8 @@
       "sampleText": "Pesquisadores poderão copiar o texto de amostra para o campo como ponto de partida, como uma maneira de acelerar a entrada de conteúdo."
     },
     "labels": {
-      "type": "Tipo (obrigatório)",
-      "questionText": "Conjunto de perguntas (obrigatório)",
+      "type": "Tipo",
+      "questionText": "Conjunto de perguntas",
       "requirementText": "Escritor do plano de requisitos deve atender (opcional, mas recomendado)",
       "guidanceText": "Orientação para perguntas (opcional mas recomendado)",
       "sampleText": "Texto de amostra"
@@ -306,7 +306,7 @@
   "QuestionOptionsComponent": {
     "labels": {
       "order": "Ordem",
-      "text": "Texto (obrigatório)",
+      "text": "Texto",
       "default": "Padrão"
     },
     "buttons": {
@@ -339,10 +339,10 @@
     },
     "labels": {
       "order": "Ordem",
-      "text": "Texto (obrigatório)",
+      "text": "Texto",
       "default": "Padrão",
-      "type": "Tipo (obrigatório)",
-      "questionText": "Conjunto de perguntas (obrigatório)",
+      "type": "Tipo",
+      "questionText": "Conjunto de perguntas",
       "requirementText": "Escritor do plano de requisitos deve atender (opcional, mas recomendado)",
       "guidanceText": "Orientação para perguntas (opcional mas recomendado)",
       "sampleText": "Texto de amostra"

--- a/styles/form/_label.scss
+++ b/styles/form/_label.scss
@@ -7,6 +7,10 @@ label,
   margin-bottom: 0.6rem;
 }
 
+.is-required {
+  font-weight: 500;
+  color: var(--slate-600);
+}
 
 .help {
   font-size: 1rem;

--- a/styles/form/_select.scss
+++ b/styles/form/_select.scss
@@ -37,12 +37,12 @@
     }
   }
 
-  span[aria-hidden] {
+  span[aria-hidden]:not(.is-required) {
     width: 1.5rem;
     line-height: 1.375rem;
     margin-left: 1rem;
     padding: 1px;
-    color: var( --gray-600);
+    color: var(--gray-600);
     forced-color-adjust: none;
     border-radius: 4px;
     font-size: 0.557rem;


### PR DESCRIPTION
## Description

This is a new PR based on [#556](https://github.com/CDLUC3/dmsp_frontend_prototype/pull/556)

It adds the new "(required)" field styling to many form input elements, and
allows for setting some files to show the "(required)" text, without being
actually required.

Fixes #552

## Type of change
- [X] Fixed test failing due to new required text
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manual testing via the living styleguide
- Automated testing


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have completed manual or automated accessibility testing for my changes
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
