### PR TITLE
Updated dependencies per renovate, npm audit, and addressed some issues that arose from these updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@
 
 ## Fixed
 - Fixed issue with Feedback Notification headers displaying for any collaborator on the Plan Overview, Section and Question pages. It should only display to Org Admins and Super Admins. Added shared isOrgAdmin hook for pages. [#249]
+
 ## Chore
+- Updated `@apollo/client` to `v4.2.0`, `dompurify` to `v3.4.6`, `@types/react` to `v18.3.29`, `react` to `v19.2.6`, `react-dom` to `v19.2.6`, `@types/node` to `v24.12.4`, `@dmptool/types` to `v3.1.5`, `postcss` to `v8.5.15`, and `tmp` to `v0.2.7`. Removed `@eslint-plugin-kit` override, and added `qs` override to address security vulnerability. Updated `zod` to `v4.4.3` to match the version in updated `@dmptool/types`, otherwise I get errors.
 - Updated version of `sanitize-html` to `v2.17.4` [#225]
 - Updated version of `next-intl` to `v4.9.2` and `icu-minify` to `v4.11.1`, and added `override` of `postcss` to `v8.5.10` to address security vulnerabilities.
 - Updated `sanitize-html` to `v2.17.3` and `dompurify` to `v3.4.0` due to security issues. Also, updated `prettier` to `v3.8.3` and `@dmptool/types` to `v3.1.4`, and `lodash` override to `v.4.18.1`. Removed overrides for `minimatch` and `test-exclude`.
@@ -128,7 +130,6 @@
 - Fixed bug where the published status on `/template/[templateId]` did not match that on the template cards at `/template` for the `unpublished changes` state. Added a shared hook for determining the correct status text [#875]
 
 ## Chore
-- Updated `@apollo/client` to `v4.2.0`, `dompurify` to `v3.4.6`, `@types/react` to `v18.3.29`, `react` to `v19.2.6`, `react-dom` to `v19.2.6`, `@types/node` to `v24.12.4`, `@dmptool/types` to `v3.1.5`, and `postcss` to `v8.5.15`. Removed `@eslint-plugin-kit` override, and added `qs` override to address security vulnerability. Updated `zod` to `v4.4.3` to match the version in updated `@dmptool/types`, otherwise I get errors.
 - Updated version of `sanitize-html` to `v2.17.4` to address critical security vulnerability
 - Updated `cypress` to `v15.15.0`. This also addresses a high security vulnerability in `systeminformation` dependency. Also, updated the date in `LICENSE.md` file to the current year.
 - Updated `@apollo/client` to `v4.1.7`, `@apollo/client-integration-nextjs` to `v0.14.5`, `next` to `v16.2.3`, `next-intl` to `v4.9.1`,`@types/node` to `v24.12.2`, `@types/sanitize-html` to `v2.16.1`, `brace-expansion` to `v2.1.0` and `minimatch` to `v10.2.5`, and `next` to `v16.2.6`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@
 - Fixed bug where the published status on `/template/[templateId]` did not match that on the template cards at `/template` for the `unpublished changes` state. Added a shared hook for determining the correct status text [#875]
 
 ## Chore
+- Updated `@apollo/client` to `v4.2.0`, `dompurify` to `v3.4.6`, `@types/react` to `v18.3.29`, `react` to `v19.2.6`, `react-dom` to `v19.2.6`, `@types/node` to `v24.12.4`, `@dmptool/types` to `v3.1.5`, and `postcss` to `v8.5.15`. Removed `@eslint-plugin-kit` override, and added `qs` override to address security vulnerability. Updated `zod` to `v4.4.3` to match the version in updated `@dmptool/types`, otherwise I get errors.
 - Updated version of `sanitize-html` to `v2.17.4` to address critical security vulnerability
 - Updated `cypress` to `v15.15.0`. This also addresses a high security vulnerability in `systeminformation` dependency. Also, updated the date in `LICENSE.md` file to the current year.
 - Updated `@apollo/client` to `v4.1.7`, `@apollo/client-integration-nextjs` to `v0.14.5`, `next` to `v16.2.3`, `next-intl` to `v4.9.1`,`@types/node` to `v24.12.2`, `@types/sanitize-html` to `v2.16.1`, `brace-expansion` to `v2.1.0` and `minimatch` to `v10.2.5`, and `next` to `v16.2.6`.

--- a/app/[locale]/admin/templates/__tests__/page.spec.tsx
+++ b/app/[locale]/admin/templates/__tests__/page.spec.tsx
@@ -367,11 +367,6 @@ describe("OrganizationTemplateListPage", () => {
     render(
       <MockedProvider
         mocks={multipleItemsErrorMock}
-        defaultOptions={{
-          watchQuery: { errorPolicy: 'all' },
-          query: { errorPolicy: 'all' },
-          mutate: { errorPolicy: 'all' },
-        }}
       >
         <OrganizationTemplateListPage />
       </MockedProvider>,

--- a/app/[locale]/projects/[projectId]/members/search/hooks/__tests__/useProjectMemberForm.spec.tsx
+++ b/app/[locale]/projects/[projectId]/members/search/hooks/__tests__/useProjectMemberForm.spec.tsx
@@ -127,10 +127,6 @@ const createWrapper = (mocks: any[] = []) => {
   const Wrapper = ({ children }: WrapperProps) => (
     <MockedProvider
       mocks={mocks}
-      defaultOptions={{
-        watchQuery: { errorPolicy: 'ignore' },
-        query: { errorPolicy: 'ignore' },
-      }}
     >
       {children}
     </MockedProvider>

--- a/app/[locale]/template/__tests__/page.spec.tsx
+++ b/app/[locale]/template/__tests__/page.spec.tsx
@@ -71,12 +71,6 @@ describe('TemplateListPage', () => {
     <MockedProvider
       mocks={apolloMocks}
       cache={apolloCache}
-      //  link={ApolloLink.empty()}
-      defaultOptions={{
-        query: { fetchPolicy: 'no-cache', errorPolicy: 'all' },
-        watchQuery: { fetchPolicy: 'no-cache', errorPolicy: 'all' },
-        mutate: { errorPolicy: 'all' }
-      }}
     >
       <TemplateListPage />
     </MockedProvider>

--- a/app/[locale]/template/customizations/[templateCustomizationId]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/customizations/[templateCustomizationId]/__tests__/page.spec.tsx
@@ -134,10 +134,6 @@ describe('TemplateCustomizationOverview', () => {
     <MockedProvider
       mocks={apolloMocks}
       cache={apolloCache}
-      defaultOptions={{
-        query: { fetchPolicy: 'no-cache', errorPolicy: 'all' },
-        watchQuery: { fetchPolicy: 'no-cache', errorPolicy: 'all' },
-      }}
     >
       <TemplateCustomizationOverview />
     </MockedProvider>

--- a/app/[locale]/template/customizations/__tests__/page.spec.tsx
+++ b/app/[locale]/template/customizations/__tests__/page.spec.tsx
@@ -88,11 +88,6 @@ describe('TemplateListCustomizationsPage', () => {
     <MockedProvider
       mocks={apolloMocks}
       cache={apolloCache}
-      defaultOptions={{
-        query: { fetchPolicy: 'no-cache', errorPolicy: 'all' },
-        watchQuery: { fetchPolicy: 'no-cache', errorPolicy: 'all' },
-        mutate: { errorPolicy: 'all' }
-      }}
     >
       <TemplateListCustomizationsPage />
     </MockedProvider>

--- a/components/CustomizedTemplate/CustomizedSectionEdit/__tests__/index.spec.tsx
+++ b/components/CustomizedTemplate/CustomizedSectionEdit/__tests__/index.spec.tsx
@@ -249,11 +249,6 @@ describe('CustomizedSectionEdit', () => {
       <MockedProvider
         mocks={mocks}
         cache={apolloCache}
-        defaultOptions={{
-          query: { fetchPolicy: 'no-cache', errorPolicy: 'all' },
-          watchQuery: { fetchPolicy: 'no-cache', errorPolicy: 'all' },
-          mutate: { errorPolicy: 'all' }
-        }}
       >
         <CustomizedSectionEdit
           section={section}

--- a/components/PlanOverviewSectionPageShared/index.tsx
+++ b/components/PlanOverviewSectionPageShared/index.tsx
@@ -169,16 +169,16 @@ export const PlanOverviewSectionPageShared: React.FC<{ config: SectionPageConfig
   }, [sectionData]);
 
   // Determine if user is a collaborator with edit access - this will allow them to see "Update" on the section cards and access the question modals even if the plan is read-only
-  const isEditCollaborator = useMemo(() => {
-    const myId = me?.me?.id;
-    if (!myId || !planData?.plan?.project?.collaborators) return false;
+const isEditCollaborator = useMemo(() => {
+  const myId = me?.me?.id;
+  if (!myId || !planData?.plan?.project?.collaborators) return false;
 
-    return planData.plan.project.collaborators.some(
-      (collaborator) =>
-        collaborator?.user?.id === myId &&
-        collaborator?.accessLevel === "EDIT"
-    );
-  }, [me?.me?.id, planData?.plan?.project?.collaborators]);
+  return planData.plan.project.collaborators.some(
+    (collaborator) =>
+      String(collaborator?.user?.id) === String(myId) && // Double-checking that the collaborator relationship is valid and has EDIT access
+      collaborator?.accessLevel === "EDIT"
+  );
+}, [me?.me?.id, planData?.plan?.project?.collaborators]);
 
   // Determine if user is an Org Admin that can see feedback request notifications
   const isOrgAdmin = useIsOrgAdmin(

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "dmsp_frontend_prototype",
       "version": "0.1.0",
       "dependencies": {
-        "@apollo/client": "4.1.7",
+        "@apollo/client": "4.2.0",
         "@apollo/client-integration-nextjs": "0.14.5",
-        "@dmptool/types": "3.1.4",
+        "@dmptool/types": "3.1.5",
         "@elastic/ecs-pino-format": "1.5.0",
         "@fortawesome/fontawesome-svg-core": "6.6.0",
         "@fortawesome/free-solid-svg-icons": "6.6.0",
@@ -19,7 +19,7 @@
         "@react-stately/toast": "3.1.3",
         "classnames": "2.5.1",
         "deepmerge": "4.3.1",
-        "dompurify": "3.4.0",
+        "dompurify": "3.4.6",
         "graphql": "16.12.0",
         "html-react-parser": "5.2.17",
         "husky": "9.1.7",
@@ -32,14 +32,14 @@
         "nprogress": "0.2.0",
         "pino": "9.14.0",
         "prop-types": "15.8.1",
-        "react": "19.2.4",
+        "react": "19.2.6",
         "react-aria-components": "1.16.0",
-        "react-dom": "19.2.4",
+        "react-dom": "19.2.6",
         "react-transition-progress": "0.0.4",
         "rxjs": "7.8.2",
         "sanitize-html": "2.17.4",
         "tinymce": "7.9.2",
-        "zod": "4.3.6"
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@graphql-codegen/cli": "6.1.2",
@@ -55,19 +55,19 @@
         "@types/jest-axe": "3.5.9",
         "@types/jsonwebtoken": "9.0.10",
         "@types/next": "9.0.0",
-        "@types/node": "24.12.2",
+        "@types/node": "24.12.4",
         "@types/nprogress": "0.2.3",
         "@types/pino": "7.0.5",
-        "@types/react": "18.3.28",
+        "@types/react": "18.3.29",
         "@types/react-dom": "18.3.7",
         "@types/sanitize-html": "2.16.1",
         "@typescript-eslint/eslint-plugin": "8.56.1",
         "@typescript-eslint/parser": "8.56.1",
         "brace-expansion": "2.1.0",
-        "cypress": "15.15.0",
+        "cypress": "^15.15.0",
         "domexception": "4.0.0",
         "dotenv": "16.6.1",
-        "eslint": "9.18.0",
+        "eslint": "9.27.0",
         "eslint-config-next": "16.1.6",
         "eslint-plugin-unused-imports": "4.3.0",
         "jest": "30.2.0",
@@ -87,15 +87,10 @@
       "license": "MIT"
     },
     "node_modules/@apollo/client": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.1.7.tgz",
-      "integrity": "sha512-CE1Pe22vszRBMGrBOovIXzTa5infy1kwF0kWX2JBLcGFXoOPBOAo9zoM++tuSRZr8PscWJyv2ka2FKoyEquEHw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.0.tgz",
+      "integrity": "sha512-uZAiXwIRidDqQKZRcL88O01IVZjY6IhLio6g+XzX4N4++Ue9pVK9WCoZvBm1dvx+x2mH0oGfVUZvTvacCW4WcQ==",
       "license": "MIT",
-      "workspaces": [
-        "dist",
-        "codegen",
-        "scripts/codemods/ac3-to-ac4"
-      ],
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -936,14 +931,14 @@
       }
     },
     "node_modules/@dmptool/types": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@dmptool/types/-/types-3.1.4.tgz",
-      "integrity": "sha512-ZKZaHUiVRu7Zm7o+B9pRuQUXY4oV/rI+NZ4h4j4sIi/7AAjHSwNfc5X8Xt3DWdYaw9zcfi+UlhjX5g2cN9u0mg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@dmptool/types/-/types-3.1.5.tgz",
+      "integrity": "sha512-xcrRW0atCsxT5CdhuhMxD6EpnC7fC/snLvMpB5y6tg/7iJidEoap0buHdYRlBcAdv8dm/sqeIwNioA8vT7mDNQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@elastic/ecs-helpers": {
@@ -1074,9 +1069,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
+      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1089,9 +1084,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1112,10 +1107,20 @@
         "node": "*"
       }
     },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
+      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1174,13 +1179,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.18.0.tgz",
-      "integrity": "sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
+      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1194,13 +1202,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
-      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1505,18 +1513,17 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.1.0.tgz",
-      "integrity": "sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.3.0.tgz",
+      "integrity": "sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
+        "@graphql-tools/utils": "^11.0.0",
         "change-case-all": "1.0.15",
         "common-tags": "1.8.2",
         "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.6.0"
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -1525,12 +1532,24 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+    "node_modules/@graphql-codegen/plugin-helpers/node_modules/@graphql-tools/utils": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.1.0.tgz",
+      "integrity": "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==",
       "dev": true,
-      "license": "0BSD"
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
     },
     "node_modules/@graphql-codegen/schema-ast": {
       "version": "5.0.0",
@@ -7688,9 +7707,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7723,9 +7742,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "18.3.29",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -10401,9 +10420,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.6.tgz",
+      "integrity": "sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10781,22 +10800,23 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.18.0.tgz",
-      "integrity": "sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
+      "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.10.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.18.0",
-        "@eslint/plugin-kit": "^0.2.5",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.27.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -10804,7 +10824,7 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
+        "eslint-scope": "^8.3.0",
         "eslint-visitor-keys": "^4.2.0",
         "espree": "^10.3.0",
         "esquery": "^1.5.0",
@@ -16710,9 +16730,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16776,9 +16796,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -17717,9 +17737,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -17736,7 +17756,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -17912,9 +17932,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -17955,9 +17975,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18059,15 +18079,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
@@ -20423,10 +20443,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -20571,9 +20591,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19533,9 +19533,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "trivy-all": "npm run trivy-high && npm run trivy-med"
   },
   "dependencies": {
-    "@apollo/client": "4.1.7",
+    "@apollo/client": "4.2.0",
     "@apollo/client-integration-nextjs": "0.14.5",
-    "@dmptool/types": "3.1.4",
+    "@dmptool/types": "3.1.5",
     "@elastic/ecs-pino-format": "1.5.0",
     "@fortawesome/fontawesome-svg-core": "6.6.0",
     "@fortawesome/free-solid-svg-icons": "6.6.0",
@@ -34,7 +34,7 @@
     "@react-stately/toast": "3.1.3",
     "classnames": "2.5.1",
     "deepmerge": "4.3.1",
-    "dompurify": "3.4.0",
+    "dompurify": "3.4.6",
     "graphql": "16.12.0",
     "html-react-parser": "5.2.17",
     "husky": "9.1.7",
@@ -47,14 +47,14 @@
     "nprogress": "0.2.0",
     "pino": "9.14.0",
     "prop-types": "15.8.1",
-    "react": "19.2.4",
+    "react": "19.2.6",
     "react-aria-components": "1.16.0",
-    "react-dom": "19.2.4",
+    "react-dom": "19.2.6",
     "react-transition-progress": "0.0.4",
     "rxjs": "7.8.2",
     "sanitize-html": "2.17.4",
     "tinymce": "7.9.2",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "6.1.2",
@@ -70,19 +70,19 @@
     "@types/jest-axe": "3.5.9",
     "@types/jsonwebtoken": "9.0.10",
     "@types/next": "9.0.0",
-    "@types/node": "24.12.2",
+    "@types/node": "24.12.4",
     "@types/nprogress": "0.2.3",
     "@types/pino": "7.0.5",
-    "@types/react": "18.3.28",
+    "@types/react": "18.3.29",
     "@types/react-dom": "18.3.7",
     "@types/sanitize-html": "2.16.1",
     "@typescript-eslint/eslint-plugin": "8.56.1",
     "@typescript-eslint/parser": "8.56.1",
     "brace-expansion": "2.1.0",
-    "cypress": "15.15.0",
+    "cypress": "^15.15.0",
     "domexception": "4.0.0",
     "dotenv": "16.6.1",
-    "eslint": "9.18.0",
+    "eslint": "9.27.0",
     "eslint-config-next": "16.1.6",
     "eslint-plugin-unused-imports": "4.3.0",
     "jest": "30.2.0",
@@ -94,8 +94,7 @@
     "typescript": "5.9.3"
   },
   "overrides": {
-    "@eslint/plugin-kit": "0.3.4",
-    "lodash": "4.18.1",
-    "postcss": "8.5.10"
+    "postcss": "8.5.15",
+    "qs": "6.15.2"
   }
 }

--- a/styles/form/_button.scss
+++ b/styles/form/_button.scss
@@ -391,9 +391,9 @@ button.link-disabled,
 input[type="button"].link-disabled,
 input[type="reset"].link-disabled,
 input[type="submit"].link-disabled {
-  @include button-link;
   color: var(--slate-400);
   cursor: not-allowed;
+  @include button-link;
 
   &[data-focus-visible],
   &:focus-visible,


### PR DESCRIPTION

## Description

- Updated `@apollo/client` to `v4.2.0`, `dompurify` to `v3.4.6`, `@types/react` to `v18.3.29`, `react` to `v19.2.6`, `react-dom` to `v19.2.6`, `@types/node` to `v24.12.4`, `@dmptool/types` to `v3.1.5`, and `postcss` to `v8.5.15`. Removed `@eslint-plugin-kit` override, and added `qs` override to address security vulnerability. Updated `zod` to `v4.4.3` to match the version in updated `@dmptool/types`, otherwise I get errors.
- Addressed use of `errorPolicy` from some unit tests because `@apollo/client v4.2.0`does not allow `errorPolicy` in top-level DefaultOptions.
