### PR TITLE
Default project funding selection to no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Added `UpdateAffiliation` and `AffiliationById` queries [#203]
 
 ## Updated
+- Defaulted the project creation funding question to "No - Skip for now" so users without awarded funding can continue more quickly [#70]
 - Updated the "Forgot Password" to "Reset password" [#79]
 - Updated `PlanCreate` page to show a loading spinner during the initial template fetch so the empty state does not flash before results load [#72]
 - Updated `SelectExistingTemplate` to pass `bestPractices` from template data into `TemplateSelectListItem` [#72]

--- a/app/[locale]/projects/[projectId]/project-funding/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/project-funding/__tests__/page.spec.tsx
@@ -98,6 +98,19 @@ describe('ProjectsCreateProjectFunding', () => {
     expect(screen.getByText('buttons.continue')).toBeInTheDocument();
   });
 
+  it('should select "no" by default', async () => {
+    await act(async () => {
+      render(
+        <MockedProvider mocks={withoutAPIMocks}>
+          <ProjectsCreateProjectFunding />
+        </MockedProvider>
+      );
+    });
+
+    expect(screen.getByLabelText('form.radioNoLabel')).toBeChecked();
+    expect(screen.getByLabelText('form.radioYesLabel')).not.toBeChecked();
+  });
+
   it('should handle funding "yes" selected (no API)', async () => {
     await act(async () => {
       render(

--- a/app/[locale]/projects/[projectId]/project-funding/page.tsx
+++ b/app/[locale]/projects/[projectId]/project-funding/page.tsx
@@ -36,7 +36,7 @@ const ProjectsCreateProjectFunding = () => {
 
   const { projectId } = params;
 
-  const [hasFunding, setHasFunding] = useState("yes");
+  const [hasFunding, setHasFunding] = useState("no");
   const [formSubmitted, setFormSubmitted] = useState(false);
 
   // localization keys


### PR DESCRIPTION
## Description

Defaults the "Do you already have funding for this project?" step in the project creation flow to "No - Skip for now".

Fixes #70
https://github.com/CDLUC3/dmptool-doc/issues/70

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore

## How Has This Been Tested?

Ran automated test and verified 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have completed manual or automated accessibility testing for my changes
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Important Note:

This branch was created from the latest `development` branch. The change is limited to the project funding step default selection and its focused test coverage.
