### PR TITLE
[Chore] - Updated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Fixed issue with Feedback Notification headers displaying for any collaborator on the Plan Overview, Section and Question pages. It should only display to Org Admins and Super Admins. Added shared isOrgAdmin hook for pages. [#249]
 
 ## Chore
+- Updated `eslint` to `v9.39.4`, `prettier` to `v3.8.4`, `brace-expansion` to `v2.1.1`, `sanitize-html` to `v2.17.5`, `@apollo/client` to `v4.2.3`, `@dmptool/types` to `v3.1.7` and `dompurify` to `v3.4.11`. Also added override for `js-yaml` to `v4.2.0` due to vulnerability [#290]
 - Bump form-data from 4.0.5 to 4.0.6
 - Added Github Action workflows `versioning.yml` and `validation-version-label.yml` to automate versioning when merging from `development` into `stage`. [#271]
 - Addressed `shell-quote` vulnerability by running `npm audit fix` to update `package-lock.json` [#278]

--- a/app/[locale]/admin/users/__tests__/index.spec.tsx
+++ b/app/[locale]/admin/users/__tests__/index.spec.tsx
@@ -220,7 +220,7 @@ describe('Admin - User Accounts Dashboard', () => {
       renderPage([makeMeMock(UserRole.Admin), makeUsersMock(), makeUsersMock()]);
       await waitFor(() => expect(screen.getByTestId('mock-table')).toBeInTheDocument());
 
-      const input = screen.getByRole('searchbox');
+      const input = screen.getByTestId('search-input') as HTMLInputElement;
       await userEvent.type(input, 'a');
       await userEvent.clear(input);
 

--- a/app/[locale]/admin/users/page.tsx
+++ b/app/[locale]/admin/users/page.tsx
@@ -372,6 +372,7 @@ function OrgUserAccountsPage(): React.ReactElement {
                 <FormInput
                   name="search"
                   type="search"
+                  data-testid="search-input"
                   className={styles.searchInput}
                   label={usersTrans('tools.searchLabel')}
                   onChange={e => handleSearchInput(e.target.value)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "dmsp_frontend_prototype",
       "version": "0.1.0",
       "dependencies": {
-        "@apollo/client": "4.2.0",
+        "@apollo/client": "4.2.3",
         "@apollo/client-integration-nextjs": "0.14.5",
-        "@dmptool/types": "3.1.5",
+        "@dmptool/types": "3.1.7",
         "@elastic/ecs-pino-format": "1.5.0",
         "@fortawesome/fontawesome-svg-core": "6.6.0",
         "@fortawesome/free-solid-svg-icons": "6.6.0",
@@ -19,7 +19,7 @@
         "@react-stately/toast": "3.1.3",
         "classnames": "2.5.1",
         "deepmerge": "4.3.1",
-        "dompurify": "3.4.6",
+        "dompurify": "3.4.11",
         "graphql": "16.12.0",
         "html-react-parser": "5.2.17",
         "husky": "9.1.7",
@@ -37,7 +37,7 @@
         "react-dom": "19.2.6",
         "react-transition-progress": "0.0.4",
         "rxjs": "7.8.2",
-        "sanitize-html": "2.17.4",
+        "sanitize-html": "2.17.5",
         "tinymce": "7.9.3",
         "zod": "4.4.3"
       },
@@ -63,17 +63,17 @@
         "@types/sanitize-html": "2.16.1",
         "@typescript-eslint/eslint-plugin": "8.56.1",
         "@typescript-eslint/parser": "8.56.1",
-        "brace-expansion": "2.1.0",
+        "brace-expansion": "2.1.1",
         "cypress": "^15.15.0",
         "domexception": "4.0.0",
         "dotenv": "16.6.1",
-        "eslint": "9.27.0",
+        "eslint": "9.39.4",
         "eslint-config-next": "16.1.6",
         "eslint-plugin-unused-imports": "4.3.0",
         "jest": "30.2.0",
         "jest-axe": "10.0.0",
         "jest-environment-jsdom": "30.2.0",
-        "prettier": "3.8.3",
+        "prettier": "3.8.4",
         "sass": "1.89.2",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@apollo/client": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.0.tgz",
-      "integrity": "sha512-uZAiXwIRidDqQKZRcL88O01IVZjY6IhLio6g+XzX4N4++Ue9pVK9WCoZvBm1dvx+x2mH0oGfVUZvTvacCW4WcQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.3.tgz",
+      "integrity": "sha512-+auRYBXow2v7cT+wKzvjyMyyEojq+G7Sf80vIR57rtEPcxRFuMXuU9IKjwxZ3muclUgdGKwZXNeuki+g0GabgQ==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -101,7 +101,7 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^16.0.0",
+        "graphql": "^16.0.0 || ^17.0.0",
         "graphql-ws": "^5.5.5 || ^6.0.3",
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
         "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
@@ -931,9 +931,9 @@
       }
     },
     "node_modules/@dmptool/types": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@dmptool/types/-/types-3.1.5.tgz",
-      "integrity": "sha512-xcrRW0atCsxT5CdhuhMxD6EpnC7fC/snLvMpB5y6tg/7iJidEoap0buHdYRlBcAdv8dm/sqeIwNioA8vT7mDNQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@dmptool/types/-/types-3.1.7.tgz",
+      "integrity": "sha512-5ncz/LHe7knpzRgRYf/W5rQhvDrLHtHyZZLWaspab3PbzaIHVyMg4dxMItscyDzHJguC7vur0Tc0kUkw6o73lA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1069,15 +1069,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
-      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1108,19 +1108,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
-      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1131,9 +1134,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
-      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1144,7 +1147,7 @@
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.3",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -1155,9 +1158,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1179,9 +1182,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
-      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1202,27 +1205,14 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.2",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3610,16 +3600,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3632,20 +3612,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -8543,9 +8509,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9204,9 +9170,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10420,9 +10386,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.6.tgz",
-      "integrity": "sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10800,33 +10766,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
-      "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.14.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.27.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -10838,7 +10803,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -11366,20 +11331,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -17801,9 +17752,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -18523,9 +18474,9 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
-      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
@@ -18953,13 +18904,6 @@
       "dependencies": {
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
       "version": "1.18.0",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "trivy-all": "npm run trivy-high && npm run trivy-med"
   },
   "dependencies": {
-    "@apollo/client": "4.2.0",
+    "@apollo/client": "4.2.3",
     "@apollo/client-integration-nextjs": "0.14.5",
-    "@dmptool/types": "3.1.5",
+    "@dmptool/types": "3.1.7",
     "@elastic/ecs-pino-format": "1.5.0",
     "@fortawesome/fontawesome-svg-core": "6.6.0",
     "@fortawesome/free-solid-svg-icons": "6.6.0",
@@ -34,7 +34,7 @@
     "@react-stately/toast": "3.1.3",
     "classnames": "2.5.1",
     "deepmerge": "4.3.1",
-    "dompurify": "3.4.6",
+    "dompurify": "3.4.11",
     "graphql": "16.12.0",
     "html-react-parser": "5.2.17",
     "husky": "9.1.7",
@@ -52,7 +52,7 @@
     "react-dom": "19.2.6",
     "react-transition-progress": "0.0.4",
     "rxjs": "7.8.2",
-    "sanitize-html": "2.17.4",
+    "sanitize-html": "2.17.5",
     "tinymce": "7.9.3",
     "zod": "4.4.3"
   },
@@ -78,23 +78,24 @@
     "@types/sanitize-html": "2.16.1",
     "@typescript-eslint/eslint-plugin": "8.56.1",
     "@typescript-eslint/parser": "8.56.1",
-    "brace-expansion": "2.1.0",
+    "brace-expansion": "2.1.1",
     "cypress": "^15.15.0",
     "domexception": "4.0.0",
     "dotenv": "16.6.1",
-    "eslint": "9.27.0",
+    "eslint": "9.39.4",
     "eslint-config-next": "16.1.6",
     "eslint-plugin-unused-imports": "4.3.0",
     "jest": "30.2.0",
     "jest-axe": "10.0.0",
     "jest-environment-jsdom": "30.2.0",
-    "prettier": "3.8.3",
+    "prettier": "3.8.4",
     "sass": "1.89.2",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"
   },
   "overrides": {
     "postcss": "8.5.15",
-    "qs": "6.15.2"
+    "qs": "6.15.2",
+    "js-yaml": "4.2.0"
   }
 }


### PR DESCRIPTION
- Updated `eslint` to `v9.39.4`, `prettier` to `v3.8.4`, `brace-expansion` to `v2.1.1`, `sanitize-html` to `v2.17.5`, `@apollo/client` to `v4.2.3`, `@dmptool/types` to `v3.1.7` and `dompurify` to `v3.4.11`. Also added override for `js-yaml` to `v4.2.0` due to vulnerability
- Also updated a unit test that was intermittently failing for admin users search input
