### PR TITLE
Updated ResearchOutputComponent to always disable checkboxes for required fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Added related works project overview page [#700]
 
 ## Updated
+- Updated `ResearchOutputComponent` so that it disables checkboxes on the research output template builder form for all fields that are required [#33]
 - Updated `AnswerByVersionedQuestionId` query and `addAnswer` mutation schemas to pass in `versionedCustomSectionId` and `versionedCustomQuestionId` so that we can get answers to custom questions and save them accordingly [#174]
 - Updated `PublishedQuestion` query to include customization fields, and updated `PlanOverviewQuestionPageShared` component to use the new customization sample text and org info [#174]
 - Moved shared `actions` from `project/[projectId]/dmp/[dmpid]/s/[sid]/q/[qid]` to `@/app/actions` since they will be shared between the three question pages [#172]

--- a/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
@@ -2065,7 +2065,7 @@ describe("Research Output Question Type - Edit", () => {
     expect(screen.getByText('researchOutput.labels.licenses')).toBeInTheDocument();
   });
 
-  it('should show tooltip for required fields (Title and Output Type) on edit', async () => {
+  it('should show tooltip for required fields', async () => {
     const mockQuestionTextArea = {
       data: { question: { id: 67, questionText: 'Research Output Table Question', json: researchOutputJson, displayOrder: 1, sectionId: 67, requirementText: '', guidanceText: '', sampleText: '', useSampleTextAsDefault: false, required: false } },
       loading: false,
@@ -2090,9 +2090,9 @@ describe("Research Output Question Type - Edit", () => {
     const outputTypeCheckbox = screen.getByLabelText('researchOutput.labels.outputType');
 
     expect(titleCheckbox).toBeDisabled();
-    expect(outputTypeCheckbox).toBeDisabled();
+    expect(outputTypeCheckbox).not.toBeDisabled();
 
-    expect(screen.getAllByText('researchOutput.tooltip.requiredFields')).toHaveLength(2);
+    expect(screen.getAllByText('researchOutput.tooltip.requiredFields')).toHaveLength(1);
   });
 
   it('should toggle field customization panels when customize button is clicked (edit)', async () => {

--- a/components/Form/ResearchOutputQuestionComponent/__mocks__/mockStandardFields.json
+++ b/components/Form/ResearchOutputQuestionComponent/__mocks__/mockStandardFields.json
@@ -20,7 +20,7 @@
     "label": "Output Type",
     "enabled": true,
     "helpText": "",
-    "required": true,
+    "required": false,
     "outputTypeConfig": {
       "mode": "defaults",
       "selectedDefaults": [],

--- a/components/Form/ResearchOutputQuestionComponent/__tests__/index.spec.tsx
+++ b/components/Form/ResearchOutputQuestionComponent/__tests__/index.spec.tsx
@@ -139,7 +139,7 @@ describe('ResearchOutputComponent', () => {
       expect(screen.getByText('Initial Access Levels')).toBeInTheDocument();
     });
 
-    it('should disable Title and Output Type checkboxes', () => {
+    it('should disable the checkbox for required fields', () => {
       render(<ResearchOutputComponent {...defaultProps} />);
 
       const checkboxes = screen.getAllByRole('checkbox');
@@ -147,7 +147,7 @@ describe('ResearchOutputComponent', () => {
       const outputTypeCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Output Type'));
 
       expect(titleCheckbox).toBeDisabled();
-      expect(outputTypeCheckbox).toBeDisabled();
+      expect(outputTypeCheckbox).not.toBeDisabled();
     });
 
     it('should show tooltip for required fields', () => {

--- a/components/Form/ResearchOutputQuestionComponent/index.tsx
+++ b/components/Form/ResearchOutputQuestionComponent/index.tsx
@@ -94,8 +94,9 @@ const ResearchOutputComponent: React.FC<ResearchOutputComponentProps> = ({
         </p>
         <div className={styles.fieldsList}>
           {standardFields.map((field) => {
-            // These fields are always required and cannot be turned off
-            const isDisabled = field.id === 'title' || field.id === 'outputType';
+            // Required fields will always have their checkbox checked and disabled to 
+            // prevent changes, and a tooltip explaining why it's disabled
+            const isDisabled = field.required;
             const tooltipId = `tooltip-${field.id}`;
 
             return (
@@ -108,7 +109,7 @@ const ResearchOutputComponent: React.FC<ResearchOutputComponentProps> = ({
                       isDisabled={isDisabled}
                       aria-describedby={isDisabled ? tooltipId : undefined}
                       className={
-                        `react-aria-Checkbox ${(field.id === 'title' || field.id === 'outputType')
+                        `react-aria-Checkbox ${(field.required)
                           ? styles.disabledCheckbox
                           : ''
                         }`

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -1441,7 +1441,7 @@ describe("Research Output Question Type", () => {
     expect(screen.getByText('researchOutput.labels.initialAccessLevels')).toBeInTheDocument();
   });
 
-  it('should show tooltip for required fields (Title and Output Type)', async () => {
+  it('should show tooltip for required fields', async () => {
     const json = JSON.stringify({
       meta: {
         schemaVersion: "1.0"
@@ -1469,10 +1469,10 @@ describe("Research Output Question Type", () => {
     const outputTypeCheckbox = screen.getByLabelText('researchOutput.labels.outputType');
 
     expect(titleCheckbox).toBeDisabled();
-    expect(outputTypeCheckbox).toBeDisabled();
+    expect(outputTypeCheckbox).not.toBeDisabled();
 
     // Check for tooltip text
-    expect(screen.getAllByText('researchOutput.tooltip.requiredFields')).toHaveLength(2);
+    expect(screen.getAllByText('researchOutput.tooltip.requiredFields')).toHaveLength(1);
   });
 
   it('should toggle field customization panels when customize button is clicked', async () => {


### PR DESCRIPTION
## Description

- Updated `ResearchOutputComponent` so that it disables checkboxes on the research output template builder form for all fields that are required

Fixes # ([33](https://github.com/CDLUC3/dmptool-doc/issues/33))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested and tested with updated unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
