### PR TITLE
Removetext on manage access page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Added description to project search page [#761](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/761)
 
 ### Updated
+- Removed some duplicate text from `template/[templateId]/access` under `External people` [#482]
 - Updated description on `template/[templateId]/access` and visibility text on template publish modal [#482]
 - Updated `/template/[templateId]` to include the `View history` link in the header description [#430]
 - Updated `PageHeaderWithTitleChange` component to pass a `descriptionAppend` in order to append the `View history` JSX [#430]

--- a/app/[locale]/template/[templateId]/access/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/access/__tests__/page.spec.tsx
@@ -84,7 +84,6 @@ describe('TemplateAccessPage', () => {
     expect(screen.getByText('paragraphs.orgAccessPara1')).toBeInTheDocument();
     expect(screen.getByText('paragraphs.orgAccessPara2')).toBeInTheDocument();
     expect(screen.getByText('headings.externalPeople')).toBeInTheDocument();
-    expect(screen.getByText('paragraphs.externalPara1')).toBeInTheDocument();
     expect(screen.getByText('headings.share')).toBeInTheDocument();
     expect(screen.getByText('paragraphs.sharePara1')).toBeInTheDocument();
     expect(screen.getByText('labels.email')).toBeInTheDocument();

--- a/app/[locale]/template/[templateId]/access/page.tsx
+++ b/app/[locale]/template/[templateId]/access/page.tsx
@@ -195,7 +195,7 @@ const TemplateAccessPage: React.FC = () => {
     const collaborators = templateCollaboratorData?.template?.collaborators;
 
     if (collaborators?.length === 0) {
-      return <p role="status">{AccessPage('messages.info.noCollaborators')}</p>;
+      return <p className={styles.emptyState} role="status">{AccessPage('messages.info.noCollaborators')}</p>;
     }
 
     return (

--- a/app/[locale]/template/[templateId]/access/page.tsx
+++ b/app/[locale]/template/[templateId]/access/page.tsx
@@ -195,7 +195,7 @@ const TemplateAccessPage: React.FC = () => {
     const collaborators = templateCollaboratorData?.template?.collaborators;
 
     if (collaborators?.length === 0) {
-      return <div className={styles.emptyState} role="status">{AccessPage('messages.info.noCollaborators')}</div>;
+      return <p role="status">{AccessPage('messages.info.noCollaborators')}</p>;
     }
 
     return (
@@ -284,7 +284,6 @@ const TemplateAccessPage: React.FC = () => {
                   <h3 id="external-access-heading">{AccessPage('headings.externalPeople')}</h3>
                 </div>
                 <div className="sectionContent">
-                  <p>{AccessPage('paragraphs.externalPara1', { orgName: organization?.name || '' })}</p>
                   <div className={styles.externalPeopleList}>
                     {renderExternalPeople}
                   </div>

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -481,8 +481,14 @@ export type AnswerCommentErrors = {
 /** The result of the findCollaborator query */
 export type CollaboratorSearchResult = {
   __typename?: 'CollaboratorSearchResult';
-  /** The collaborator's affiliation */
-  affiliation?: Maybe<Affiliation>;
+  /** The collaborator's affiliation name */
+  affiliationName?: Maybe<Scalars['String']['output']>;
+  /** The affiliation's ROR ID */
+  affiliationRORId?: Maybe<Scalars['String']['output']>;
+  /** The affiliation's ROR URL */
+  affiliationURL?: Maybe<Scalars['String']['output']>;
+  /** The collaborator's email */
+  email?: Maybe<Scalars['String']['output']>;
   /** The collaborator's first/given name */
   givenName?: Maybe<Scalars['String']['output']>;
   /** The unique identifier for the Object */
@@ -491,6 +497,26 @@ export type CollaboratorSearchResult = {
   orcid?: Maybe<Scalars['String']['output']>;
   /** The collaborator's last/sur name */
   surName?: Maybe<Scalars['String']['output']>;
+};
+
+export type CollaboratorSearchResults = PaginatedQueryResults & {
+  __typename?: 'CollaboratorSearchResults';
+  /** The sortFields that are available for this query (for standard offset pagination only!) */
+  availableSortFields?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  /** The current offset of the results (for standard offset pagination) */
+  currentOffset?: Maybe<Scalars['Int']['output']>;
+  /** Whether or not there is a next page */
+  hasNextPage?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether or not there is a previous page */
+  hasPreviousPage?: Maybe<Scalars['Boolean']['output']>;
+  /** The TemplateSearchResults that match the search criteria */
+  items?: Maybe<Array<Maybe<CollaboratorSearchResult>>>;
+  /** The number of items returned */
+  limit?: Maybe<Scalars['Int']['output']>;
+  /** The cursor to use for the next page of results (for infinite scroll/load more) */
+  nextCursor?: Maybe<Scalars['String']['output']>;
+  /** The total number of possible items */
+  totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 export type ExternalFunding = {
@@ -2259,7 +2285,7 @@ export type Query = {
   /** Get all of the research domains related to the specified top level domain (more nuanced ones) */
   childResearchDomains?: Maybe<Array<Maybe<ResearchDomain>>>;
   /** Search for a User to add as a collaborator */
-  findCollaborator?: Maybe<Array<Maybe<CollaboratorSearchResult>>>;
+  findCollaborator?: Maybe<CollaboratorSearchResults>;
   /** Get all of the supported Languages */
   languages?: Maybe<Array<Maybe<Language>>>;
   /** Fetch a specific license */
@@ -2415,7 +2441,8 @@ export type QueryChildResearchDomainsArgs = {
 
 
 export type QueryFindCollaboratorArgs = {
-  term?: InputMaybe<Scalars['String']['input']>;
+  options?: InputMaybe<PaginationOptions>;
+  term: Scalars['String']['input'];
 };
 
 
@@ -3793,7 +3820,7 @@ export type VersionedSectionSearchResults = PaginatedQueryResults & {
   hasNextPage?: Maybe<Scalars['Boolean']['output']>;
   /** Whether or not there is a previous page */
   hasPreviousPage?: Maybe<Scalars['Boolean']['output']>;
-  /** The TemplateSearchResults that match the search criteria */
+  /** The SectionSearchResults that match the search criteria */
   items?: Maybe<Array<Maybe<VersionedSectionSearchResult>>>;
   /** The number of items returned */
   limit?: Maybe<Scalars['Int']['output']>;

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -387,7 +387,6 @@
     "paragraphs": {
       "orgAccessPara1": "Everyone at {name} can view and edit",
       "orgAccessPara2": "{count} administrator(s) can manage access",
-      "externalPara1": "Share this template with people outside {orgName}",
       "sharePara1": "Enter their email address. If they do not already have a DMP Tool account they will be prompted to create one.",
       "modalPara1": "Please confirm that you want to remove {email}"
     },

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -387,7 +387,6 @@
     "paragraphs": {
       "orgAccessPara1": "Todos em {name} podem ver e editar",
       "orgAccessPara2": "Administradores {count} podem gerenciar o acesso",
-      "externalPara1": "Compartilhe este modelo com pessoas fora do {orgName}",
       "sharePara1": "Digite seu endereço de e-mail. Se eles já não tiverem uma conta de DMP Tool eles serão convidados a criar uma.",
       "modalPara1": "Por favor, confirme que você deseja remover {email}"
     },


### PR DESCRIPTION
## Description

Previously, there was a PR under the same ticket to update some text on the Manage Access page. Becky reviewed it and decided that we need to remove some text.

- Removed some duplicate text from `template/[templateId]/access` under `External people`

Fixes # (#482 )

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually tested and updated unit test for page.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
