### PR TITLE
 Disable Apollo Graphql renovate PR and fix missing logs from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+### Added
+- Added updated description that includes template source, affiliation name, version and publish date on the `Plan Overview` page [#621]
+
+
+### Updated
+
+
+### Fixed
+
+
+### Removed
+
+### Chore
+- Disable `Apollo Graphql` renovate PR and fix missing logs from CHANGELOG
+- Added `renovate.json` config file in order to get automatic PRs for dependency updates
 ==================================================================================================================
 <!-- Merged below to main branch on Friday, July 18th, 2025  -->
 ### Added

--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,11 @@
     "Dockerfile*",
     "docker-compose.yml",
     ".nvmrc"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Apollo GraphQL packages", // disable update to @apollo/client and @apollo/experimental-nextjs-app-support for now
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Description

There is a `renovate` PR that keeps on reappearing even though we are currently not able to make that update due to some version collisions (https://github.com/CDLUC3/dmsp_frontend_prototype/pull/905). It sounds like usually we can just close a PR as long as the title as the package and version number, but since this PR is a `group`, we have to update the `renovate.json` file to block this PR.

Hopefully this will work.

