### PR TITLE
Updated renovate and dependabot configs for comparison purposes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,9 @@ updates:
     directory: "/"
     # Check the npm registry for updates once a week
     schedule:
-      interval: "weekly"
+    interval: "weekly"
+    # Open a maximum of 50 pull requests at a time
+    open-pull-requests-limit: 50
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -19,5 +21,7 @@ updates:
     directory: "/"
     # Check for updates once a week
     schedule:
-      interval: "weekly"
+    interval: "weekly"
+    # Open a maximum of 50 pull requests at a time
+    open-pull-requests-limit: 50
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Chore
+- Updated `renovate` and `dependabot` configs for comparison purposes
+
 ==================================================================================================================
 <!-- Merged below to main branch on Friday, July 18th, 2025  -->
 ### Added
@@ -59,8 +62,6 @@
 - Created the static page for the org admin user dashboard. [#782]
 
 ### Updated
-<<<<<<< HEAD
-
 - Removed some duplicate text from `template/[templateId]/access` under `External people` [#482]
 - Updated description on `template/[templateId]/access` and visibility text on template publish modal [#482]
 - Updated `/template/[templateId]` to include the `View history` link in the header description [#430]
@@ -81,7 +82,6 @@
 =======
 - Updated the `CODE_OF_CONDUCT.md` to reflect CDLUC3's Code of Conduct
 - Updated the `CONTRIBUTING.md` to include steps for contributing to the repo
->>>>>>> main
 - Updated the shared`RadioGroupComponent` and `CheckboxGroupComponent` components to be more like a wrapper to reduce duplicate of code and make it more flexible [#743]
 - Project over is now using sidebar to allow for collaboration [#750]
 - Sidebar is now using global styling rather than css modules [#750]

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
   "extends": [
     "config:recommended"
   ],
+  "timezone": "America/Los_Angeles",
+  "schedule": [
+    "before 5am on monday"
+  ],
   "enabledManagers": [
     "npm"
   ],


### PR DESCRIPTION
## Description

I have been comparing Renovate with Dependabot for managing dependency updates. I need to compare the dependency updates that Dependabot lists with Renovate, but currently there is no dashboard, so the only way is to increase the limit for generating PRs.

Configured Dependabot to give us a longer list of PRs, in order to compare its list with Renovate.
Updated renovate config to schedule the PRs
