### PR TITLE
 Fixed issue with /login page not loading when refresh token has expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 ### Remove
 - Removed `boolean` question type from the Add Question question types list [#990]
 ### Fixed
+- Fixed issue with `/login` page not loading when `dmspr` refresh token expires [#35]
 - Fixed issue on Guidance Group creation, where saving content for one tag, wipes out the entered content (unsaved) for other tags [#6]
 - Fixed related works pagination.
 


### PR DESCRIPTION
## Description
When the `dmspr` refresh token expired and the backend returned a `401` error, the `authHelper` would redirect the user to `/login` page, but this was causing an infinite loop because the excluded pages, like `/login` page, should not get these token checks.

- Updated middleware to exclude the `/login` page from the refresh token check, so that we don't get an infinite loop happening when the `authHelper` does a redirect to `/login` page.
- Made sure to clear expired refresh tokens so that subsequent requests don't waste time trying to refresh again

Fixes # ([35](https://github.com/CDLUC3/dmptool-doc/issues/35))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
