### PR TITLE
Updated TemplateEditPage to apply Unpublished changes status when isDirty=true and latestPublishDate is not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Added new `ResearchOutputAnswerComponent`, `SingleResearchOutputComponent`, `RepoSelectorForAnswer` and `MetaDataStandardForAnswer` components for the rendering of `researchOutputTable` question type answer form [#787]
 - Added `utils/researchOutputTransformations.ts` to group utilities for `researchOutputTable` [#787]
 ### Updated
+- Updated `TemplateEditPage` component with the new `Unpublished changes` status [#875]
 - Updated `QuestionAdd` and associated unit tests to include tests for new `researchOutputTable` question type [#787]
 - Update `PlanOverviewQuestionPage` component and related unit test in template builder flow to add `researchOutputTable` question type support [#787]
 - Updated `QuestionEdit` page and related unit test to improve the `researchOutputTable` question type application by moving hydration out to hook [#787]

--- a/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/__tests__/page.spec.tsx
@@ -360,6 +360,207 @@ describe("TemplateEditPage", () => {
     });
   });
 
+  it("should display draft status when there is no publish date", async () => {
+    const mockTemplateDataWithNoPublishDate = {
+      __typename: "Template",
+      id: 395,
+      name: "Test Template",
+      description: null,
+      errors: {
+        __typename: "TemplateErrors",
+        general: null,
+        name: null,
+        ownerId: null
+      },
+      latestPublishVersion: "",
+      latestPublishDate: null,
+      created: "2026-01-06 16:02:26",
+      sections: [
+        {
+          __typename: "Section",
+          id: 1815,
+          name: "Section One",
+          bestPractice: false,
+          displayOrder: 1,
+          isDirty: false,
+          questions: [
+            {
+              __typename: "Question",
+              errors: {
+                __typename: "QuestionErrors",
+                general: null,
+              },
+              displayOrder: 1,
+              guidanceText: "",
+              id: 3688,
+              questionText: "Text area question123",
+              sectionId: 1815,
+              templateId: 395
+            }
+          ]
+        }
+      ],
+      owner: {
+        __typename: "Affiliation",
+        displayName: "California Digital Library (cdlib.org)",
+        id: 1
+      },
+      latestPublishVisibility: "PUBLIC",
+      bestPractice: false,
+      isDirty: true
+    };
+
+    (useTemplateQuery as jest.Mock).mockReturnValue({
+      data: { template: mockTemplateDataWithNoPublishDate },
+      loading: false,
+      error: null,
+    });
+    (useCreateTemplateVersionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: "value" } }), // Correct way to mock a resolved promise
+      { loading: false, error: undefined },
+    ]);
+
+    await act(async () => {
+      render(<TemplateEditPage />);
+    });
+
+    expect(screen.getByText("status.draft")).toBeInTheDocument();
+  });
+
+  it("should display published status when there is a publish date and isDirty is false", async () => {
+    const mockPublishedTemplateWithNoEdits = {
+      __typename: "Template",
+      id: 395,
+      name: "Test Template",
+      description: null,
+      errors: {
+        __typename: "TemplateErrors",
+        general: null,
+        name: null,
+        ownerId: null
+      },
+      latestPublishVersion: "",
+      latestPublishDate: "1767715403000",
+      created: "2026-01-06 16:02:26",
+      sections: [
+        {
+          __typename: "Section",
+          id: 1815,
+          name: "Section One",
+          bestPractice: false,
+          displayOrder: 1,
+          isDirty: false,
+          questions: [
+            {
+              __typename: "Question",
+              errors: {
+                __typename: "QuestionErrors",
+                general: null,
+              },
+              displayOrder: 1,
+              guidanceText: "",
+              id: 3688,
+              questionText: "Text area question123",
+              sectionId: 1815,
+              templateId: 395
+            }
+          ]
+        }
+      ],
+      owner: {
+        __typename: "Affiliation",
+        displayName: "California Digital Library (cdlib.org)",
+        id: 1
+      },
+      latestPublishVisibility: "PUBLIC",
+      bestPractice: false,
+      isDirty: false
+    };
+
+    (useTemplateQuery as jest.Mock).mockReturnValue({
+      data: { template: mockPublishedTemplateWithNoEdits },
+      loading: false,
+      error: null,
+    });
+    (useCreateTemplateVersionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: "value" } }), // Correct way to mock a resolved promise
+      { loading: false, error: undefined },
+    ]);
+
+    await act(async () => {
+      render(<TemplateEditPage />);
+    });
+
+    expect(screen.getByText("status.published")).toBeInTheDocument();
+  });
+
+  it("should display \"Unpublished changes\" status when there is a publish date and isDirty is true", async () => {
+    const mockPublishedTemplateWithNoEdits = {
+      __typename: "Template",
+      id: 395,
+      name: "Test Template",
+      description: null,
+      errors: {
+        __typename: "TemplateErrors",
+        general: null,
+        name: null,
+        ownerId: null
+      },
+      latestPublishVersion: "",
+      latestPublishDate: "1767715403000",
+      created: "2026-01-06 16:02:26",
+      sections: [
+        {
+          __typename: "Section",
+          id: 1815,
+          name: "Section One",
+          bestPractice: false,
+          displayOrder: 1,
+          isDirty: false,
+          questions: [
+            {
+              __typename: "Question",
+              errors: {
+                __typename: "QuestionErrors",
+                general: null,
+              },
+              displayOrder: 1,
+              guidanceText: "",
+              id: 3688,
+              questionText: "Text area question123",
+              sectionId: 1815,
+              templateId: 395
+            }
+          ]
+        }
+      ],
+      owner: {
+        __typename: "Affiliation",
+        displayName: "California Digital Library (cdlib.org)",
+        id: 1
+      },
+      latestPublishVisibility: "PUBLIC",
+      bestPractice: false,
+      isDirty: true
+    };
+
+    (useTemplateQuery as jest.Mock).mockReturnValue({
+      data: { template: mockPublishedTemplateWithNoEdits },
+      loading: false,
+      error: null,
+    });
+    (useCreateTemplateVersionMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockResolvedValueOnce({ data: { key: "value" } }), // Correct way to mock a resolved promise
+      { loading: false, error: undefined },
+    ]);
+
+    await act(async () => {
+      render(<TemplateEditPage />);
+    });
+
+    expect(screen.getByText("status.unpublishedChanges")).toBeInTheDocument();
+  });
+
   it("should display errors.saveTemplate error message if no result when calling saveTemplate", async () => {
     (useTemplateQuery as jest.Mock).mockReturnValue({
       data: { template: mockTemplateData },

--- a/app/[locale]/template/[templateId]/page.tsx
+++ b/app/[locale]/template/[templateId]/page.tsx
@@ -436,6 +436,16 @@ const TemplateEditPage: React.FC = () => {
     setIsReordering(false);
   };
 
+  const getPublishStatusText = (isDirty: boolean, latestPublishDate: string | null | undefined) => {
+    if (isDirty && latestPublishDate) {
+      return Global("status.unpublishedChanges");
+    } else if (!latestPublishDate) {
+      return Global("status.draft");
+    } else {
+      return Global("status.published");
+    }
+  };
+
   // Need to set this info to update template title
   useEffect(() => {
     if (data?.template) {
@@ -572,11 +582,11 @@ const TemplateEditPage: React.FC = () => {
                   onPress={() => console.log("Preview")}
                   className="sidePanelLink"
                 >
-                  Preview
+                  {Global('buttons.preview')}
                 </Link>
               </div>
 
-              {template.isDirty && (
+              {(template.isDirty && !template.latestPublishDate) && (
                 <div className="panelRow mb-5">
                   <div>
                     <h3>{EditTemplate("button.publishTemplate")}</h3>
@@ -595,7 +605,7 @@ const TemplateEditPage: React.FC = () => {
               <div className="panelRow mb-5">
                 <div>
                   <h3>{EditTemplate("heading.visibilitySettings")}</h3>
-                  <p>{template.isDirty ? EditTemplate("notPublished") : EditTemplate("published")}</p>
+                  <p>{getPublishStatusText(template.isDirty, template?.latestPublishDate)}</p>
                 </div>
                 <Link
                   href="#"

--- a/messages/en-US/global.json
+++ b/messages/en-US/global.json
@@ -856,6 +856,11 @@
       "table": "Table",
       "affiliationSearch": "Affiliation search",
       "researchOutputTable": "Research output table"
+    },
+    "status": {
+      "published": "Published",
+      "draft": "Draft",
+      "unpublishedChanges": "Unpublished changes"
     }
   },
   "OrganizationTemplates": {

--- a/messages/pt-BR/global.json
+++ b/messages/pt-BR/global.json
@@ -855,6 +855,11 @@
       "filteredSearch": "Pesquisa com filtros",
       "table": "Tabela",
       "affiliationSearch": "Busca de afiliação"
+    },
+    "status": {
+      "published": "Publicado",
+      "draft": "Rascunho",
+      "unpublishedChanges": "Alterações não publicadas"
     }
   },
   "OrganizationTemplates": {


### PR DESCRIPTION
## Description
Currently, when editing a template, the side panel displays the publish status of either "Draft" or "Published", but if the template was published previously, and has new edits, it should say "Unpublished changes".
- Updated the Template Edit page to display the status of "Unpublished changes" if the `isDirty` flag is true and `latestPublishedDate` is not null (meaning it was published before).

Fixes # ([875](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/875))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
