### PR TITLE
Added extra condition before displaying preferred repositories checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Added `UpdateAffiliation` and `AffiliationById` queries [#203]
 
 ## Updated
+- Enhanced condition in `RepoSelectorForAnswer` to display the preferred Repositories checkbox [#118]
 - Updated `FeedbackOptions` component to use real data [#203]
 
 ## Updated

--- a/components/RepoSelectorForAnswer/index.tsx
+++ b/components/RepoSelectorForAnswer/index.tsx
@@ -605,7 +605,7 @@ const RepoSelectorForAnswer = ({
                                 placeholder='e.g. DNA, titanium, FAIR, etc.'
                               />
                             </SearchField>
-                            {preferredReposURIs && preferredReposURIs.length > 0 && (
+                            {preferredReposURIs && preferredReposURIs.length > 0 && repositories.length > 0 && (
                               <div className={styles.checkboxWrapper}>
                                 <Checkbox
                                   value='preferredOnly'


### PR DESCRIPTION
## Description

This change will prevent the "preferred Repositories" checkbox from displaying when there is no `repositories` data returned from `re3byURIs`.

- Enhanced condition in `RepoSelectorForAnswer` to display the preferred Repositories checkbox

Fixes # ([118](https://github.com/CDLUC3/dmptool-doc/issues/118))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested locally to make sure the data came back in alphabetical order


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
