### PR TITLE
Add combined issue template for bugs and tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,52 @@
+---
+name: "Template"
+about: "Copmbined template for new task and bug tickets"
+---
+
+### Summary
+
+Short summary of the issue or task
+
+### Links to impacted areas
+
+Provide specific URLs/direction to pages or other areas that are affected
+
+### Images
+
+For bugs, provide pictures or video of the issue occurring
+For tasks, provide links to wireframes, URLs of current tool pages to copy, screenshots, mock-ups, or a detailed description of what it should look like
+
+### Acceptance criteria
+
+Add more specific details here about what to implement and how the end behavior should work.  For Bugs this may just be that the bug is fixed per expected behavior, but sometimes if that fix isn't clear this may be needed.
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+### Relevant technical decisions
+
+As we make decisions as a group on technical or implementation details, add notes here.  This just should be updated over time and have the latest information
+
+## For bugs only, add the following:
+
+### Environment/Context
+
+Environment variables, browser, OS, or other potentially relevant technical details about the situation where it was encountered
+
+### Steps to reproduce
+
+Add specific steps here on how to reproduce the issue, ending with the incorrect behavior observed
+- Step 1
+- Step 2
+- Step 3
+
+### Actual behavior
+
+What is currently happening that shouldn't after the steps above
+
+### Expected behavior
+
+What precisely should happen after the steps
+
+### Workarounds
+
+What other options there are, if any, for the user to get past the issue (e.g. navigating to a page a different way if there is a broken link)


### PR DESCRIPTION
I combined the Bug and Task templates to a shared template.  Most sections apply to both with some slight wording tweaks, with some extra sections at the bottom for bugs that can be deleted for Task tickets.

## Description

Adding a new file.  If approved, we should likely remove the old 2 templates, unless we want to try and have them separated in the future still
Fixes N/A

## Type of change
- [x] Chore

## How Has This Been Tested?

I looked at it on https://markdownlivepreview.com/ to make sure it appeared how I expected.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have completed manual or automated accessibility testing for my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
