### PR TITLE
Updated Research output standardFields config to only require 'title' field when answering question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added related works project overview page [#700]
 
 ## Updated
+- Updated Research Output standardFields config so that only `title` field is required when answering question [#33]
 - `Custom Question` updates [#929]
 - Moved `addQuestionMutation` out of `QuestionView` so that `QuestionView` can be shared for both `BASE` and `CUSTOM` questions
   - Updated `QuestionTypeSelectPage` to include the `addQuestionMutation` and `getDisplayOrder` and pass those to `QuestionAdd`

--- a/app/hooks/useResearchOutputTable.ts
+++ b/app/hooks/useResearchOutputTable.ts
@@ -85,7 +85,7 @@ export const useResearchOutputTable = ({ setHasUnsavedChanges, announce, initial
       placeholder: '',
       helpText: '',
       maxLength: '',
-      required: true,
+      required: false,
       value: ''
     },
     {
@@ -94,7 +94,7 @@ export const useResearchOutputTable = ({ setHasUnsavedChanges, announce, initial
       languageTranslationKey: 'labels.outputType',
       enabled: true,
       helpText: '',
-      required: true,
+      required: false,
       outputTypeConfig: {
         mode: 'defaults' as 'defaults' | 'mine',
         selectedDefaults: [] as string[],
@@ -213,6 +213,8 @@ export const useResearchOutputTable = ({ setHasUnsavedChanges, announce, initial
       }
       : undefined;
 
+    console.log("***standardFields in buildResearchOutputFormState:", standardFields);
+    console.log("***Transformed data from buildResearchOutputFormState:", transformedData);
     return stateToJSON(standardFields, additionalFields, transformedData);
   }, [standardFields, additionalFields, defaultResearchOutputTypesData]);
 

--- a/app/hooks/useResearchOutputTable.ts
+++ b/app/hooks/useResearchOutputTable.ts
@@ -213,8 +213,6 @@ export const useResearchOutputTable = ({ setHasUnsavedChanges, announce, initial
       }
       : undefined;
 
-    console.log("***standardFields in buildResearchOutputFormState:", standardFields);
-    console.log("***Transformed data from buildResearchOutputFormState:", transformedData);
     return stateToJSON(standardFields, additionalFields, transformedData);
   }, [standardFields, additionalFields, defaultResearchOutputTypesData]);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ networks:
 
 services:
   dmsp-frontend-prototype:
-    container_name: dmsp_frontend
+    container_name: dmptool-ui
     build:
       context: .
       dockerfile: Dockerfile.dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -11730,9 +11730,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION

## Description

- Updated Research Output standardFields config so that only `title` field is required when answering question

Fixes # ([33](https://github.com/CDLUC3/dmptool-doc/issues/33))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
