### PR TITLE
Fixed accessibility test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added related works project overview page [#700]
 
 ## Updated
+- Updated `PlanOverviewSectionPage` left nav to appear only for large screens over `1800px` for now, because it was overlapping with the content for smaller devices [#34]
 - `Custom Question` updates [#929]
 - Moved `addQuestionMutation` out of `QuestionView` so that `QuestionView` can be shared for both `BASE` and `CUSTOM` questions
   - Updated `QuestionTypeSelectPage` to include the `addQuestionMutation` and `getDisplayOrder` and pass those to `QuestionAdd`

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/PlanOverviewSectionPage.module.scss
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/PlanOverviewSectionPage.module.scss
@@ -1,6 +1,8 @@
+@use '@/styles/responsive' as r;
+
 // PlanOverviewSectionPage.module.scss
 .questionCard {
-  background: white;
+  background: var(--gray-50);
   border-radius: var(--border-radius-lg);
   margin-bottom: var(--space-4);
   box-shadow: var(--card-shadow);
@@ -59,19 +61,32 @@
 
 /* Plan Navigation - Subtle sidebar for very large screens only */
 .planNavigation {
-  display: none;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
   position: fixed;
   left: 20px;
   top: 20%;
   width: 180px;
   font-size: 13px;
   z-index: 1000;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
 
-  /* Show when there's room for 1200px container + sidebar + margins */
-  @media (min-width: 1620px) {
-    display: block;
+  /* Show when centered container (1200px) + both margins fit beside nav:
+     2 × (nav_left(20px) + nav_width(180px) + gap(100px)) + container(1200px) = 1800px */
+  @include r.device(xxxxl) {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+
+    &.planNavigationHidden {
+      visibility: hidden;
+      opacity: 0;
+      pointer-events: none;
+    }
   }
 }
+
 
 /* Content wrapper with relative positioning for the absolute nav */
 .contentWrapper {

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/page.tsx
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/s/[sid]/page.tsx
@@ -204,8 +204,7 @@ const PlanOverviewSectionPage: React.FC = () => {
           <div className={styles.contentWrapper}>
             {/* Subtle plan navigation for very large screens */}
             <nav
-              className={styles.planNavigation}
-              style={{ display: showNavigation ? 'block' : 'none' }}
+              className={`${styles.planNavigation} ${!showNavigation ? styles.planNavigationHidden : ''}`}
               aria-labelledby="plan-nav-title"
             >
               <h2 id="plan-nav-title" className={"hidden-accessibly"}>{Section('navigation.planNavigation')}</h2>
@@ -244,7 +243,7 @@ const PlanOverviewSectionPage: React.FC = () => {
               <section aria-label={"Requirements"}>
                 {sectionData?.publishedSection?.requirements && (
                   <>
-                    <h4>{t('headings.requirementsBy', { funder: plan.funder_name })}</h4>
+                    <h3 className="h4">{t('headings.requirementsBy', { funder: plan.funder_name })}</h3>
                     <SafeHtml html={sectionData?.publishedSection?.requirements} />
                   </>
                 )}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ networks:
 
 services:
   dmsp-frontend-prototype:
-    container_name: dmsp_frontend
+    container_name: dmptool-ui
     build:
       context: .
       dockerfile: Dockerfile.dev

--- a/styles/_responsive.scss
+++ b/styles/_responsive.scss
@@ -11,7 +11,9 @@ $breakpoints: (
   'md': 768px,
   'lg': 1024px,
   'xl': 1200px,
-  'xxl': 1440px
+  'xxl': 1440px,
+  'xxxl': 1600px,
+  'xxxxl': 1800px
 );
 
 // A quick helper to create a media query block for a named device


### PR DESCRIPTION
## Description

Left navigation sidebar overlapped with main content on Section Overview page. Instead of completely removing it, I fixed a bug that was preventing it from being hidden for smaller screens.


- Updated `PlanOverviewSectionPage` left nav to appear only for large screens over `1800px` for now, because it was overlapping with the content for smaller devices

Fixes # ([34](https://github.com/CDLUC3/dmptool-doc/issues/34))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screen recording

https://github.com/user-attachments/assets/eece676e-ef73-487b-ada2-d76bb11ceba6


