### PR TITLE
Fixed issue with default 'sampleText' appearing again in textArea again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Updated `/login` page step=email to include a "Back" button so user can go back to Step 1 [#997]
 
 ## Fixed
+- Fixed issue with default `sampleText` appearing again in textArea question, after the user overrides it, saves, and then deletes their answer [#7]
 - Updated "Back" button on /login page to have `type=button` instead of `type=submit`
 - Fixed bug where the published status on `/template/[templateId]` did not match that on the template cards at `/template` for the `unpublished changes` state. Added a shared hook for determining the correct status text [#875]
 

--- a/__mocks__/common/mockPublishedQuestionDataForTextArea.json
+++ b/__mocks__/common/mockPublishedQuestionDataForTextArea.json
@@ -8,7 +8,7 @@
       "general": null,
       "questionText": null,
       "requirementText": null,
-      "sampleText": null,
+      "sampleText": "This is my sample text",
       "displayOrder": null,
       "questionConditionIds": null,
       "versionedSectionId": null,

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]/page.tsx
@@ -1274,7 +1274,11 @@ const PlanOverviewQuestionPage: React.FC = () => {
     },
     textAreaProps: {
       content:
-        !formData.textAreaContent &&
+        // Check if answerId does not exist (meaning answer has not yet been created) and 
+        // question allows sample text as default and sample text exists, then use sample text. 
+        // Otherwise use formData which could be existing answer or user input
+        !answerData?.answerByVersionedQuestionId?.id &&
+          !formData.textAreaContent &&
           question?.useSampleTextAsDefault &&
           !!question?.sampleText
           ? question.sampleText


### PR DESCRIPTION
## Description

The default sample text was reappearing in the `textArea` field after a user overwrites and saves an answer, and then later deletes their answer.
- Added check for an `answer id` before adding the `sample text`.

Fixes # ([7](https://github.com/CDLUC3/dmptool-doc/issues/7))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
This was tested manually and with unit test


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screen recording
### Shows that sample text does not reappear once a user has saved an answer and then deletes their answer


https://github.com/user-attachments/assets/21351cd5-5514-4d8a-a3a8-e416f529f9eb



