### PR TITLE
Added a "Back" button to step=2 of the Login page so that user can get back to step 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added related works project overview page [#700]
 
 ## Updated
-
+- Updated `/login` page step=email to include a "Back" button so user can go back to Step 1 [#997]
 
 ## Chore
 - Updated `middleware.ts` to `proxy.ts` per `middleware` being deprecated in `next v16` [#51]

--- a/app/[locale]/login/__tests__/page.spec.tsx
+++ b/app/[locale]/login/__tests__/page.spec.tsx
@@ -100,6 +100,7 @@ describe('LoginPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId("passInput")).toBeInTheDocument();
       expect(screen.getByTestId("actionSubmit")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "buttons.back" })).toBeInTheDocument();
     });
 
     // Ensure that email field is read-only on this step

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -34,6 +34,7 @@ type LoginSteps =
 
 const LoginPage: React.FC = () => {
   const t = useTranslations('LoginPage');
+  const Global = useTranslations('Global');
   const errorRef = useRef<HTMLDivElement>(null);
   const formRef = useRef<HTMLFormElement | null>(null);
   const [step, setStep] = useState<LoginSteps>("email");
@@ -47,6 +48,10 @@ const LoginPage: React.FC = () => {
   const router = useRouter();
 
   const { setIsAuthenticated } = useAuthContext();
+
+  const returnToEmail = () => {
+    setStep("email");
+  };
 
   const handleLogin = async () => {
     setLoading(true);
@@ -194,13 +199,16 @@ const LoginPage: React.FC = () => {
             )}
 
             {(step === "password") && (
-              <Button
-                type="submit"
-                isDisabled={loading}
-                data-testid="actionSubmit"
-              >
-                {loading ? '...' : t('login')}
-              </Button>
+              <div className="button-container">
+                <Button type="submit" className="secondary" onPress={returnToEmail}>{Global('buttons.back')}</Button>
+                <Button
+                  type="submit"
+                  isDisabled={loading}
+                  data-testid="actionSubmit"
+                >
+                  {loading ? '...' : t('login')}
+                </Button>
+              </div>
             )}
           </ToolbarContainer>
 

--- a/app/[locale]/projects/[projectId]/dmp/create/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/create/__tests__/page.spec.tsx
@@ -902,20 +902,19 @@ describe('PlanCreate Component using base mock', () => {
     });
 
     // Wait for all loading states to complete by checking for content that appears after loading
-    // The component won't show checkboxes until queries complete and state updates
     await waitFor(
-      () => {
-        // Wait for the checkbox to appear after all initialization
-        const checkbox = screen.getByRole('checkbox', { name: 'Affiliation 1 Name' });
-        expect(checkbox).toBeInTheDocument();
-      },
-      { timeout: 5000 } // Increase timeout for multiple query resolution
-    );
+      async () => {
+        // 1. Checkbox appears (means queries loaded and state computed)
+        expect(screen.getByRole('checkbox', { name: 'Affiliation 1 Name' })).toBeInTheDocument();
 
-    // Wait for the correct number of templates to load
-    await waitFor(() => {
-      expect(screen.getAllByTestId('template-metadata')).toHaveLength(5);
-    });
+        // 2. Templates loaded (means lazy query completed)
+        expect(screen.getAllByTestId('template-metadata')).toHaveLength(5);
+
+        // 3. No loading indicators present
+        expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+      },
+      { timeout: 10000 } // Increase timeout
+    );
 
     // NOW make individual assertions (outside waitFor)
     const templateData = screen.getAllByTestId('template-metadata');


### PR DESCRIPTION
## Description

After the initial change to make the email field read-only on Step=2 of the Login process, we forgot to add a "Back" button for the user to get back to Step=1 so they can edit their email address.

So the ticket was put into Retest, and I made this change.

Fixes # ([997](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/997))

## Type of change
Please delete options that are not relevant
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration.


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
