### PR TITLE
Updated Project Details page to hide subDomain field until user selects a research domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Hooked up the `Download plan` page and added a `download-narrative` api endpoint [#313]
 
 ### Updated
+- Updated Project Details subdomains field to only display once a user selects a research domain [#947]
 
 ### Fixed
 

--- a/app/[locale]/projects/[projectId]/project/page.tsx
+++ b/app/[locale]/projects/[projectId]/project/page.tsx
@@ -40,20 +40,12 @@ import { getCalendarDateValue } from "@/utils/dateUtils";
 import { scrollToTop } from '@/utils/general';
 import { logECS, routePath } from '@/utils/index';
 import { useToast } from '@/context/ToastContext';
+import { ProjectDetailsFormInterface } from "@/app/types";
+
 
 interface ProjectFormErrorsInterface {
   projectName: string;
   projectAbstract: string;
-}
-
-interface ProjectDetailsFormInterface {
-  projectName: string;
-  projectAbstract: string;
-  startDate: string | CalendarDate | null;
-  endDate: string | CalendarDate | null;
-  researchDomainId: string | number;
-  isTestProject: string | boolean;
-  parentResearchDomainId: string | number;
 }
 
 const ProjectsProjectDetail = () => {

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import { PlanSectionProgress, TemplateVisibility, PlanFeedback, ProjectFundingStatus } from "@/generated/graphql";
 import { AffiliationSearchQuestionType, AnyQuestionType } from '@dmptool/types';
+import { CalendarDate } from "@internationalized/date";
 
 // Re-export types from questionAdd module
 export * from './questionAdd';
@@ -513,3 +514,14 @@ export interface ProjectFundingInterface {
   funderOpportunityNumber: string;
   funderProjectNumber: string;
 }
+
+export interface ProjectDetailsFormInterface {
+  projectName: string;
+  projectAbstract: string;
+  startDate: string | CalendarDate | null;
+  endDate: string | CalendarDate | null;
+  researchDomainId: string | number;
+  isTestProject: string | boolean;
+  parentResearchDomainId: string | number;
+}
+

--- a/messages/en-US/planBuilderProjectOverview.json
+++ b/messages/en-US/planBuilderProjectOverview.json
@@ -123,7 +123,7 @@
       "researchDomain": "Research domain",
       "mockProject": "Mock project",
       "realProject": "Real project",
-      "childDomain": "Select a subdomain for {name}:",
+      "childDomain": "Select a subdomain for {name}",
       "item": "Item"
     },
     "helpText": {

--- a/messages/pt-BR/planBuilderProjectOverview.json
+++ b/messages/pt-BR/planBuilderProjectOverview.json
@@ -123,7 +123,7 @@
       "researchDomain": "Domínio de pesquisa",
       "mockProject": "Projeto fictício",
       "realProject": "Projeto real",
-      "childDomain": "Selecione um subdomínio para {name}:",
+      "childDomain": "Selecione um subdomínio para {name}",
       "item": "Produto"
     },
     "helpText": {


### PR DESCRIPTION
## Description

- Updated Project Details page to hide subDomain field until user selects a research domain

Fixes # ([947](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/947))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and updated unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screen Recording

https://github.com/user-attachments/assets/82792a7b-3fef-4763-948a-b73c751e6a8e

