### PR TITLE
Update to try and fix the preferred  Repositories not displaying 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## Updated
+- Updated `RepoSelectorForAnswer` to wait to query `Re3byUrIsDocument` until we have `preferredReposURIs` because preferred repos don't display even though they eventually do to trigger the display of the "preferred repositories" checkbox [#118]
+
 ## Chore
 - Updated `sanitize-html` to `v2.17.3` and `dompurify` to `v3.4.0` due to security issues. Also, updated `prettier` to `v3.8.3` and `@dmptool/types` to `v3.1.4`, and `lodash` override to `v.4.18.1`. Removed overrides for `minimatch` and `test-exclude`.
 

--- a/components/RepoSelectorForAnswer/index.tsx
+++ b/components/RepoSelectorForAnswer/index.tsx
@@ -175,6 +175,7 @@ const RepoSelectorForAnswer = ({
     variables: {
       uris: preferredReposURIs || []
     },
+    skip: !preferredReposURIs || preferredReposURIs.length === 0
   });
 
   // Repositories lazy query


### PR DESCRIPTION

## Description

I believe that there might be a timing issue causing the preferred repositories data not to display. So what happens is that we see the "preferred repositories" checkbox checked, but no data is rendered. 
- Updated `RepoSelectorForAnswer` to wait to query Re3byURIsDocument until we have preferredReposURIs. My thought is that maybe the query runs before its there, and returns an empty data set

Fixes # ([118](https://github.com/CDLUC3/dmptool-doc/issues/118))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested, although it was difficult because i was not able to reproduce locally


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
