### PR TITLE
Updated tinymce version to v7.9.3 due to vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Fixed issue with Feedback Notification headers displaying for any collaborator on the Plan Overview, Section and Question pages. It should only display to Org Admins and Super Admins. Added shared isOrgAdmin hook for pages. [#249]
 
 ## Chore
+- Updated `tinymce` to `v7.9.3` due to high vulnerabilities [#276]
 - Updated `@apollo/client` to `v4.2.0`, `dompurify` to `v3.4.6`, `@types/react` to `v18.3.29`, `react` to `v19.2.6`, `react-dom` to `v19.2.6`, `@types/node` to `v24.12.4`, `@dmptool/types` to `v3.1.5`, `postcss` to `v8.5.15`, and `tmp` to `v0.2.7`. Removed `@eslint-plugin-kit` override, and added `qs` override to address security vulnerability. Updated `zod` to `v4.4.3` to match the version in updated `@dmptool/types`, otherwise I get errors.
 - Updated version of `sanitize-html` to `v2.17.4` [#225]
 - Updated version of `next-intl` to `v4.9.2` and `icu-minify` to `v4.11.1`, and added `override` of `postcss` to `v8.5.10` to address security vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "react-transition-progress": "0.0.4",
         "rxjs": "7.8.2",
         "sanitize-html": "2.17.4",
-        "tinymce": "7.9.2",
+        "tinymce": "7.9.3",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -19497,9 +19497,9 @@
       }
     },
     "node_modules/tinymce": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-7.9.2.tgz",
-      "integrity": "sha512-zS2gn2CPQmZhUqLzkhwYH+WGsx/DIRY/mS18RVzsIcuQg2lN2uzaqoHSJU6DdMUpvXBtBFnLNpumC3QrDwLBzA==",
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-7.9.3.tgz",
+      "integrity": "sha512-Mtm54U5YJ6Pyo/GaAx+JSHXTGEuxrg2AowVWCD9zy1eBolp5Ub7S1rTtsyQdxhPegfhLuR3VLiTKGw1tacv09g==",
       "license": "GPL-2.0-or-later"
     },
     "node_modules/title-case": {
@@ -20446,7 +20446,7 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-transition-progress": "0.0.4",
     "rxjs": "7.8.2",
     "sanitize-html": "2.17.4",
-    "tinymce": "7.9.2",
+    "tinymce": "7.9.3",
     "zod": "4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

- Updated `tinymce` to `v7.9.3` due to high vulnerabilities

Fixes # ([276](https://github.com/CDLUC3/dmptool-doc/issues/276))

## Type of change
- [X] Chore

## How Has This Been Tested?
Tested Rich Text Editors on site, and they were still working. Didn't see any errors.
