### PR TITLE
Addressed 'fast-redact' vulnerability by updating 'pino' version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@
 - Deleted `__mocks__/mockQuestionTypes.json` as it is no longer needed [#322](https://github.com/CDLUC3/dmsp_backend_prototype/issues/322)
 
 ### Chore
+- Addressed `fast-redact` but upgrading `pino` version 
 - Upgraded to `NextJS v15.5.2` to remove vulnerability and added `next-env.d.ts` to the ignore list for linting. [#751]
 
 ====================================================================================================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "next": "15.5.2",
         "next-intl": "4.1.0",
         "node-fetch": "3.3.1",
-        "pino": "9.7.0",
+        "pino": "9.12.0",
         "prop-types": "15.8.1",
         "react": "19.1.1",
         "react-aria-components": "1.10.1",
@@ -10530,14 +10530,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -15445,12 +15437,11 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
-      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.12.0.tgz",
+      "integrity": "sha512-0Gd0OezGvqtqMwgYxpL7P0pSHHzTJ0Lx992h+mNlMtRVfNnqweWmf0JmRWk5gJzHalyd2mxTzKjhiNbGS2Ztfw==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "^2.0.0",
         "pino-std-serializers": "^7.0.0",
@@ -15458,6 +15449,7 @@
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
         "sonic-boom": "^4.0.1",
         "thread-stream": "^3.0.0"
       },
@@ -16662,6 +16654,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/slow-redact": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.0.tgz",
+      "integrity": "sha512-cf723wn9JeRIYP9tdtd86GuqoR5937u64Io+CYjlm2i7jvu7g0H+Cp0l0ShAf/4ZL+ISUTVT+8Qzz7RZmp9FjA=="
     },
     "node_modules/snake-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "next": "15.5.2",
     "next-intl": "4.1.0",
     "node-fetch": "3.3.1",
-    "pino": "9.7.0",
+    "pino": "9.12.0",
     "prop-types": "15.8.1",
     "react": "19.1.1",
     "react-aria-components": "1.10.1",


### PR DESCRIPTION
## Description

Dependabot reported a Prototype Pollution vulnerability in `fast-redact` version `3.5.0` and earlier package, where an attacker could potentially inject properties into Object.prototype

Because there is a zero-day bug, there are no patches for this available. However, we updated the `pino` package to a new version that does not use this package.

## Type of change

- [X] Chore

## How Has This Been Tested?
All existing unit tests pass

