### PR TITLE
Configured renovate.json to stop current PRs for updates to apollo/cl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Removed
 
 ### Chore
+- Trying another method of disabling the renovate `Apollo Graphql Group update` 
 - Disable `Apollo Graphql` renovate PR and fix missing logs from CHANGELOG
 - Added `renovate.json` config file in order to get automatic PRs for dependency updates
 ==================================================================================================================

--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,12 @@
   ],
   "packageRules": [
     {
-      "groupName": "Apollo GraphQL packages", // disable update to @apollo/client and @apollo/experimental-nextjs-app-support for now
-      "enabled": false
+      "matchPackageNames": [
+        "@apollo/client",
+        "@apollo/experimental-nextjs-app-support"
+      ],
+      "enabled": false,
+      "description": "Disable updates for specific Apollo GraphQL packages"
     }
   ]
 }


### PR DESCRIPTION
## Description

Reconfigured renovate.json to stop current PRs for updates to `apollo/client` and `apollo/experimental-nextjs-app-support` since it collides with graphql-codegen. The earlier change did not work: https://github.com/CDLUC3/dmsp_frontend_prototype/pull/906

Trying a different approach to the `renovate.json` config to stop submitting PRs for updating the above dependencies, as they currently don't work with the `graphql-codegen` versions.
