### PR TITLE
Bug: Template section reorder arrow hover state issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Updated `RepoSelectorForAnswer` to wait to query `Re3byUrIsDocument` until we have `preferredReposURIs` because preferred repos don't display even though they eventually do to trigger the display of the "preferred repositories" checkbox [#118]
 
 ## Fixed
+- Fixed section &  question reorder arrow buttons turning white on hover. Added a shared `order-button` style so arrows use link-blue colors and remain visible [#76]
 - Updated the `project` graphql query to include `email` and `created` field so we can display info for invited project collaborators who haven't accepted invite [#287]
 - Fixed `type` errors resulting from deprecated `errorPolicy` in unit tests [#252]
 - Fixed issue with Feedback Notification headers displaying for any collaborator on the Plan Overview, Section and Question pages. It should only display to Org Admins and Super Admins. Added shared isOrgAdmin hook for pages. [#249]

--- a/components/CustomizedTemplate/CustomizedQuestionEdit/customizedQuestionEdit.module.scss
+++ b/components/CustomizedTemplate/CustomizedQuestionEdit/customizedQuestionEdit.module.scss
@@ -102,22 +102,10 @@
     gap: var(--space-1);
   }
 
+  // Shared interactive styles live in styles/form/_order-button.scss
   .orderButton {
-    padding: var(--space-1);
-    background: none;
-    color: var(--gray-600);
     margin: 0;
-    cursor: pointer;
     font-size: var(--fs-lg);
-    transition: color 0.2s ease;
-
-    &:focus,
-    &:hover {
-      background: none;
-      color: var(--text-color);
-      outline: 2px solid var(--blue-500);
-      outline-offset: 2px;
-    }
   }
 
   // Organization question styling

--- a/components/CustomizedTemplate/CustomizedQuestionEdit/index.tsx
+++ b/components/CustomizedTemplate/CustomizedQuestionEdit/index.tsx
@@ -138,14 +138,14 @@ const CustomizedQuestionEdit: React.FC<CustomizedQuestionEditProps> = ({
         {questionType === 'CUSTOM' && (
           <div className={styles.orderButtons}>
             <Button
-              className={`${styles.btnDefault} ${styles.orderButton}`}
+              className={`order-button ${styles.orderButton}`}
               aria-label={EditQuestion("buttons.moveUp", { name: text })}
               onPress={() => handleDisplayOrderChange(questionId, questionDisplayOrder - 1)}
             >
               <UpArrowIcon />
             </Button>
             <Button
-              className={`${styles.btnDefault} ${styles.orderButton}`}
+              className={`order-button ${styles.orderButton}`}
               aria-label={EditQuestion("buttons.moveDown", { name: text })}
               onPress={() => handleDisplayOrderChange(questionId, questionDisplayOrder + 1)}
             >

--- a/components/QuestionEditCard/QuestionEditCard.module.scss
+++ b/components/QuestionEditCard/QuestionEditCard.module.scss
@@ -102,22 +102,10 @@
     gap: var(--space-1);
   }
 
+  // Component-level hook; shared interactive styles live in styles/form/_order-button.scss
   .orderButton {
-    padding: var(--space-1);
-    background: none;
-    color: var(--gray-600);
     margin: 0;
-    cursor: pointer;
     font-size: var(--fs-lg);
-    transition: color 0.2s ease;
-
-    &:focus,
-    &:hover {
-      background: none;
-      color: var(--text-color);
-      outline: 2px solid var(--blue-500);
-      outline-offset: 2px;
-    }
   }
 
   // Organization question styling

--- a/components/QuestionEditCard/index.tsx
+++ b/components/QuestionEditCard/index.tsx
@@ -192,14 +192,14 @@ const QuestionEditCard: React.FC<QuestionEditCardProps> = ({
         </TransitionLink>
         <div className={styles.orderButtons}>
           <Button
-            className={`${styles.btnDefault} ${styles.orderButton}`}
+            className={`order-button ${styles.orderButton}`}
             aria-label={EditQuestion("buttons.moveUp", { name: text })}
             onPress={() => handleDisplayOrderChange(questionId, questionDisplayOrder - 1)}
           >
             <UpArrowIcon />
           </Button>
           <Button
-            className={`${styles.btnDefault} ${styles.orderButton}`}
+            className={`order-button ${styles.orderButton}`}
             aria-label={EditQuestion("buttons.moveDown", { name: text })}
             onPress={() => handleDisplayOrderChange(questionId, questionDisplayOrder + 1)}
           >

--- a/components/SectionHeaderEdit/SectionHeaderEdit.module.scss
+++ b/components/SectionHeaderEdit/SectionHeaderEdit.module.scss
@@ -55,7 +55,6 @@
 }
 
 .editButton,
-.orderButton,
 .expandButton {
   background: none;
   border: none;
@@ -89,16 +88,10 @@
   }
 }
 
+// shared interactive styles live in styles/form/_order-button.scss
 .orderButton {
-  padding: var(--space-1);
-  color: var(--gray-600);
-
-  &:focus,
-  &:hover {
-    background: transparent !important;
-    color: var(--text-color);
-    outline: 2px solid var(--blue-500);
-    outline-offset: 2px;
+  @include device(md) {
+    margin-left: var(--space-2);
   }
 }
 

--- a/components/SectionHeaderEdit/index.tsx
+++ b/components/SectionHeaderEdit/index.tsx
@@ -133,7 +133,7 @@ const SectionHeaderEdit: React.FC<SectionHeaderEditProps> = ({
         <div className={styles.orderButtons}>
           {onMoveUp && (
             <Button
-              className={`${styles.btnDefault} ${styles.orderButton}`}
+              className={`order-button ${styles.orderButton}`}
               onPress={onMoveUp}
               aria-label={Sections("buttons.moveUp", { title })}
             >
@@ -143,7 +143,7 @@ const SectionHeaderEdit: React.FC<SectionHeaderEditProps> = ({
 
           {onMoveDown && (
             <Button
-              className={`${styles.btnDefault} ${styles.orderButton}`}
+              className={`order-button ${styles.orderButton}`}
               onPress={onMoveDown}
               aria-label={Sections("buttons.moveDown", { title })}
             >

--- a/styles/form/_button.scss
+++ b/styles/form/_button.scss
@@ -1,4 +1,5 @@
 @use '@/styles/responsive' as r;
+@use 'order-button';
 
 @mixin button-focus {
   outline: 2px solid var(--blue-900);
@@ -324,7 +325,7 @@ a.button-link {
 
 // Primary button styles
 // Note: Default buttons without a class use primary styling as fallback
-.react-aria-Button:not(.secondary):not(.tertiary):not(.link):not(.danger):not(.selectButton),
+.react-aria-Button:not(.secondary):not(.tertiary):not(.link):not(.danger):not(.selectButton):not(.order-button),
 .react-aria-Button.primary,
 .react-aria-Button--primary,
 button.primary,

--- a/styles/form/_order-button.scss
+++ b/styles/form/_order-button.scss
@@ -1,0 +1,34 @@
+// Styles for section/question reorder arrow buttons.
+.react-aria-Button.order-button,
+button.order-button {
+  background: none !important;
+  border: none !important;
+  padding: var(--space-1) !important;
+  margin: 0;
+  color: var(--gray-600);
+  border-radius: 50%;
+  cursor: pointer;
+  font-weight: normal;
+  transition: color 0.2s ease;
+
+  &:hover,
+  &[data-hovered] {
+    background: transparent !important;
+    color: var(--link-color) !important;
+  }
+
+  &:focus,
+  &:focus-visible,
+  &[data-focus-visible] {
+    background: transparent !important;
+    color: var(--link-color) !important;
+    outline: 2px solid var(--blue-500);
+    outline-offset: 2px;
+  }
+
+  &:active,
+  &[data-pressed] {
+    background: transparent !important;
+    color: var(--link-color-pressed) !important;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a shared `order-button` style and applies it to all section/question reorder controls so interactive states use link-blue colors instead of white which was a bug

**Changes:**
- Added `/form/_order-button.scss` with shared hover, focus, and pressed states using `--link-color` tokens
- Excluded `.order-button` from primary button styling in `styles/form/_button.scss` in case of conflicts
- Updated `SectionHeaderEdit`, `QuestionEditCard`, and `CustomizedQuestionEdit` to use `className="order-button"` (replacing the undefined `btnDefault` class)
- Kept level `.orderButton` classes for component-specific layout hooks (e.g. icon sizing, spacing)

Fixes [CDLUC3/dmptool-doc#76](https://github.com/CDLUC3/dmptool-doc/issues/76)

No dependencies related to this change.

Hover
<img width="3142" height="1352" alt="image" src="https://github.com/user-attachments/assets/c3838eac-ce28-4bbe-ae5a-65fea0eb5f0b" />


Focus
<img width="3200" height="1456" alt="image" src="https://github.com/user-attachments/assets/83fd695a-2d64-416c-8e17-511b91811306" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore

## How Has This Been Tested?

Tested manually but also no failures or linting issues in the automated testing

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have completed manual or automated accessibility testing for my changes
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch.
