### PR TITLE
Updated research output files to remove outputType and Description fields as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `UpdateAffiliation` and `AffiliationById` queries [#203]
 
 ## Updated
+- Updated `useResearchoutputTable` hook to not include `outputType` field as one that is initially enabled. Updated `expandedFields` logic for Research Output fields to be dynamic [#33]
 - Updated Request Feedback Options text [#226]
 - Updated `PlanOverviewPage` and `plan` schema to include the `planCreator` field now passed as part of `plan` query response, and fixed bug in determining `read-only` [#198]
 - Updated `RepoSelectorForAnswer` to fix the issue with repositories not displaying in repositories search modal. Main change was to place the repositoriesData handling into a useEffect, since fetchRepositoriesData is async [#224]

--- a/app/[locale]/projects/[projectId]/dmp/[dmpid]/__mocks__/planQueryMock.ts
+++ b/app/[locale]/projects/[projectId]/dmp/[dmpid]/__mocks__/planQueryMock.ts
@@ -102,10 +102,10 @@ export const mockPlanData = {
         totalQuestions: 1
       }
     ],
-    "planCreator": {
-      "id": 3,
-      "affiliation": {
-        "uri": "https://ror.org/03yrm5c26"
+    planCreator: {
+      id: 3,
+      affiliation: {
+        uri: "https://ror.org/03yrm5c26"
       }
     },
     created: "1741308996000",

--- a/app/hooks/__tests__/useResearchOutputTable.spec.ts
+++ b/app/hooks/__tests__/useResearchOutputTable.spec.ts
@@ -79,7 +79,7 @@ describe('useResearchOutputTable', () => {
   it('should initialize with default standard fields and states', () => {
     const { result } = renderHook(() => useResearchOutputTable({ setHasUnsavedChanges, announce }));
     expect(result.current.standardFields.length).toBeGreaterThan(0);
-    expect(result.current.expandedFields).toEqual(['title', 'outputType']);
+    expect(result.current.expandedFields).toEqual(['title']);
     expect(result.current.nonCustomizableFieldIds).toContain('accessLevels');
     expect(result.current.additionalFields).toEqual([]);
     expect(typeof result.current.buildResearchOutputFormState).toBe('function');

--- a/app/hooks/useResearchOutputTable.ts
+++ b/app/hooks/useResearchOutputTable.ts
@@ -92,7 +92,7 @@ export const useResearchOutputTable = ({ setHasUnsavedChanges, announce, initial
       id: RO_OUTPUT_TYPE_ID,
       label: QuestionAdd('researchOutput.labels.outputType'),
       languageTranslationKey: 'labels.outputType',
-      enabled: true,
+      enabled: false,
       helpText: '',
       required: false,
       outputTypeConfig: {
@@ -192,7 +192,7 @@ export const useResearchOutputTable = ({ setHasUnsavedChanges, announce, initial
       id: (field as any).id ?? `custom_field_${Date.now()}_${idx}`,// Ensure each field has a unique ID for updates
     })) as AdditionalFieldsType[])
   );
-  const [expandedFields, setExpandedFields] = useState<string[]>(hydrated?.expandedFields || ['title', 'outputType']);
+  const [expandedFields, setExpandedFields] = useState<string[]>(hydrated?.expandedFields || ['title']);
   // State for managing custom output types
   const [newOutputType, setNewOutputType] = useState<OutputTypeInterface>({ type: '', description: '' });
   // State for managing custom license types

--- a/components/Form/ResearchOutputQuestionComponent/index.tsx
+++ b/components/Form/ResearchOutputQuestionComponent/index.tsx
@@ -107,6 +107,7 @@ const ResearchOutputComponent: React.FC<ResearchOutputComponentProps> = ({
                     <Checkbox
                       isSelected={field.enabled}
                       isDisabled={isDisabled}
+                      data-testid={`checkbox-${field.id}`}
                       aria-describedby={isDisabled ? tooltipId : undefined}
                       className={
                         `react-aria-Checkbox ${(field.required)

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -1507,7 +1507,7 @@ describe("Research Output Question Type", () => {
     // Find customize buttons (there should be multiple)
     const customizeButtons = screen.getAllByText('buttons.customize');
     const initialNoOfCloseButtons = screen.queryAllByText('buttons.close');;
-    expect(initialNoOfCloseButtons.length).toBe(1); // Only Output Type is expanded by default
+    expect(initialNoOfCloseButtons.length).toBe(0);
     expect(customizeButtons.length).toBeGreaterThan(0);
 
     // Click the first customize button (for Output Type which is always expanded)
@@ -1518,7 +1518,7 @@ describe("Research Output Question Type", () => {
     // Should show an additionalclose button after clicking and expanding
     await waitFor(() => {
       const closeButtons = screen.getAllByText('buttons.close');;
-      expect(closeButtons.length).toBe(2);
+      expect(closeButtons.length).toBe(1);
     });
   });
 
@@ -1699,6 +1699,10 @@ describe("Research Output Question Type", () => {
       />);
 
     // Find the panel
+    const outputTypeCheckbox = screen.getByTestId('checkbox-outputType');
+    await act(async () => { // open panel
+      fireEvent.click(outputTypeCheckbox);
+    });
     const panel = document.getElementById('panel-outputType');
     if (!panel) throw new Error('panel-outputType not found');
 

--- a/components/RepoSelectorForAnswer/index.tsx
+++ b/components/RepoSelectorForAnswer/index.tsx
@@ -85,6 +85,17 @@ function toSubjectAreaObject(str: string): { id: string; name: string } {
   return { id, name };
 }
 
+// Deduplicate repositories by URI to avoid duplicates in search results
+const dedupeByUri = (repos: Repository[]): Repository[] => {
+  const seenUris = new Set<string>();
+  return repos.filter(repo => {
+    const uri = repo.uri ?? '';
+    if (seenUris.has(uri)) return false;
+    seenUris.add(uri);
+    return true;
+  });
+};
+
 /* Research Output question's Repository Selection System */
 const RepoSelectorForAnswer = ({
   value,
@@ -260,7 +271,7 @@ const RepoSelectorForAnswer = ({
         return matchesSearch && matchesSubject && matchesType;
       }) as Repository[];
 
-      setRepositories(filtered);
+      setRepositories(dedupeByUri(filtered));
       setTotalCount(filtered.length);
       setTotalPages(1);
       setHasNextPage(false);
@@ -411,16 +422,7 @@ const RepoSelectorForAnswer = ({
           }
           return true;
         });
-        // Deduplicate by URI — the API can return the same repository more than once,
-        // which causes React duplicate-key warnings since we use uri as the item key.
-        const seenUris = new Set<string>();
-        const dedupedRepos = validRepos.filter(repo => {
-          const uri = repo.uri ?? '';
-          if (seenUris.has(uri)) return false;
-          seenUris.add(uri);
-          return true;
-        });
-        setRepositories(dedupedRepos);
+        setRepositories(dedupeByUri(validRepos));
         setTotalCount(repositoriesData.repositories.totalCount ?? 0);
         setTotalPages(Math.ceil((repositoriesData.repositories.totalCount ?? 0) / LIMIT));
         setHasNextPage(repositoriesData.repositories.hasNextPage ?? false);
@@ -445,7 +447,7 @@ const RepoSelectorForAnswer = ({
       preferredReposURIs.length > 0 &&
       preferredRepositoriesData?.re3byURIs &&
       showPreferredOnly) {
-      setRepositories(preferredRepositoriesData.re3byURIs as Repository[]);
+      setRepositories(dedupeByUri(preferredRepositoriesData.re3byURIs as Repository[]));
       setTotalCount(preferredRepositoriesData.re3byURIs.length);
       setTotalPages(1);
       setHasNextPage(false);
@@ -475,7 +477,7 @@ const RepoSelectorForAnswer = ({
         // Preferred URIs returned no results (URI mismatch etc.) — fall back to all repos
         setShowPreferredOnly(false);
       } else {
-        setRepositories(preferredRepositoriesData.re3byURIs as Repository[]);
+        setRepositories(dedupeByUri(preferredRepositoriesData.re3byURIs as Repository[]));
         setTotalCount(preferredRepositoriesData.re3byURIs.length);
         setTotalPages(1);
         setHasNextPage(false);

--- a/utils/researchOutputTransformations.ts
+++ b/utils/researchOutputTransformations.ts
@@ -487,7 +487,9 @@ export const jsonToState = (
     return {
       standardFields: initialStandardFields,
       additionalFields: [],
-      expandedFields: ['title', 'outputType'],
+      expandedFields: initialStandardFields
+        .filter(f => f.enabled)
+        .map(f => f.id),
     };
   }
 


### PR DESCRIPTION

## Description

- Updated `useResearchoutputTable` hook to not include `outputType` field as one that is initially enabled. Updated `expandedFields` logic for Research Output fields to be dynamic

Fixes # ([33](https://github.com/CDLUC3/dmptool-doc/issues/33))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested and updated some unit tests


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshots
### Description and Output type are no longer showing as required when creating a question or answering:

<img width="937" height="667" alt="Image" src="https://github.com/user-attachments/assets/01f3300f-a790-4108-a669-1922219b48f2" />

<img width="901" height="669" alt="Image" src="https://github.com/user-attachments/assets/ff559ce7-d19e-4dcd-b121-068b1fce8d9a" />
