### PR TITLE
Added help text fields to Description, Repositories, Metadata Standards, License, Initial Access Level and Custom Text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Added
+- Added `Help text` fields to `Description, Repositories, Metadata Standards, License, Access Level and Custom Text` fields in Research Output question type [#970]
 - Added customizable `Initial Access Level` field to the QuestionAdd page for Research Outputs question type [#969]
 - Added new `Start DMP` page at `projects/[projectId]/dmp/start` to direct user to create new plan or upload existing [#956]
 - Added `autosave` back to the `PlanOverviewQuestionpage` [#944]

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -133,8 +133,22 @@ const defaultOutputTypes = [
 
 // Initial Standard Fields data
 const initialStandardFields: StandardField[] = [
-  { id: 'title', label: 'Title', enabled: true, required: true },
-  { id: 'description', label: 'Description', enabled: false, placeholder: '', helpText: '', maxLength: '', required: true, value: '' },
+  {
+    id: 'title',
+    label: 'Title',
+    enabled: true,
+    required: true
+  },
+  {
+    id: 'description',
+    label: 'Description',
+    enabled: false,
+    placeholder: '',
+    helpText: '',
+    maxLength: '',
+    required: true,
+    value: ''
+  },
   {
     id: 'outputType',
     label: 'Output Type',
@@ -1052,14 +1066,27 @@ const QuestionAdd = ({
                               <div className={styles.fieldPanel}>
                                 {/** Description */}
                                 {field.id === 'description' && (
-                                  <FormTextArea
-                                    name={QuestionAdd('researchOutput.labels.descriptionLowerCase')}
-                                    isRequired={false}
-                                    richText={true}
-                                    label={QuestionAdd('researchOutput.labels.description')}
-                                    value={field.value}
-                                    onChange={(newValue) => updateStandardFieldProperty('description', 'value', newValue)}
-                                  />
+                                  <>
+                                    <FormTextArea
+                                      name={QuestionAdd('researchOutput.labels.descriptionLowerCase')}
+                                      isRequired={false}
+                                      richText={true}
+                                      label={QuestionAdd('researchOutput.labels.description')}
+                                      value={field.value}
+                                      onChange={(newValue) => updateStandardFieldProperty('description', 'value', newValue)}
+                                    />
+
+                                    <FormInput
+                                      name="descriptionHelpText"
+                                      type="text"
+                                      isRequired={false}
+                                      label={QuestionAdd('labels.helpText', { fieldName: QuestionAdd('researchOutput.labels.description') })}
+                                      value={field.helpText || ''}
+                                      onChange={(e) => updateStandardFieldProperty('description', 'helpText', e.currentTarget.value)}
+                                      helpMessage={QuestionAdd('researchOutput.helpText')}
+                                      maxLength={300}
+                                    />
+                                  </>
                                 )}
 
                                 {/** Data Flags Configuration */}
@@ -1123,6 +1150,17 @@ const QuestionAdd = ({
                                       value={field.value}
                                       onChange={(value) => updateStandardFieldProperty('repoSelector', 'value', value)}
                                     />
+
+                                    <FormInput
+                                      name="repositoriesHelpText"
+                                      type="text"
+                                      isRequired={false}
+                                      label={QuestionAdd('labels.helpText', { fieldName: field.label })}
+                                      value={field.helpText || ''}
+                                      onChange={(e) => updateStandardFieldProperty('repoSelector', 'helpText', e.currentTarget.value)}
+                                      helpMessage={QuestionAdd('researchOutput.helpText')}
+                                      maxLength={300}
+                                    />
                                   </>
                                 )}
 
@@ -1144,31 +1182,67 @@ const QuestionAdd = ({
                                       helpMessage={QuestionAdd('researchOutput.metaDataStandards.helpText')}
                                       onChange={(value) => updateStandardFieldProperty('metaDataStandards', 'value', value)}
                                     />
+
+                                    <FormInput
+                                      name="metadataStandardsHelpText"
+                                      type="text"
+                                      isRequired={false}
+                                      label={QuestionAdd('labels.helpText', { fieldName: field.label })}
+                                      value={field.helpText || ''}
+                                      onChange={(e) => updateStandardFieldProperty('metadataStandards', 'helpText', e.currentTarget.value)}
+                                      helpMessage={QuestionAdd('researchOutput.helpText')}
+                                      maxLength={300}
+                                    />
                                   </>
                                 )}
 
                                 {/**License configurations */}
                                 {field.id === 'licenses' && (
-                                  <LicenseField
-                                    field={field}
-                                    newLicenseType={newLicenseType}
-                                    setNewLicenseType={setNewLicenseType}
-                                    onModeChange={handleLicenseModeChange}
-                                    onAddCustomType={handleAddCustomLicenseType}
-                                    onRemoveCustomType={handleRemoveCustomLicenseType}
-                                  />
+                                  <>
+                                    <LicenseField
+                                      field={field}
+                                      newLicenseType={newLicenseType}
+                                      setNewLicenseType={setNewLicenseType}
+                                      onModeChange={handleLicenseModeChange}
+                                      onAddCustomType={handleAddCustomLicenseType}
+                                      onRemoveCustomType={handleRemoveCustomLicenseType}
+                                    />
+                                    <FormInput
+                                      name="licensesHelpText"
+                                      type="text"
+                                      isRequired={false}
+                                      label={QuestionAdd('labels.helpText', { fieldName: field.label })}
+                                      value={field.helpText || ''}
+                                      onChange={(e) => updateStandardFieldProperty('licenses', 'helpText', e.currentTarget.value)}
+                                      helpMessage={QuestionAdd('researchOutput.helpText')}
+                                      maxLength={300}
+                                    />
+                                  </>
                                 )}
 
                                 {/**Access level configurations */}
                                 {field.id === 'accessLevels' && (
-                                  <InitialAccessLevel
-                                    field={field}
-                                    newAccessLevel={newAccessLevel}
-                                    setNewAccessLevel={setNewAccessLevel}
-                                    onModeChange={handleAccessLevelModeChange}
-                                    onAddCustomType={handleAddCustomAccessLevel}
-                                    onRemoveCustomType={handleRemoveCustomAccessLevels}
-                                  />
+                                  <>
+                                    <InitialAccessLevel
+                                      field={field}
+                                      newAccessLevel={newAccessLevel}
+                                      setNewAccessLevel={setNewAccessLevel}
+                                      onModeChange={handleAccessLevelModeChange}
+                                      onAddCustomType={handleAddCustomAccessLevel}
+                                      onRemoveCustomType={handleRemoveCustomAccessLevels}
+                                    />
+
+                                    <FormInput
+                                      name="accessLevelsHelpText"
+                                      type="text"
+                                      isRequired={false}
+                                      label={QuestionAdd('labels.helpText', { fieldName: field.label })}
+                                      value={field.helpText || ''}
+                                      onChange={(e) => updateStandardFieldProperty('accessLevels', 'helpText', e.currentTarget.value)}
+                                      helpMessage={QuestionAdd('researchOutput.helpText')}
+                                      maxLength={300}
+                                    />
+                                  </>
                                 )}
                               </div>
                             )}
@@ -1235,14 +1309,14 @@ const QuestionAdd = ({
                                     />
 
                                     {/* Help Text */}
-                                    <FormTextArea
+                                    <FormInput
                                       name={`${field.id}_help`}
                                       isRequired={false}
-                                      richText={false}
-                                      label={QuestionAdd('researchOutput.additionalFields.helpText.label')}
+                                      label={QuestionAdd('labels.helpText', { fieldName: field.customLabel || field.label })}
                                       value={field.helpText}
                                       onChange={(value) => handleUpdateAdditionalField(field.id, 'helpText', value)}
-                                      helpMessage={QuestionAdd('researchOutput.additionalFields.helpText.helpText')}
+                                      helpMessage={QuestionAdd('researchOutput.helpText')}
+                                      maxLength={300}
                                     />
 
                                     {/* Max Length for text field */}

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -369,7 +369,8 @@
       "addCustomOutputType": "Add custom output type",
       "addCustomAccessLevel": "Add custom access level",
       "customTypeList": "Custom output types list",
-      "customAccessLevelList": "Custom access levels list"
+      "customAccessLevelList": "Custom access levels list",
+      "helpText": "Help text for {fieldName}"
     },
     "buttons": {
       "addRow": "Add Row",
@@ -400,6 +401,7 @@
       }
     },
     "researchOutput": {
+      "helpText": "Max length is 300 characters.",
       "headings": {
         "enableStandardFields": "Enable standard fields",
         "additionalTextFields": "Additional text fields"
@@ -538,7 +540,7 @@
         },
         "helpText": {
           "label": "Help text",
-          "helpText": "Optional help text to guide users"
+          "helpText": "Optional help text to guide users. Max length 300 characters."
         },
         "maxLength": {
           "label": "Maximum length",

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -369,7 +369,8 @@
       "addCustomOutputType": "Adicionar tipo de saída personalizado",
       "addCustomAccessLevel": "Adicionar nível de acesso personalizado",
       "customTypeList": "Lista de tipos de saída personalizados",
-      "customAccessLevelList": "Lista de níveis de acesso personalizados"
+      "customAccessLevelList": "Lista de níveis de acesso personalizados",
+      "helpText": "Texto de ajuda para {fieldName}"
     },
     "buttons": {
       "addRow": "Adicionar linha",
@@ -398,6 +399,7 @@
       }
     },
     "researchOutput": {
+      "helpText": "O comprimento máximo é de 300 caracteres.",
       "headings": {
         "enableStandardFields": "Ativar campos padrão"
       },
@@ -532,18 +534,18 @@
           "helpText": "O rótulo que será exibido para este campo"
         },
         "helpText": {
-          "label": "Help text",
-          "helpText": "Optional help text to guide users"
+          "label": "Texto de ajuda",
+          "helpText": "Texto de ajuda opcional para orientar os usuários. Comprimento máximo de 300 caracteres."
         },
         "maxLength": {
-          "label": "Maximum length",
-          "helpText": "Maximum number of characters allowed (leave empty for no limit)"
+          "label": "Comprimento máximo",
+          "helpText": "Número máximo de caracteres permitidos (deixe vazio para sem limite)"
         },
         "defaultValue": {
-          "label": "Default value",
-          "helpText": "Default value for this field"
+          "label": "Valor padrão",
+          "helpText": "Valor padrão para este campo"
         },
-        "addFieldBtn": "Add additional field"
+        "addFieldBtn": "Adicionar campo adicional"
       }
     }
   },


### PR DESCRIPTION

## Description

Pretty simple update to add "Help text" fields with a max length of 300 to Description, Repositories, Metadata Standards, License, Initial Access Level and Custom text fields

Fixes # ([970](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/970))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually tested. Unit tests will be updated in more detail when integrating with actual Research Output question type from backend.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
