### PR TITLE
Added Github Action workflows to automate versioning

### DIFF
--- a/.github/workflows/validation-version-label.yml
+++ b/.github/workflows/validation-version-label.yml
@@ -1,0 +1,48 @@
+name: Validate Version Label
+
+on:
+  pull_request:
+    branches:
+      - stage
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate version label
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+
+          HAS_MAJOR=0
+          HAS_MINOR=0
+          HAS_PATCH=0
+
+          [[ "$LABELS" == *"version:major"* ]] && HAS_MAJOR=1
+          [[ "$LABELS" == *"version:minor"* ]] && HAS_MINOR=1
+          [[ "$LABELS" == *"version:patch"* ]] && HAS_PATCH=1
+
+          COUNT=$((HAS_MAJOR + HAS_MINOR + HAS_PATCH))
+
+          echo "Version labels found:"
+          echo "  major=$HAS_MAJOR"
+          echo "  minor=$HAS_MINOR"
+          echo "  patch=$HAS_PATCH"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::warning::No version label found. Will default to patch bump on merge."
+          fi
+
+          if [ "$COUNT" -gt 1 ]; then
+            echo "::error::PR contains multiple version labels. Select exactly one of: version:major, version:minor, or version:patch"
+            exit 1
+          fi
+
+          echo "Valid version label found."

--- a/.github/workflows/validation-version-label.yml
+++ b/.github/workflows/validation-version-label.yml
@@ -3,7 +3,7 @@ name: Validate Version Label
 on:
   pull_request:
     branches:
-      - stage
+      - main
     types:
       - opened
       - synchronize
@@ -37,7 +37,8 @@ jobs:
           echo "  patch=$HAS_PATCH"
 
           if [ "$COUNT" -eq 0 ]; then
-            echo "::warning::No version label found. Will default to patch bump on merge."
+            echo "::error::No version label found. Add exactly one of: version:major, version:minor, or version:patch"
+            exit 1
           fi
 
           if [ "$COUNT" -gt 1 ]; then

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -4,7 +4,7 @@ on:
     types:
       - closed
     branches:
-      - stage
+      - main
 
 permissions:
   contents: write
@@ -66,6 +66,10 @@ jobs:
             echo "### Updated"
             echo ""
             echo "### Fixed"
