### PR TITLE
Fixed bug in logo upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `UpdateAffiliation` and `AffiliationById` queries [#203]
 
 ## Updated
+- Fixed bug in org logo upload logic
 - Update feedback options page, fundings add page to work with the Affiliation `displayName`
 - Updated the `FormInput` component to accept either a string or a `React.ReactNode` object in the `helpMessage` so we can include resolvable URLs
 - Fixed a flaky test in the Plan Overview page tests

--- a/app/[locale]/admin/organization-details/page.tsx
+++ b/app/[locale]/admin/organization-details/page.tsx
@@ -407,7 +407,7 @@ const OrganizationDetailsPage: React.FC = () => {
       }) || [AffiliationType.Other];
 
       // Get the existing logo file name
-      let logoName = organization.logoName;
+      let logoNameToSave = organization.logoName;
 
       // Process newly uploaded logo if applicable
       if (uploadFile && logoName) {
@@ -416,10 +416,10 @@ const OrganizationDetailsPage: React.FC = () => {
           // The processLogoUpload function will have set error messages if it failed, so just abort
           return [undefined, false];
         }
-        logoName = s3Key;
-      } else if (logoName && !logoUrl) {
+        logoNameToSave = s3Key;
+      } else if (logoNameToSave && !logoUrl) {
         // If the logo was removed
-        logoName = undefined;
+        logoNameToSave = undefined;
       }
 
       const subHeaderLinks: AffiliationLinkInput[] = organizationLinks.map((link: OrganizationLink) => {
@@ -438,7 +438,7 @@ const OrganizationDetailsPage: React.FC = () => {
             contactName: organization.contactName,
             contactEmail: organization.contactEmail,
             types,
-            logoName,
+            logoName: logoNameToSave,
             fundrefId: organization.fundrefId,
             ssoEntityId: organization.ssoEntityId,
             ssoEmailDomains: organization.ssoEmailDomains,


### PR DESCRIPTION
Was testing in dev and realized that there was a bug when trying to add a logo to an org that does not already have one defined.

The `logoName` variable was overloaded. Its defined using `useState` but we were also defining it locally within the `updateAffiliation` function which was causing confusion. The bug was resulting in the `logoName` never getting updated when the existing record had no prior `logoName`.