### PR TITLE
Removed description fields for Repositories, Metadata Standards and Description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 ### Removed
+- Removed `Description` fields for Research Output question fields [#970]
 - Removed `scrollToTop` from `Template Create` page [#950]
 
 ### Chore

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -1836,7 +1836,7 @@ describe("Research Output Question Type", () => {
     });
 
     // Should show repository configuration
-    expect(screen.getByText('researchOutput.repoSelector.descriptionLabel')).toBeInTheDocument();
+    expect(screen.getByText('labels.helpText')).toBeInTheDocument();
   });
 
   it('should handle metadata standards configuration', async () => {
@@ -1870,7 +1870,7 @@ describe("Research Output Question Type", () => {
     });
 
     // Should show metadata standards configuration
-    expect(screen.getByText('researchOutput.metaDataStandards.descriptionLabel')).toBeInTheDocument();
+    expect(screen.getByText('labels.helpText')).toBeInTheDocument();
   });
 
   it('should handle license configuration', async () => {

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -1066,27 +1066,16 @@ const QuestionAdd = ({
                               <div className={styles.fieldPanel}>
                                 {/** Description */}
                                 {field.id === 'description' && (
-                                  <>
-                                    <FormTextArea
-                                      name={QuestionAdd('researchOutput.labels.descriptionLowerCase')}
-                                      isRequired={false}
-                                      richText={true}
-                                      label={QuestionAdd('researchOutput.labels.description')}
-                                      value={field.value}
-                                      onChange={(newValue) => updateStandardFieldProperty('description', 'value', newValue)}
-                                    />
-
-                                    <FormInput
-                                      name="descriptionHelpText"
-                                      type="text"
-                                      isRequired={false}
-                                      label={QuestionAdd('labels.helpText', { fieldName: QuestionAdd('researchOutput.labels.description') })}
-                                      value={field.helpText || ''}
-                                      onChange={(e) => updateStandardFieldProperty('description', 'helpText', e.currentTarget.value)}
-                                      helpMessage={QuestionAdd('researchOutput.helpText')}
-                                      maxLength={300}
-                                    />
-                                  </>
+                                  <FormInput
+                                    name="descriptionHelpText"
+                                    type="text"
+                                    isRequired={false}
+                                    label={QuestionAdd('labels.helpText', { fieldName: QuestionAdd('researchOutput.labels.description') })}
+                                    value={field.helpText || ''}
+                                    onChange={(e) => updateStandardFieldProperty('description', 'helpText', e.currentTarget.value)}
+                                    helpMessage={QuestionAdd('researchOutput.helpText')}
+                                    maxLength={300}
+                                  />
                                 )}
 
                                 {/** Data Flags Configuration */}
@@ -1142,15 +1131,6 @@ const QuestionAdd = ({
                                       onRepositoriesChange={handleRepositoriesChange}
                                     />
 
-                                    <FormTextArea
-                                      name="repoSelectorDescription"
-                                      isRequired={false}
-                                      richText={true}
-                                      label={QuestionAdd('researchOutput.repoSelector.descriptionLabel')}
-                                      value={field.value}
-                                      onChange={(value) => updateStandardFieldProperty('repoSelector', 'value', value)}
-                                    />
-
                                     <FormInput
                                       name="repositoriesHelpText"
                                       type="text"
@@ -1171,16 +1151,6 @@ const QuestionAdd = ({
                                       field={field}
                                       handleToggleMetaDataStandards={handleToggleMetaDataStandards}
                                       onMetaDataStandardsChange={handleMetaDataStandardsChange}
-                                    />
-
-                                    <FormTextArea
-                                      name="metadataStandardsDescription"
-                                      isRequired={false}
-                                      richText={true}
-                                      label={QuestionAdd('researchOutput.metaDataStandards.descriptionLabel')}
-                                      value={field.value}
-                                      helpMessage={QuestionAdd('researchOutput.metaDataStandards.helpText')}
-                                      onChange={(value) => updateStandardFieldProperty('metaDataStandards', 'value', value)}
                                     />
 
                                     <FormInput


### PR DESCRIPTION

## Description

- Previously added Help Text fields, but need to now remove the Description fields
Fixes # ([970](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/970))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually tested and updated unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshot
### Description fields no longer included for Description, Repositories or Metadata Standards
<img width="748" height="878" alt="image" src="https://github.com/user-attachments/assets/5bc0c9eb-0dbd-48ef-90cd-69aeb8d75d3f" />


<img width="625" height="885" alt="image" src="https://github.com/user-attachments/assets/bbc4c109-fd6a-4a86-889f-b0f38b955536" />
