### PR TITLE
Updated renovate.json for main branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,19 @@
     "Dockerfile*",
     "docker-compose.yml",
     ".nvmrc"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "@apollo/client",
+        "@apollo/experimental-nextjs-app-support"
+      ],
+      "enabled": false,
+      "description": "Disable updates for Apollo GraphQL packages"
+    }
+  ],
+  "ignoreDeps": [
+    "@apollo/client",
+    "@apollo/experimental-nextjs-app-support"
   ]
 }


### PR DESCRIPTION
## Description

I forgot that I have to update `renovate.json` on the root branch, which is `main` for us, in order to ignore the Apollo GraphQL PR update. It's sort of a pain, but I'll do it for now to see if it works.
