### PR TITLE
Fixed type error in FormSelect due to a change in @types/react versions when merging stage into development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@
 - Deleted `__mocks__/mockQuestionTypes.json` as it is no longer needed [#322](https://github.com/CDLUC3/dmsp_backend_prototype/issues/322)
 
 ### Chore
-
+- Fixed type error in `FormSelect` due to a change in `@types/react` versions when merging `stage` into `development`
 - Addressed `fast-redact` but upgrading `pino` version
 - Upgraded to `NextJS v15.5.2` to remove vulnerability and added `next-env.d.ts` to the ignore list for linting. [#751]
 

--- a/components/Form/FormSelect/index.tsx
+++ b/components/Form/FormSelect/index.tsx
@@ -22,7 +22,7 @@ interface SelectItem {
   name: string;
 }
 interface MySelectProps<T extends SelectItem>
-  extends Omit<SelectProps<T>, 'children'> {
+  extends Omit<SelectProps<T>, 'children' | 'onChange'> {
   label?: string;
   ariaLabel?: string;
   errorMessage?: string | ((validation: ValidationResult) => string);


### PR DESCRIPTION

## Description

We got a type error when merging stage into development, due to a change in `@types/react` versions. Somehow they got out of sync.

