### PR TITLE
Changed 'remove' buttons in Repository and Metadata Standards selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Updated
 - Updated Project Details subdomains field to only display once a user selects a research domain [#947]
+- Updated `Remove` buttons to be `secondary` buttons, rather than `red` [#964]
 
 ### Fixed
 

--- a/components/QuestionAdd/MetaDataStandards.tsx
+++ b/components/QuestionAdd/MetaDataStandards.tsx
@@ -202,7 +202,7 @@ const MetaDataStandardsSelector = ({
                   <Button
                     onClick={removeAllStandards}
                     isDisabled={selectedCount === 0}
-                    className="danger medium"
+                    className="secondary medium"
                   >
                     {Global('buttons.removeAll')}
                   </Button>
@@ -219,7 +219,7 @@ const MetaDataStandardsSelector = ({
                         </div>
                         <Button
                           onClick={() => removeStandard(std.id)}
-                          className="danger small"
+                          className="secondary small"
                         >
                           {Global('buttons.remove')}
                         </Button>
@@ -374,7 +374,7 @@ const MetaDataStandardsSelector = ({
                               <div className={styles.searchResultTitle}>{std.name}</div>
                               <Button
                                 onClick={() => toggleSelection(std)}
-                                className={`small ${isSelected ? 'danger' : 'primary'}`}
+                                className={`small ${isSelected ? 'secondary' : 'primary'}`}
                               >
                                 {isSelected ? Global('buttons.remove') : Global('buttons.select')}
                               </Button>

--- a/components/QuestionAdd/ReposSelector.tsx
+++ b/components/QuestionAdd/ReposSelector.tsx
@@ -279,7 +279,7 @@ const RepositorySelectionSystem = ({
                   <Button
                     onClick={removeAllRepos}
                     isDisabled={selectedCount === 0}
-                    className="danger medium"
+                    className="medium secondary"
                   >
                     {Global('buttons.removeAll')}
                   </Button>
@@ -311,7 +311,7 @@ const RepositorySelectionSystem = ({
                         </div>
                         <Button
                           onClick={() => removeRepo(repo.id)}
-                          className={`${styles.removeBtn} danger small`}
+                          className={`${styles.removeBtn} secondary small`}
                         >
                           {Global('buttons.remove')}
                         </Button>
@@ -504,7 +504,7 @@ const RepositorySelectionSystem = ({
                               <div className={styles.searchResultTitle}>{repo.name}</div>
                               <Button
                                 onClick={() => toggleSelection(repo)}
-                                className={`small ${isSelected ? 'danger' : 'primary'}`}
+                                className={`small ${isSelected ? 'secondary' : 'primary'}`}
                               >
                                 {isSelected ? Global('buttons.remove') : Global('buttons.select')}
                               </Button>

--- a/styles/form/_button.scss
+++ b/styles/form/_button.scss
@@ -71,7 +71,7 @@
 }
 
 @mixin button-secondary {
-  background: transparent;
+  background: var(--bg-white);
 
   // box-shadow makes border appear on the inside of button, keeping it same size as primary button, as opposed to
   // border, which renders the border on the outside of the button, making secondary larger than primary. An


### PR DESCRIPTION

## Description

- Updated the static "Research Outputs" page to use `secondary` styles on the `remove` buttons for Repository and Metadata standards selectors.

Fixes # ([964](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/964))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshots

<img width="530" height="669" alt="image" src="https://github.com/user-attachments/assets/29f2f358-3f55-4755-b02d-6c3d67aabb58" />

<img width="518" height="683" alt="image" src="https://github.com/user-attachments/assets/b7079860-2f64-4858-b571-ad99da310a60" />
