### PR TITLE
Fixed middleware to redirect back to same url after token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Removed research outputs, including related pages and routes, from the demp overview [#764](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/764)
 
 ### Fixed
+- Update middleware to redirect back to same URL when tokens have been refreshed [#848]
 - Updated `ResearchDomainCascadingDropdown` to not require Research domain fields [#763] 
 - Added missing `relatedWorks` translation keys since it was breaking the pages when locale=pt-BR.
 - Returned changes that were initially part of PR `#816` related to `/template` pagination [#812]

--- a/middleware.ts
+++ b/middleware.ts
@@ -110,18 +110,18 @@ export async function middleware(request: NextRequest) {
 
       if (refreshResult?.response) {
         const backendResponse = refreshResult.response;
-        const nextResponse = NextResponse.next();
+        const newResponse = NextResponse.redirect(request.url);
 
         // Copy Set-Cookie headers from backend → NextResponse
         const setCookie = backendResponse.headers.get("set-cookie");
         if (setCookie) {
           // Multiple cookies can be comma-separated, handle them individually
           setCookie.split(",").forEach(cookie => {
-            nextResponse.headers.append("set-cookie", cookie);
+            newResponse.headers.append("set-cookie", cookie);
           });
         }
 
-        return nextResponse;
+        return newResponse;
       }
 
       // If refresh helper tells us to redirect, do it now

--- a/middleware.ts
+++ b/middleware.ts
@@ -110,6 +110,7 @@ export async function middleware(request: NextRequest) {
 
       if (refreshResult?.response) {
         const backendResponse = refreshResult.response;
+        // We need to redirect to the same URL to ensure cookies are set properly in browser
         const newResponse = NextResponse.redirect(request.url);
 
         // Copy Set-Cookie headers from backend → NextResponse


### PR DESCRIPTION
## Description

In some scenarios, when the middleware refreshes the auth token, the user gets a 404 error. This is because the middleware executes before the actual route is resolved. We set the cookies and return NextResponse.next(), but the request continues without retrying the navigation with the new cookies. To fix this, I updated the middleware to redirect back to the same url to get the new tokens from the browser cookies.


Fixes # ([848](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/848))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested with existing unit tests still passing


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
