### PR TITLE
Fixed issue where output type answer was being saved using id rather than value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Updated `/login` page step=email to include a "Back" button so user can go back to Step 1 [#997]
 
 ## Fixed
+- Fixed issue where selected output type on Research Output answer was being saved using id rather than the value
 - Fixed some issues in `Research Output` question answer form, where data flags checkboxes were not displaying and output types was missing the custom output
 - Fixed issue with missing `as builder` in `Dockerfile.prod`
 - Fixed bug where user's org was not displaying as a filter option, and Best practice was displaying instead [#62]

--- a/components/Form/ResearchOutputAnswerComponent/SingleResearchOutputComponent/index.tsx
+++ b/components/Form/ResearchOutputAnswerComponent/SingleResearchOutputComponent/index.tsx
@@ -518,11 +518,18 @@ const SingleResearchOutputComponent = ({
                     isRequired={col.required}
                     name={name}
                     options={tooltipSelectItems}
-                    defaultSelectedKey={String(value)}
+                    defaultSelectedKey={
+                      tooltipSelectItems.find(opt => opt.label === String(value))?.id ?? String(value)
+                    }
                     errorMessage={fieldError}
                     helpMessage={col.content.attributes?.help || col?.help}
                     onSelectionChange={(val: Key | null) => {
-                      if (val !== null) handleCellChange(colIndex, val);
+                      if (val !== null) {
+                        // Use label instead of id for output type
+                        const selectedOption = tooltipSelectItems.find(opt => opt.id === String(val));
+                        handleCellChange(colIndex, selectedOption?.label ?? String(val));
+                      }
+
                     }}
                   />
                 ) : (
@@ -532,11 +539,21 @@ const SingleResearchOutputComponent = ({
                     isRequired={col.required}
                     name={name}
                     items={formSelectItems}
-                    selectedKey={String(value)}
+                    selectedKey={
+                      formSelectItems.find(item => item.name === String(value))?.id ?? String(value)
+                    }
                     isInvalid={!!fieldError}
                     errorMessage={fieldError}
                     helpMessage={col.content.attributes?.help || col?.help}
-                    onChange={val => handleCellChange(colIndex, val)}
+                    onChange={val => {
+                      if (isOutputTypeField) {
+                        // Use label instead of id for output type
+                        const selectedItem = formSelectItems.find(item => item.id === val);
+                        handleCellChange(colIndex, selectedItem?.name ?? val);
+                      } else {
+                        handleCellChange(colIndex, val);
+                      }
+                    }}
                   />
                 )}
               </div>


### PR DESCRIPTION
## Description
One more small bug I ran across while working with the Research Output data. 

- Fixed issue where selected output type on Research Output answer was being saved using id rather than the value, so that the `answer` json will not contain something like `my-output-type`, but rather `my output type`, and that is what will display in the answer.

Fixes # ([141](https://github.com/CDLUC3/dmptool-doc/issues/141))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
