### PR TITLE
[Chore] - updated dompurify to v3.3.2 due to security vulnerability, some other updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed bug where the published status on `/template/[templateId]` did not match that on the template cards at `/template` for the `unpublished changes` state. Added a shared hook for determining the correct status text [#875]
 
 ## Chore
+- Updated version of `dompurify` to `v3.3.2` due to security vulnerability, and included updates to`test-exclude` to v7.0.2, `sanitize-html` to v2.17.1, `tinymce` to v7.9.2, `next-intl` to v4.8.3, `html-react-parser` to v5.2.17, `@types/node` to v24.12.0, and `@types/react to v18.3.28.
 - Updated version of `minimatch` to `10.2.4` to address vulnerabilities
 - Updated version of `@dmptool/types` to `3.1.2` and `zod` to match package version to `4.3.6`
 - Added override for `minimatch` dependency and removed them for `prismjs` and `qs`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,15 +19,15 @@
         "@react-stately/toast": "3.1.2",
         "classnames": "2.5.1",
         "deepmerge": "4.3.1",
-        "dompurify": "3.3.1",
+        "dompurify": "3.3.2",
         "graphql": "16.12.0",
-        "html-react-parser": "5.2.16",
+        "html-react-parser": "5.2.17",
         "husky": "9.1.7",
         "jose": "6.1.3",
         "jsonwebtoken": "9.0.3",
         "loglevel": "1.9.2",
         "next": "16.1.6",
-        "next-intl": "4.8.2",
+        "next-intl": "4.8.3",
         "node-fetch": "3.3.2",
         "pino": "9.14.0",
         "prop-types": "15.8.1",
@@ -35,8 +35,8 @@
         "react-aria-components": "1.14.0",
         "react-dom": "19.2.4",
         "rxjs": "7.8.2",
-        "sanitize-html": "2.17.0",
-        "tinymce": "7.9.1",
+        "sanitize-html": "2.17.1",
+        "tinymce": "7.9.2",
         "zod": "4.3.6"
       },
       "devDependencies": {
@@ -53,9 +53,9 @@
         "@types/jest-axe": "3.5.9",
         "@types/jsonwebtoken": "9.0.10",
         "@types/next": "9.0.0",
-        "@types/node": "24.10.9",
+        "@types/node": "24.12.0",
         "@types/pino": "7.0.5",
-        "@types/react": "18.3.27",
+        "@types/react": "18.3.28",
         "@types/react-dom": "18.3.7",
         "@types/sanitize-html": "2.16.0",
         "@typescript-eslint/eslint-plugin": "8.56.1",
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/@ardatan/relay-compiler": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.3.tgz",
-      "integrity": "sha512-mBDFOGvAoVlWaWqs3hm1AciGHSQE1rqFc/liZTyYz/Oek9yZdT5H26pH2zAFuEiTiBVPPyMuqf5VjOFPI2DGsQ==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.3.0.tgz",
+      "integrity": "sha512-lc6PyM1IQCSa87DMChfv61HuhrSquHGhsF+WFSm2csFnKMSHaj0S1M8fnGr04i7O9YnwyR+OcgQ3CfzlEPC9Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -188,7 +188,7 @@
         "@babel/runtime": "^7.26.10",
         "chalk": "^4.0.0",
         "fb-watchman": "^2.0.0",
-        "immutable": "~3.7.6",
+        "immutable": "^5.1.5",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "relay-runtime": "12.0.0",
@@ -7652,9 +7652,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.10.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
-      "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7680,9 +7680,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.27",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
-      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -10468,10 +10468,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -12603,9 +12606,9 @@
       }
     },
     "node_modules/html-dom-parser": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.7.tgz",
-      "integrity": "sha512-Sn+6S3Z8P3P12qqUm4+9wnchC3Bjc4DHp60fgnUdgeiy6e3EbECFWdrmyTBuphxJA5Is7V400+v7ct/Ix2pJFw==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.8.tgz",
+      "integrity": "sha512-MCIUng//mF2qTtGHXJWr6OLfHWmg3Pm8ezpfiltF83tizPWY17JxT4dRLE8lykJ5bChJELoY3onQKPbufJHxYA==",
       "funding": [
         {
           "type": "github",
@@ -12670,9 +12673,9 @@
       "license": "MIT"
     },
     "node_modules/html-react-parser": {
-      "version": "5.2.16",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.16.tgz",
-      "integrity": "sha512-1S6KLse1hKWOXYL/PSnZhsARJBE6eIO93CjPlDKMneO0wz8YTnzTfc9Yw4mWsCk2kcB9IrU+R0W6Rdi4N7YfJw==",
+      "version": "5.2.17",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.17.tgz",
+      "integrity": "sha512-m+K/7Moq1jodAB4VL0RXSOmtwLUYoAsikZhwd+hGQe5Vtw2dbWfpFd60poxojMU0Tsh9w59mN1QLEcoHz0Dx9w==",
       "funding": [
         {
           "type": "github",
@@ -12686,7 +12689,7 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "5.0.3",
-        "html-dom-parser": "5.1.7",
+        "html-dom-parser": "5.1.8",
         "react-property": "2.0.2",
         "style-to-js": "1.1.21"
       },
@@ -12903,14 +12906,11 @@
       }
     },
     "node_modules/immutable": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-      "integrity": "sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.8.0"
-      }
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -16837,9 +16837,9 @@
       }
     },
     "node_modules/next-intl": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.8.2.tgz",
-      "integrity": "sha512-GuuwyvyEI49/oehQbBXEoY8KSIYCzmfMLhmIwhMXTb+yeBmly1PnJcpgph3KczQ+HTJMXwXCmkizgtT8jBMf3A==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.8.3.tgz",
+      "integrity": "sha512-PvdBDWg+Leh7BR7GJUQbCDVVaBRn37GwDBWc9sv0rVQOJDQ5JU1rVzx9EEGuOGYo0DHAl70++9LQ7HxTawdL7w==",
       "funding": [
         {
           "type": "individual",
@@ -16848,14 +16848,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@formatjs/intl-localematcher": "^0.5.4",
+        "@formatjs/intl-localematcher": "^0.8.1",
         "@parcel/watcher": "^2.4.1",
         "@swc/core": "^1.15.2",
-        "icu-minify": "^4.8.2",
+        "icu-minify": "^4.8.3",
         "negotiator": "^1.0.0",
-        "next-intl-swc-plugin-extractor": "^4.8.2",
+        "next-intl-swc-plugin-extractor": "^4.8.3",
         "po-parser": "^2.1.1",
-        "use-intl": "^4.8.2"
+        "use-intl": "^4.8.3"
       },
       "peerDependencies": {
         "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -16874,13 +16874,23 @@
       "integrity": "sha512-YcaT+R9z69XkGhpDarVFWUprrCMbxgIQYPUaXoE6LGVnLjGdo8hu3gL6bramDVjNKViYY8a/pXPy7Bna0mXORg==",
       "license": "MIT"
     },
-    "node_modules/next-intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
-      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+    "node_modules/next-intl/node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.0.tgz",
+      "integrity": "sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "2"
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/next-intl/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.1.tgz",
+      "integrity": "sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.0",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/next/node_modules/@swc/helpers": {
@@ -18478,9 +18488,9 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
-      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.1.tgz",
+      "integrity": "sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
@@ -18511,13 +18521,6 @@
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
       }
-    },
-    "node_modules/sass/node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -19407,15 +19410,15 @@
       }
     },
     "node_modules/test-exclude": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^10.4.1",
-        "minimatch": "^9.0.4"
+        "minimatch": "^10.2.2"
       },
       "engines": {
         "node": ">=18"
@@ -19506,9 +19509,9 @@
       }
     },
     "node_modules/tinymce": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-7.9.1.tgz",
-      "integrity": "sha512-zaOHwmiP1EqTeLRXAvVriDb00JYnfEjWGPdKEuac7MiZJ5aiDMZ4Unc98Gmajn+PBljOmO1GKV6G0KwWn3+k8A==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-7.9.2.tgz",
+      "integrity": "sha512-zS2gn2CPQmZhUqLzkhwYH+WGsx/DIRY/mS18RVzsIcuQg2lN2uzaqoHSJU6DdMUpvXBtBFnLNpumC3QrDwLBzA==",
       "license": "GPL-2.0-or-later"
     },
     "node_modules/title-case": {
@@ -20498,7 +20501,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
     "@react-stately/toast": "3.1.2",
     "classnames": "2.5.1",
     "deepmerge": "4.3.1",
-    "dompurify": "3.3.1",
+    "dompurify": "3.3.2",
     "graphql": "16.12.0",
-    "html-react-parser": "5.2.16",
+    "html-react-parser": "5.2.17",
     "husky": "9.1.7",
     "jose": "6.1.3",
     "jsonwebtoken": "9.0.3",
     "loglevel": "1.9.2",
     "next": "16.1.6",
-    "next-intl": "4.8.2",
+    "next-intl": "4.8.3",
     "node-fetch": "3.3.2",
     "pino": "9.14.0",
     "prop-types": "15.8.1",
@@ -50,8 +50,8 @@
     "react-aria-components": "1.14.0",
     "react-dom": "19.2.4",
     "rxjs": "7.8.2",
-    "sanitize-html": "2.17.0",
-    "tinymce": "7.9.1",
+    "sanitize-html": "2.17.1",
+    "tinymce": "7.9.2",
     "zod": "4.3.6"
   },
   "devDependencies": {
@@ -68,9 +68,9 @@
     "@types/jest-axe": "3.5.9",
     "@types/jsonwebtoken": "9.0.10",
     "@types/next": "9.0.0",
-    "@types/node": "24.10.9",
+    "@types/node": "24.12.0",
     "@types/pino": "7.0.5",
-    "@types/react": "18.3.27",
+    "@types/react": "18.3.28",
     "@types/react-dom": "18.3.7",
     "@types/sanitize-html": "2.16.0",
     "@typescript-eslint/eslint-plugin": "8.56.1",
@@ -93,6 +93,6 @@
   "overrides": {
     "minimatch": "10.2.4",
     "@eslint/plugin-kit": "0.3.4",
-    "test-exclude": "7.0.1"
+    "test-exclude": "7.0.2"
   }
 }


### PR DESCRIPTION
…ed updatrs to test-exclude to v7.0.2, sanitize-html to v2.17.1, tinymce to v7.9.2, next-intl to v4.8.3, html-react-parser to v5.2.17, @types/node to v24.12.0 and @types/react to v18.3.28

## Description

- Updated version of `dompurify` to `v3.3.2` due to security vulnerability, and included updates to`test-exclude` to v7.0.2, `sanitize-html` to v2.17.1, `tinymce` to v7.9.2, `next-intl` to v4.8.3, `html-react-parser` to v5.2.17, `@types/node` to v24.12.0, and `@types/react to v18.3.28.

Tested and there doesn't appear to be any errors from the updates.
