### PR TITLE
Reverted the optimistic update when a successful response includes errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `UpdateAffiliation` and `AffiliationById` queries [#203]
 
 ## Updated
+- Updated `handleRevoke` method in `ProjectsProjectColalboration` component so that we revert the optimistic update if errors are returned as part of the successful response [#228]
 - Updated `ProjectsProjectCollaboration`, `ProjectsProjectFunding`, `ProjectsProjectMembers` and `ProjectsProjectDetail` to query `project` resolver instead to get its data, so that we can easily get `readOnly` data. Updated those components to disable or remove form fields, CTAs and links in `readOnly` mode [#245]
 - Updated `ProjectOverviewPage` to change links to `view` versions, disable some CTAs,hide `related works` section, and change plan button text to "View plan in `readOnly` mode [#245]
 - Updated `AccessLevelRadioGroup` and `ResearchDomainCascadingDropdown` to pass in a `isDisabled` prop so that we can disable the radio buttons for readOnly mode [#245]

--- a/app/[locale]/projects/[projectId]/collaboration/page.tsx
+++ b/app/[locale]/projects/[projectId]/collaboration/page.tsx
@@ -282,6 +282,8 @@ const ProjectsProjectCollaboration = () => {
         // This will flatten field-level errors into an array of strings, since we have no form fields here
         // and want to display any errors at the top of the page
         const errs = extractErrors(normalizedErrors);
+        // revert optimistic update if mutation fails
+        setProjectCollaborators(originalCollaborators);
         setErrorMessages(errs);
       } else {
         //Successfully updated


### PR DESCRIPTION
## Description

This change was needed because when the backend returned a "general" error, per se, then the `optimistic` removal of the collaborator was not reversed. So even though the error was displayed at the top of the page, it looked like the change had been made, and the collaborator removed, even when it wasn't.

- Updated `handleRevoke` method in `ProjectsProjectColalboration` component so that we revert the optimistic update if errors are returned as part of the successful response

Fixes # ([228](https://github.com/CDLUC3/dmptool-doc/issues/228))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules
* Note: backend dependency in this PR: https://github.com/CDLUC3/dmptool-apollo-server/pull/742

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 

## Screenshot
<img width="1081" height="463" alt="image" src="https://github.com/user-attachments/assets/37cbb3e8-0231-40af-88e1-9a15df7680ab" />