+            echo ""
+            echo "### Removed"
+            echo ""
+            echo "### Chore"
             echo ""
             cat CHANGELOG.md
           } > CHANGELOG.tmp

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,87 @@
+name: Automated Versioning
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - stage
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    if: github.event.pull_request.merged == true
+    #GitHub-hosted runner with Ubuntu
+    runs-on: ubuntu-latest 
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Determine version bump
+        id: bump
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+
+        run: |
+          if [[ "$LABELS" == *"version:major"* ]]; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif [[ "$LABELS" == *"version:minor"* ]]; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          elif [[ "$LABELS" == *"version:patch"* ]]; then
+            echo "type=patch" >> $GITHUB_OUTPUT
+          else
+            echo "type=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bump version
+        run: |
+          npm version ${{ steps.bump.outputs.type }} --no-git-tag-version
+
+      - name: Get new version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          {
+            echo "## v${VERSION}"
+            echo ""
+            echo "### Added"
+            echo ""
+            echo "### Updated"
+            echo ""
+            echo "### Fixed"
+            echo ""
+            cat CHANGELOG.md
+          } > CHANGELOG.tmp
+
+          mv CHANGELOG.tmp CHANGELOG.md
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          git add package.json CHANGELOG.md
+
+          git commit -m "chore: release v${{ steps.version.outputs.version }}" || exit 0
+
+          git tag -f "v${{ steps.version.outputs.version }}"
+
+          git push origin HEAD:${{ github.event.pull_request.base.ref }}
+          git push --tags --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - Fixed issue with Feedback Notification headers displaying for any collaborator on the Plan Overview, Section and Question pages. It should only display to Org Admins and Super Admins. Added shared isOrgAdmin hook for pages. [#249]
 
 ## Chore
-- Added Github Action workflows `versioning.yml` and `validation-version-label.yml` to automate versioning when merging from `development` into `stage`.
+- Added Github Action workflows `versioning.yml` and `validation-version-label.yml` to automate versioning when merging from `development` into `stage`. [#271]
 - Updated `tinymce` to `v7.9.3` due to high vulnerabilities [#276]
 - Updated `@apollo/client` to `v4.2.0`, `dompurify` to `v3.4.6`, `@types/react` to `v18.3.29`, `react` to `v19.2.6`, `react-dom` to `v19.2.6`, `@types/node` to `v24.12.4`, `@dmptool/types` to `v3.1.5`, `postcss` to `v8.5.15`, and `tmp` to `v0.2.7`. Removed `@eslint-plugin-kit` override, and added `qs` override to address security vulnerability. Updated `zod` to `v4.4.3` to match the version in updated `@dmptool/types`, otherwise I get errors.
 - Updated version of `sanitize-html` to `v2.17.4` [#225]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Fixed issue with Feedback Notification headers displaying for any collaborator on the Plan Overview, Section and Question pages. It should only display to Org Admins and Super Admins. Added shared isOrgAdmin hook for pages. [#249]
 
 ## Chore
+- Added Github Action workflows `versioning.yml` and `validation-version-label.yml` to automate versioning when merging from `development` into `stage`.
 - Updated `tinymce` to `v7.9.3` due to high vulnerabilities [#276]
 - Updated `@apollo/client` to `v4.2.0`, `dompurify` to `v3.4.6`, `@types/react` to `v18.3.29`, `react` to `v19.2.6`, `react-dom` to `v19.2.6`, `@types/node` to `v24.12.4`, `@dmptool/types` to `v3.1.5`, `postcss` to `v8.5.15`, and `tmp` to `v0.2.7`. Removed `@eslint-plugin-kit` override, and added `qs` override to address security vulnerability. Updated `zod` to `v4.4.3` to match the version in updated `@dmptool/types`, otherwise I get errors.
 - Updated version of `sanitize-html` to `v2.17.4` [#225]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [Testing](#testing)
 - [API Routes](#api-routes)
 - [Working with GraphQL](#working-with-graphql)
+- [Automated Versioning](#automated-versioning)
 - [Contributing](#contributing)
 - [Contributors](#contributors)
 - [License](#license)
@@ -341,6 +342,22 @@ We use the `@apollo/client` package to manage the connection with Apollo Server.
 
 The `lib/graphql/graphqlHelper.ts` file provides logic for handling retries and processing GraphQL errors from Apollo Server.
 
+## Automated Versioning
+This project uses GitHub Actions to automatically manage version bumping and changelog updates whenever a pull request is merged from `development` into `stage`.
+
+### How It Works
+Two workflows handle versioning:
+1. Validate Version Label - Runs on every PR opened or updated against `stage`. If there is a version label applied, it will use that to determine the new version. If no label is applied, it will automatically do a `patch` version update.
+2. Automated Versioning - Runs when a PR is merged into `stage`. It reads the version label, bumps `package.json` using `npm version`, prepends a new section to `CHANGELOG.md`, commits both files, and pushes a Git tag. The command and tag are pushed directly to the `stage` branch by `github-actions`.
+
+### PR Labels
+When opening a PR from `development` to `stage`, you can apply one of the following labels. Labels can be found in the "Labels" dropdown on the PR page's right sidebar.
+
+| Label         | When to use                                                             |
+|---------------|-------------------------------------------------------------------------|
+| version:major | Breaking changes or significant new features (e.g., 1.0.0 -> 2.0.0)     |
+| version:minor | New backwards-compatible functionality (e.g., 1.0.0 -> 1.1.0)           |
+| version:patch | Bug fixes and minor backwards-compatible changes (e.g., 1.0.0 -> 1.0.1) |
 
 ## Contributing
 1. Clone the repo from github (`git clone git@github.com:CDLUC3/dmsp_frontend_prototype.git`)


### PR DESCRIPTION
## Description

I was going to push up directly to `main` branch, but it has some `type` errors, so I thought I'd just create this PR and then plan on merging to `stage` and then merging `stage` to `main`. I want to test this workflow on `dmptool-ui` before applying it to all the repos.

Essentially, the `workflows` will check for `version:major`, `version:minor`, or `version:patch` labels on the PR. If they are not present, it will default to a `patch` version.

The workflow will bump `package.json`, prepend the new version at the top of `CHANGELOG.md`, commit files, and push a git tag to `stage`.

- Added Github Action workflows `versioning.yml` and `validation-version-label.yml` to automate versioning when merging from `development` into `stage`.
- Updated `README.md`

Fixes # ([271](https://github.com/CDLUC3/dmptool-doc/issues/271))

## Type of change
- [X] Chore
