### PR TITLE
Bug #61: Fix responsive alignment in the template answer choice editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Added `UpdateAffiliation` and `AffiliationById` queries [#203]
 
 ## Updated
+- Redesigned the template question answer-choice editor with responsive choice cards, accessible reordering and removal controls, clearer validation, and localized English and Portuguese labels
 - Fixed issue with local reference to `@dmptool/types`
 - Updated ResearchOutputTable question and answer components to use the new `commonStandardId` property
 - Updated the ResearchOutputTable question to include the Anticipated Release Date and Anticipated File Size columns in the JSON but continue to NOT display to the admin when editing the question.

--- a/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/__tests__/page.spec.tsx
@@ -1793,11 +1793,11 @@ describe('Options questions', () => {
     })
 
 
-    const allRows = screen.queryAllByLabelText('Text');
-    expect(allRows.length).toBe(3);
+    const allRows = screen.queryAllByLabelText(/labels.choiceNumber/);
+    expect(allRows.length).toBe(4);
 
     // Enter the label text for new radio button
-    fireEvent.change(allRows[2], { target: { value: 'Maybe' } });
+    fireEvent.change(allRows[3], { target: { value: 'Maybe' } });
 
     // Get the save button and save
     const saveButton = screen.getByText('buttons.saveAndUpdate');
@@ -1870,11 +1870,11 @@ describe('Options questions', () => {
       fireEvent.click(addButton);
     })
 
-    const allRows = screen.queryAllByLabelText('Text');
-    expect(allRows.length).toBe(3);
+    const allRows = screen.queryAllByLabelText(/labels.choiceNumber/);
+    expect(allRows.length).toBe(4);
 
     // Enter the label text for new radio button
-    fireEvent.change(allRows[2], { target: { value: 'Maybe' } });
+    fireEvent.change(allRows[3], { target: { value: 'Maybe' } });
 
     // Wait for state update
     await waitFor(() => {

--- a/app/[locale]/template/[templateId]/q/[q_slug]/questionEdit.module.scss
+++ b/app/[locale]/template/[templateId]/q/[q_slug]/questionEdit.module.scss
@@ -1,6 +1,7 @@
 .optionsDescription {
-  font-size: var(--fs-sm);
-  font-weight:600;
+  margin: 0 0 var(--space-1);
+  font-size: var(--fs-base);
+  font-weight: 600;
 }
 
 .searchField {
@@ -33,11 +34,6 @@
   width: fit-content;
 }
 
-.optionsWrapper {
-  padding: var(--space-0);
-  margin-bottom: var(--space-6);
-}
-
 .questionFormField {
   height: 100px
 }
@@ -60,7 +56,5 @@
 }
 
 .optionsWrapper {
-  border: 1px solid var(--border-color);
-  padding: var(--space-4);
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-6);
 }

--- a/app/[locale]/template/customizations/[templateCustomizationId]/customQuestion/[customQuestionId]/customQuestionEdit.module.scss
+++ b/app/[locale]/template/customizations/[templateCustomizationId]/customQuestion/[customQuestionId]/customQuestionEdit.module.scss
@@ -1,6 +1,7 @@
 .optionsDescription {
-  font-size: var(--fs-sm);
-  font-weight:600;
+  margin: 0 0 var(--space-1);
+  font-size: var(--fs-base);
+  font-weight: 600;
 }
 
 .searchField {
@@ -60,9 +61,7 @@
 }
 
 .optionsWrapper {
-  border: 1px solid var(--border-color);
-  padding: var(--space-4);
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-6);
 }
 
 .questionContainer {

--- a/components/Form/QuestionOptionsComponent/__tests__/index.spec.tsx
+++ b/components/Form/QuestionOptionsComponent/__tests__/index.spec.tsx
@@ -1,21 +1,23 @@
-import React, { ReactNode } from 'react';
-import { fireEvent, render, screen } from '@/utils/test-utils';
-import { RichTranslationValues } from 'next-intl';
-import QuestionOptionsComponent
-  from '@/components/Form/QuestionOptionsComponent';
+import React, { ReactNode } from "react";
+import { fireEvent, render, screen } from "@/utils/test-utils";
+import { RichTranslationValues } from "next-intl";
+import { axe, toHaveNoViolations } from "jest-axe";
+import QuestionOptionsComponent from "@/components/Form/QuestionOptionsComponent";
+
+expect.extend(toHaveNoViolations);
 
 type MockUseTranslations = {
   (key: string, ...args: unknown[]): string;
   rich: (key: string, values?: RichTranslationValues) => ReactNode;
 };
 
-jest.mock('next-intl', () => ({
+jest.mock("next-intl", () => ({
   useTranslations: jest.fn(() => {
     const mockUseTranslations: MockUseTranslations = ((key: string) => key) as MockUseTranslations;
 
     mockUseTranslations.rich = (key, values) => {
       const p = values?.p;
-      if (typeof p === 'function') {
+      if (typeof p === "function") {
         return p(key); // Can return JSX
       }
       return key; // fallback
@@ -25,8 +27,8 @@ jest.mock('next-intl', () => ({
   }),
 }));
 
-const mockQuestionJSON = "{\"meta\":{\"schemaVersion\":\"1.0\"},\"type\":\"radioButtons\",\"options\":[{\"type\":\"option\",\"attributes\":{\"label\":\"Option 1\",\"value\":\"1\",\"selected\":false}},{\"type\":\"option\",\"attributes\":{\"label\":\"Option 2\",\"value\":\"2\",\"selected\":true}}]}"
-
+const mockQuestionJSON =
+  '{"meta":{"schemaVersion":"1.0"},"type":"radioButtons","options":[{"type":"option","attributes":{"label":"Option 1","value":"1","selected":false}},{"type":"option","attributes":{"label":"Option 2","value":"2","selected":true}}]}';
 
 type Row = {
   id?: number | null;
@@ -34,174 +36,255 @@ type Row = {
   isSelected?: boolean | null;
 };
 
-describe('QuestionOptionsComponent', () => {
+describe("QuestionOptionsComponent", () => {
   let rows: Row[], setRows: jest.Mock;
 
   beforeEach(() => {
-    rows = [
-      { id: 1, text: 'Option 1', isSelected: false },
-    ];
+    rows = [{ id: 1, text: "Option 1", isSelected: false }];
     setRows = jest.fn();
   });
 
-  it('should render initial rows correctly', () => {
-    render(<QuestionOptionsComponent
-      rows={rows}
-      setRows={setRows}
-      questionJSON={mockQuestionJSON}
-      formSubmitted={true}
-      setFormSubmitted={jest.fn()}
-    />);
+  it("should render initial rows correctly", () => {
+    render(
+      <QuestionOptionsComponent
+        rows={rows}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
 
-    expect(screen.getByLabelText(/labels.order/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/labels.text/)).toBeInTheDocument();
-    expect(screen.getByLabelText('labels.default')).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "messages.rowInfo" })).toHaveAccessibleDescription(
+      "messages.instructions",
+    );
+    expect(screen.queryByLabelText(/labels.order/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.choiceNumber/)).toBeInTheDocument();
+    expect(screen.getByLabelText("buttons.setDefault")).toBeInTheDocument();
   });
 
-  it('should add a new row when the add button is clicked', () => {
-    render(<QuestionOptionsComponent
-      rows={rows}
-      setRows={setRows}
-      questionJSON={mockQuestionJSON}
-      formSubmitted={true}
-      setFormSubmitted={jest.fn()}
-    />);
+  it("should show clear errors when a required choice is blank", () => {
+    render(
+      <QuestionOptionsComponent
+        rows={[{ id: 1, text: "", isSelected: false }]}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        formSubmitted={false}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
 
-    const addButton = screen.getByRole('button', { name: /buttons.addRow/i });
+    const choiceInput = screen.getByLabelText(/labels.choiceNumber/);
+    fireEvent.invalid(choiceInput);
+
+    expect(choiceInput).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("messages.choiceErrors")).toHaveAttribute("role", "alert");
+    expect(screen.getByText("messages.choiceRequired")).toBeInTheDocument();
+  });
+
+  it("should add a new row when the add button is clicked", () => {
+    render(
+      <QuestionOptionsComponent
+        rows={rows}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
+
+    const addButton = screen.getByRole("button", { name: /buttons.addRow/i });
     fireEvent.click(addButton);
 
-    expect(setRows).toHaveBeenCalledWith([{ id: 1, isSelected: false, text: "Option 1" }, { id: 2, isSelected: false, text: "" }]);
-    expect(screen.getByText('announcements.rowAdded')).toBeInTheDocument();
+    expect(setRows).toHaveBeenCalledWith([
+      { id: 1, isSelected: false, text: "Option 1" },
+      { id: 2, isSelected: false, text: "" },
+    ]);
+    expect(screen.getByText("announcements.rowAdded")).toBeInTheDocument();
   });
 
-  it('should update text field correctly', () => {
-    render(<QuestionOptionsComponent
-      rows={rows}
-      setRows={setRows}
-      questionJSON={mockQuestionJSON}
-      formSubmitted={true}
-      setFormSubmitted={jest.fn()}
-    />);
+  it("should update text field correctly", () => {
+    render(
+      <QuestionOptionsComponent
+        rows={rows}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
 
-    const textInput = screen.getByLabelText(/labels.text/);
-    fireEvent.change(textInput, { target: { value: 'Updated Option' } });
+    const textInput = screen.getByLabelText(/labels.choiceNumber/);
+    fireEvent.change(textInput, { target: { value: "Updated Option" } });
 
     expect(setRows).toHaveBeenCalledWith([{ id: 1, isSelected: false, text: "Updated Option" }]);
   });
 
-  it('should handle case where questionJSON is passed as an object', () => {
+  it("should handle case where questionJSON is passed as an object", () => {
     const questionJSONObj = JSON.parse(mockQuestionJSON);
-    render(<QuestionOptionsComponent
-      rows={rows}
-      setRows={setRows}
-      questionJSON={questionJSONObj}
-      formSubmitted={true}
-      setFormSubmitted={jest.fn()}
-    />);
+    render(
+      <QuestionOptionsComponent
+        rows={rows}
+        setRows={setRows}
+        questionJSON={questionJSONObj}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
 
-    const textInput = screen.getByLabelText(/labels.text/);
-    fireEvent.change(textInput, { target: { value: 'Updated Option' } });
+    const textInput = screen.getByLabelText(/labels.choiceNumber/);
+    fireEvent.change(textInput, { target: { value: "Updated Option" } });
 
     expect(setRows).toHaveBeenCalledWith([{ id: 1, isSelected: false, text: "Updated Option" }]);
   });
 
-  it('should set a row as default when checkbox is clicked', () => {
-    render(<QuestionOptionsComponent
-      rows={rows}
-      setRows={setRows}
-      questionJSON={mockQuestionJSON}
-      formSubmitted={true}
-      setFormSubmitted={jest.fn()}
-    />);
+  it("should set a row as default when checkbox is clicked", () => {
+    render(
+      <QuestionOptionsComponent
+        rows={rows}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
 
-    const defaultCheckbox = screen.getByLabelText('labels.default');
+    const defaultCheckbox = screen.getByLabelText("buttons.setDefault");
     fireEvent.click(defaultCheckbox);
-
 
     expect(setRows).toHaveBeenCalledWith([{ id: 1, isSelected: true, text: "Option 1" }]);
   });
 
-  it('should allow checking of multiple checkboxes', () => {
-    const mockCheckboxJSON = "{\"type\":\"checkBoxes\",\"meta\":{\"schemaVersion\":\"1.0\",\"labelTranslationKey\":\"questions.research_methods\"},\"options\":[{\"type\":\"option\",\"attributes\":{\"label\":\"Interviews\",\"value\":\"interviews\",\"checked\":true}},{\"type\":\"option\",\"attributes\":{\"label\":\"Surveys\",\"value\":\"surveys\",\"checked\":false}},{\"type\":\"option\",\"attributes\":{\"label\":\"Observations\",\"value\":\"observations\",\"checked\":true}},{\"type\":\"option\",\"attributes\":{\"label\":\"Focus Groups\",\"value\":\"focus_groups\",\"checked\":true}}]}"
+  it("should allow multiple checkbox choices to be selected by default", () => {
+    const mockCheckboxJSON =
+      '{"type":"checkBoxes","meta":{"schemaVersion":"1.0","labelTranslationKey":"questions.research_methods"},"options":[{"type":"option","attributes":{"label":"Interviews","value":"interviews","checked":true}},{"type":"option","attributes":{"label":"Surveys","value":"surveys","checked":false}},{"type":"option","attributes":{"label":"Observations","value":"observations","checked":true}},{"type":"option","attributes":{"label":"Focus Groups","value":"focus_groups","checked":true}}]}';
+    const checkboxRows = [
+      { id: 1, text: "Option 1", isSelected: true },
+      { id: 2, text: "Option 2", isSelected: false },
+    ];
 
-    // Use a stateful wrapper so setRows updates the UI
-    function Wrapper() {
-      const [rows, setRows] = React.useState<Row[]>([
-        { id: 1, text: 'Option 1', isSelected: false }
-      ]);
-      return (
-        <QuestionOptionsComponent
-          rows={rows}
-          setRows={setRows}
-          questionJSON={mockCheckboxJSON}
-          formSubmitted={true}
-          setFormSubmitted={jest.fn()}
-        />
-      );
-    }
+    render(
+      <QuestionOptionsComponent
+        rows={checkboxRows}
+        setRows={setRows}
+        questionJSON={mockCheckboxJSON}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
 
-    render(<Wrapper />);
+    fireEvent.click(screen.getByLabelText("buttons.setDefault"));
 
-    const textInput = screen.getByLabelText(/labels.text/);
-    fireEvent.change(textInput, { target: { value: 'Option 1' } });
-
-    const defaultCheckbox = screen.getByTestId('default-1');
-    fireEvent.click(defaultCheckbox);
-
-
-    const addButton = screen.getByRole('button', { name: /buttons.addRow/i });
-    fireEvent.click(addButton);
-
-    const defaultCheckbox2 = screen.getByTestId('default-2');
-    fireEvent.click(defaultCheckbox2);
-
-    // Assert that there are now two checkboxes
-    expect(screen.getAllByTestId(/^default-/)).toHaveLength(2);
-
-    //Delete the second row
-    const removeButtons = screen.getAllByLabelText('buttons.deleteRow');
-    fireEvent.click(removeButtons[1]); // Click the first one
-
-    expect(rows).toEqual([
-      { id: 1, text: 'Option 1', isSelected: false }
+    expect(setRows).toHaveBeenCalledWith([
+      { id: 1, text: "Option 1", isSelected: true },
+      { id: 2, text: "Option 2", isSelected: true },
     ]);
   });
 
-  it('should add a row when the add button is clicked', () => {
-    render(<QuestionOptionsComponent
-      rows={rows}
-      setRows={setRows}
-      questionJSON={mockQuestionJSON}
-      formSubmitted={true}
-      setFormSubmitted={jest.fn()}
-    />);
+  it("should allow multiple multi-select choices to be selected by default", () => {
+    const multiSelectRows = [
+      { id: 1, text: "Option 1", isSelected: true },
+      { id: 2, text: "Option 2", isSelected: false },
+    ];
 
-    const addButton = screen.getByRole('button', { name: /buttons.addRow/i });
-    fireEvent.click(addButton);
+    render(
+      <QuestionOptionsComponent
+        rows={multiSelectRows}
+        setRows={setRows}
+        questionJSON={{ type: "multiselectBox", attributes: { multiple: true } }}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
 
-    expect(setRows).toHaveBeenCalledWith([{ id: 1, isSelected: false, text: "Option 1" }, { id: 2, isSelected: false, text: "" }]);
+    fireEvent.click(screen.getByLabelText("buttons.setDefault"));
+
+    expect(setRows).toHaveBeenCalledWith([
+      { id: 1, text: "Option 1", isSelected: true },
+      { id: 2, text: "Option 2", isSelected: true },
+    ]);
   });
 
-  it('should remove a row when delete button is clicked', () => {
-    render(<QuestionOptionsComponent
-      rows={rows}
-      setRows={setRows}
-      questionJSON={mockQuestionJSON}
-      formSubmitted={true}
-      setFormSubmitted={jest.fn()}
-    />);
+  it("should add a row when the add button is clicked", () => {
+    render(
+      <QuestionOptionsComponent
+        rows={rows}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
 
-    const deleteButton = screen.getByRole('button', { name: /buttons.deleteRow/i });
+    const addButton = screen.getByRole("button", { name: /buttons.addRow/i });
+    fireEvent.click(addButton);
+
+    expect(setRows).toHaveBeenCalledWith([
+      { id: 1, isSelected: false, text: "Option 1" },
+      { id: 2, isSelected: false, text: "" },
+    ]);
+  });
+
+  it("should remove a row when delete button is clicked", () => {
+    render(
+      <QuestionOptionsComponent
+        rows={rows}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
+
+    const deleteButton = screen.getByRole("button", { name: /buttons.deleteRow/i });
     fireEvent.click(deleteButton);
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(screen.getByText("messages.confirmRemove")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "buttons.confirmRemove" }));
 
     expect(setRows).toHaveBeenCalledWith([]);
   });
 
-  it('should set the correct row as default and unset others', () => {
+  it("should remove a choice whose generated id is zero", () => {
+    render(
+      <QuestionOptionsComponent
+        rows={[{ id: 0, text: "Option 1", isSelected: false }]}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /buttons.deleteRow/i }));
+    fireEvent.click(screen.getByRole("button", { name: "buttons.confirmRemove" }));
+
+    expect(setRows).toHaveBeenCalledWith([]);
+  });
+
+  it("should keep the choice when removal is cancelled", () => {
+    render(
+      <QuestionOptionsComponent
+        rows={rows}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        formSubmitted={true}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /buttons.deleteRow/i }));
+    fireEvent.click(screen.getByRole("button", { name: "buttons.cancel" }));
+
+    expect(setRows).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("should set the correct row as default and unset others", () => {
     const mockSetRows = jest.fn();
     const rows = [
-      { id: 1, orderNumber: 1, text: 'Option 1', isSelected: false, questionId: 1 },
-      { id: 2, orderNumber: 2, text: 'Option 2', isSelected: false, questionId: 1 },
+      { id: 1, orderNumber: 1, text: "Option 1", isSelected: true, questionId: 1 },
+      { id: 2, orderNumber: 2, text: "Option 2", isSelected: false, questionId: 1 },
     ];
 
     const { getByLabelText } = render(
@@ -210,30 +293,26 @@ describe('QuestionOptionsComponent', () => {
         setRows={mockSetRows}
         questionJSON={mockQuestionJSON}
         setFormSubmitted={jest.fn()}
-      />
+      />,
     );
 
-    const defaultCheckbox = getByLabelText('Set row 2 as default');
+    const defaultCheckbox = getByLabelText("buttons.setDefault");
     fireEvent.click(defaultCheckbox);
 
     expect(mockSetRows).toHaveBeenCalledTimes(1);
 
     const updatedRows = mockSetRows.mock.calls[0][0];
     expect(updatedRows).toEqual([
-      { id: 1, orderNumber: 1, text: 'Option 1', isSelected: false, questionId: 1 },
-      { id: 2, orderNumber: 2, text: 'Option 2', isSelected: true, questionId: 1 },
-    ]);
-    expect(updatedRows).toEqual([
-      { id: 1, orderNumber: 1, text: 'Option 1', isSelected: false, questionId: 1 },
-      { id: 2, orderNumber: 2, text: 'Option 2', isSelected: true, questionId: 1 }, // <== isDefault changed
+      { id: 1, orderNumber: 1, text: "Option 1", isSelected: false, questionId: 1 },
+      { id: 2, orderNumber: 2, text: "Option 2", isSelected: true, questionId: 1 },
     ]);
   });
 
-  it('should uncheck the checked default', () => {
+  it("should uncheck the checked default", () => {
     function Wrapper() {
       const [rows, setRows] = React.useState<Row[]>([
-        { id: 1, text: 'Option 1', isSelected: false },
-        { id: 2, text: 'Option 2', isSelected: false },
+        { id: 1, text: "Option 1", isSelected: false },
+        { id: 2, text: "Option 2", isSelected: false },
       ]);
 
       return (
@@ -246,9 +325,9 @@ describe('QuestionOptionsComponent', () => {
       );
     }
 
-    const { getByLabelText } = render(<Wrapper />);
+    const { getAllByLabelText } = render(<Wrapper />);
 
-    const defaultCheckbox = getByLabelText('Set row 2 as default');
+    const defaultCheckbox = getAllByLabelText("buttons.setDefault")[1];
 
     // First click - should check it
     fireEvent.click(defaultCheckbox);
@@ -257,5 +336,56 @@ describe('QuestionOptionsComponent', () => {
     // Second click - should uncheck it
     fireEvent.click(defaultCheckbox);
     expect(defaultCheckbox).not.toBeChecked();
+  });
+
+  it("should reorder options with the move buttons", () => {
+    const optionRows = [
+      { id: 1, text: "Option 1", isSelected: true },
+      { id: 2, text: "Option 2", isSelected: false },
+    ];
+    const setFormSubmitted = jest.fn();
+
+    render(
+      <QuestionOptionsComponent
+        rows={optionRows}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        setFormSubmitted={setFormSubmitted}
+      />,
+    );
+
+    const moveUpButtons = screen.getAllByRole("button", { name: "buttons.moveUp" });
+    const moveDownButtons = screen.getAllByRole("button", { name: "buttons.moveDown" });
+
+    expect(moveUpButtons).toHaveLength(2);
+    expect(moveDownButtons).toHaveLength(2);
+    expect(moveUpButtons[0]).toBeDisabled();
+    expect(moveDownButtons[1]).toBeDisabled();
+
+    fireEvent.click(moveDownButtons[0]);
+
+    expect(setRows).toHaveBeenCalledWith([
+      { id: 2, text: "Option 2", isSelected: false },
+      { id: 1, text: "Option 1", isSelected: true },
+    ]);
+    expect(setFormSubmitted).toHaveBeenCalledWith(false);
+    expect(screen.getByText("announcements.rowMoved")).toBeInTheDocument();
+  });
+
+  it("should have no automated accessibility violations", async () => {
+    const { container } = render(
+      <QuestionOptionsComponent
+        rows={[
+          { id: 1, text: "Option 1", isSelected: false },
+          { id: 2, text: "Option 2", isSelected: true },
+        ]}
+        setRows={setRows}
+        questionJSON={mockQuestionJSON}
+        formSubmitted={false}
+        setFormSubmitted={jest.fn()}
+      />,
+    );
+
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/components/Form/QuestionOptionsComponent/index.tsx
+++ b/components/Form/QuestionOptionsComponent/index.tsx
@@ -1,15 +1,75 @@
-'use client'
+"use client";
 
 import { useState } from "react";
-import { Checkbox, } from "react-aria-components";
+import { Button, Checkbox, Dialog, DialogTrigger, Heading, Modal, ModalOverlay } from "react-aria-components";
 
-import FormInput from '@/components/Form/FormInput';
-import { useTranslations } from 'next-intl';
-import {
-  CHECKBOXES_QUESTION_TYPE
-} from '@/lib/constants';
-import styles from './optionsComponent.module.scss';
+import FormInput from "@/components/Form/FormInput";
+import { DmpIcon } from "@/components/Icons";
+import { useTranslations } from "next-intl";
+import { CHECKBOXES_QUESTION_TYPE } from "@/lib/constants";
+import styles from "./optionsComponent.module.scss";
 
+const UpArrowIcon = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M18 15L12 9L6 15"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const DownArrowIcon = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M6 9L12 15L18 9"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const PlusIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    aria-hidden="true"
+  >
+    <line
+      x1="12"
+      y1="5"
+      x2="12"
+      y2="19"
+    />
+    <line
+      x1="5"
+      y1="12"
+      x2="19"
+      y2="12"
+    />
+  </svg>
+);
 
 interface Row {
   id?: number | null;
@@ -17,183 +77,283 @@ interface Row {
   isSelected?: boolean | null;
 }
 
+interface ParsedOptionsQuestion {
+  type?: string;
+  attributes?: {
+    multiple?: boolean;
+  };
+}
+
 interface QuestionOptionsComponentProps {
   rows: Row[] | null;
   setRows: (rows: Row[]) => void;
-  questionJSON?: string;
+  questionJSON?: string | ParsedOptionsQuestion;
   formSubmitted?: boolean;
   setFormSubmitted: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-
-/**This component is used to add question type fields that use options
- * For example, radio buttons, check boxes and select drop-downs
- */
-const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({ rows, setRows, questionJSON, formSubmitted, setFormSubmitted }) => {
+/** Edits choices for radio, checkbox, select, and multi-select questions. */
+const QuestionOptionsComponent: React.FC<QuestionOptionsComponentProps> = ({
+  rows,
+  setRows,
+  questionJSON,
+  formSubmitted,
+  setFormSubmitted,
+}) => {
   const [announcement, setAnnouncement] = useState<string>("");
-  const parsedQuestionJSON = (typeof questionJSON === 'string') ? JSON.parse(questionJSON) : questionJSON || {};
-  const Global = useTranslations('Global');
-  const QuestionOptions = useTranslations('QuestionOptionsComponent');
+  const [touchedRows, setTouchedRows] = useState<Set<number>>(new Set());
+  const parsedQuestionJSON: ParsedOptionsQuestion =
+    typeof questionJSON === "string" ? JSON.parse(questionJSON) : (questionJSON ?? {});
+  const QuestionOptions = useTranslations("QuestionOptionsComponent");
 
-  // Add options row
   const addRow = () => {
     if (rows) {
-      // Either calculate next order number off of last orderNumber, if present, or just use the row.length to increment
-      const length = rows.length;
-      const nextNum = (length + 1);
+      const nextNum = Math.max(0, ...rows.map((row) => row.id ?? 0)) + 1;
 
       const newRow = {
-        id: nextNum, //if rows already has a set value, then increment from there
+        id: nextNum,
         text: "",
         isSelected: false,
       };
 
       setRows([...rows, newRow]);
-      setAnnouncement(QuestionOptions('announcements.rowAdded', { nextNum }));
+      setAnnouncement(QuestionOptions("announcements.rowAdded", { nextNum }));
       setFormSubmitted(false);
     }
   };
 
-  // Delete options row
-  const deleteRow = (id: number) => {
-    if (id && id !== 0) {
-      const updatedRows = rows?.filter(row => row.id !== id);
-      setRows(updatedRows || []);
-      setAnnouncement(QuestionOptions('announcements.rowRemoved', { id }));
-    }
+  const deleteRow = (rowIndex: number, position: number) => {
+    const updatedRows = rows?.filter((_, index) => index !== rowIndex);
+    setRows(updatedRows || []);
+    setAnnouncement(QuestionOptions("announcements.rowRemoved", { number: position }));
   };
 
-
-  const toggleSelection = (id: number) => {
+  const setDefault = (rowIndex: number, position: number) => {
     if (!rows) return;
 
-    const updatedRows = rows.map(row =>
-      row.id === id
-        ? { ...row, isSelected: !row.isSelected }
-        : row
-    );
+    const selectedRow = rows[rowIndex];
+    const willSelect = !selectedRow?.isSelected;
 
-    setRows(updatedRows); // this calls updateRows()
-  };
-
-  const setDefault = (id: number) => {
-    if (!rows) return;
-
-    // allow multiple selections for checkboxes or multiSelect
     if (parsedQuestionJSON.type === CHECKBOXES_QUESTION_TYPE || parsedQuestionJSON.attributes?.multiple === true) {
-      toggleSelection(id);
+      setRows(rows.map((row, index) => (index === rowIndex ? { ...row, isSelected: willSelect } : row)));
     } else {
-      const updatedRows = rows.map(row => ({
-        ...row,
-        isSelected: row.id === id ? !row.isSelected : false, // toggle if already selected
-      }));
-
-      setRows(updatedRows);
-      setAnnouncement(QuestionOptions('announcements.rowDefault', { id }));
+      setRows(
+        rows.map((row, index) => ({
+          ...row,
+          isSelected: index === rowIndex ? willSelect : false,
+        })),
+      );
     }
+
+    setAnnouncement(
+      QuestionOptions(willSelect ? "announcements.rowDefault" : "announcements.rowDefaultCleared", {
+        number: position,
+      }),
+    );
   };
 
-  // Update rows state
-  const handleChange = (id: number | string | null, field: string, value: string | number) => {
+  const updateChoiceText = (rowIndex: number, text: string) => {
     if (!rows) return;
 
-    const updatedRows = rows.map((row) => {
-      if (row.id === id) {
-        return { ...row, [field]: value };
-      }
-      return row;
-    });
+    setRows(rows.map((row, index) => (index === rowIndex ? { ...row, text } : row)));
+  };
+
+  const moveRow = (index: number, direction: -1 | 1) => {
+    if (!rows) return;
+
+    const destinationIndex = index + direction;
+    if (destinationIndex < 0 || destinationIndex >= rows.length) return;
+
+    const updatedRows = [...rows];
+    [updatedRows[index], updatedRows[destinationIndex]] = [updatedRows[destinationIndex], updatedRows[index]];
 
     setRows(updatedRows);
+    setAnnouncement(
+      QuestionOptions("announcements.rowMoved", {
+        from: index + 1,
+        to: destinationIndex + 1,
+      }),
+    );
+    setFormSubmitted(false);
   };
+
+  const markRowTouched = (rowId: number) => {
+    setTouchedRows((current) => {
+      const updated = new Set(current);
+      updated.add(rowId);
+      return updated;
+    });
+  };
+
+  const hasVisibleChoiceErrors = rows?.some((row, index) => {
+    const rowId = row.id ?? index;
+    return !row.text.trim() && (formSubmitted || touchedRows.has(rowId));
+  });
 
   return (
     <>
+      <p
+        id="answer-choice-instructions"
+        className={styles.instructions}
+      >
+        {QuestionOptions("messages.instructions")}
+      </p>
+      {hasVisibleChoiceErrors && (
+        <p
+          className={styles.sectionError}
+          role="alert"
+        >
+          {QuestionOptions("messages.choiceErrors")}
+        </p>
+      )}
       <div className={styles.tableContainer}>
-        {rows && rows.map((row, index) => (
-          <div key={row.id} className={styles.row} role="group">
-            {/**Let screenreader know which row they are on */}
-            <span id={`row-label-${row.id}`} className='hidden-accessibly'>
-              {QuestionOptions('messages.rowInfo', { number: index + 1 })}
-            </span>
+        {rows &&
+          rows.map((row, index) => {
+            const rowId = row.id ?? index;
+            const rowDomId = `choice-${rowId}`;
+            const isChoiceInvalid = !row.text.trim() && (formSubmitted || touchedRows.has(rowId));
 
-            <div className={styles.cell}>
-              <FormInput
-                id={`order-${row.id}`}
-                name="orderNumber"
-                type="text"
-                disabled={true}
-                isRequired={true}
-                label={QuestionOptions('labels.order')}
-                value={(index + 1).toString()}
-                placeholder={QuestionOptions('placeholder.orderNumber')}
-                ariaLabel={index === 0 ? undefined : "Order"}
-              />
-            </div>
-            <div className={styles.cell}>
-              <FormInput
-                id={`text-${row.id}`}
-                name="text"
-                type="text"
-                isRequired={true}
-                label={QuestionOptions('labels.text')}
-                labelClasses={styles.textFieldLabel}
-                value={row.text}
-                onChange={(e) => handleChange(row.id ?? null, "text", e.target.value)}
-                placeholder={QuestionOptions('placeholder.text')}
-                ariaLabel={index === 0 ? undefined : "Text"}
-                isInvalid={!row.text && formSubmitted}
-                errorMessage="Text field is required"
-              />
-            </div>
-            <div className={`${styles.cell} ${styles.default}`}>
-              <label htmlFor={`default-${row.id}`}>{QuestionOptions('labels.default')}</label>
-              <Checkbox
-                id={`default-${row.id}`}
-                data-testid={`default-${row.id}`}
-                aria-checked={row.isSelected}
-                aria-label={`Set row ${index + 1} as default`}
-                onChange={() => setDefault(row.id || 0)}
-                className={`${styles.optionsCheckbox} react-aria-Checkbox`}
-                isSelected={row.isSelected ? row.isSelected : false}
+            return (
+              <div
+                key={rowDomId}
+                className={`${styles.row} ${isChoiceInvalid ? styles.rowInvalid : ""}`}
+                role="group"
+                aria-labelledby={`${rowDomId}-label`}
+                aria-describedby="answer-choice-instructions"
               >
-                <div className={`${styles.checkBox} checkbox`}>
-                  <svg viewBox="0 0 18 18" aria-hidden="true">
-                    <polyline points="1 9 7 14 15 4" />
-                  </svg>
+                <span
+                  id={`${rowDomId}-label`}
+                  className="hidden-accessibly"
+                >
+                  {QuestionOptions("messages.rowInfo", { number: index + 1 })}
+                </span>
+                <div className={`${styles.cell} ${styles.text}`}>
+                  <FormInput
+                    id={`${rowDomId}-text`}
+                    name="text"
+                    type="text"
+                    isRequired={true}
+                    label={QuestionOptions("labels.choiceNumber", { number: index + 1 })}
+                    labelClasses={styles.textFieldLabel}
+                    value={row.text}
+                    onChange={(e) => updateChoiceText(index, e.target.value)}
+                    onBlur={() => markRowTouched(rowId)}
+                    onInvalid={() => markRowTouched(rowId)}
+                    placeholder={QuestionOptions("placeholder.text")}
+                    isInvalid={isChoiceInvalid}
+                    errorMessage={QuestionOptions("messages.choiceRequired", { number: index + 1 })}
+                  />
                 </div>
-              </Checkbox>
-            </div>
-            <div className={styles.remove}>
-              <button
-                type="button"
-                onClick={() => deleteRow(row.id || 0)}
-                aria-label={QuestionOptions('buttons.deleteRow', { count: index + 1 })}
-                className={`${styles.deleteButton} react-aria-Button secondary`}
-              >
-                {Global('buttons.remove')}
-              </button>
-              {/**Screen readers will announce when a new row was added */}
-              <p aria-live="polite" className='hidden-accessibly'>
-                {rows.length > 0 ? QuestionOptions('messages.successAddingRow', { number: rows.length }) : ""}
-              </p>
+                <div className={`${styles.cell} ${styles.default}`}>
+                  <Checkbox
+                    id={`${rowDomId}-default`}
+                    data-testid={`default-${rowId}`}
+                    aria-label={QuestionOptions(row.isSelected ? "buttons.clearDefault" : "buttons.setDefault", {
+                      number: index + 1,
+                    })}
+                    onChange={() => setDefault(index, index + 1)}
+                    className={`${styles.optionsCheckbox} react-aria-Checkbox`}
+                    isSelected={row.isSelected ? row.isSelected : false}
+                  >
+                    <div className={`${styles.checkBox} checkbox`}>
+                      <svg
+                        viewBox="0 0 18 18"
+                        aria-hidden="true"
+                      >
+                        <polyline points="1 9 7 14 15 4" />
+                      </svg>
+                    </div>
+                    <span>{QuestionOptions("labels.default")}</span>
+                  </Checkbox>
+                </div>
+                <div className={styles.actions}>
+                  <div
+                    className={styles.orderButtons}
+                    role="group"
+                    aria-label={QuestionOptions("labels.reorder", { number: index + 1 })}
+                  >
+                    <Button
+                      className={`order-button ${styles.orderButton}`}
+                      onPress={() => moveRow(index, -1)}
+                      isDisabled={index === 0}
+                      aria-label={QuestionOptions("buttons.moveUp", { number: index + 1 })}
+                    >
+                      <UpArrowIcon />
+                    </Button>
+                    <Button
+                      className={`order-button ${styles.orderButton}`}
+                      onPress={() => moveRow(index, 1)}
+                      isDisabled={index === rows.length - 1}
+                      aria-label={QuestionOptions("buttons.moveDown", { number: index + 1 })}
+                    >
+                      <DownArrowIcon />
+                    </Button>
+                  </div>
+                  <DialogTrigger>
+                    <Button
+                      aria-label={QuestionOptions("buttons.deleteRow", { count: index + 1 })}
+                      className={styles.deleteButton}
+                    >
+                      <DmpIcon
+                        icon="trashcan"
+                        classes={styles.trashcanIcon}
+                      />
+                    </Button>
+                    <ModalOverlay isDismissable>
+                      <Modal>
+                        <Dialog role="alertdialog">
+                          {({ close }) => (
+                            <>
+                              <Heading slot="title">
+                                {QuestionOptions("headings.removeChoice", { number: index + 1 })}
+                              </Heading>
+                              <p>{QuestionOptions("messages.confirmRemove", { number: index + 1 })}</p>
+                              <div className={styles.dialogActions}>
+                                <Button
+                                  className="secondary"
+                                  onPress={close}
+                                >
+                                  {QuestionOptions("buttons.cancel")}
+                                </Button>
+                                <Button
+                                  className="danger"
+                                  onPress={() => {
+                                    deleteRow(index, index + 1);
+                                    close();
+                                  }}
+                                >
+                                  {QuestionOptions("buttons.confirmRemove")}
+                                </Button>
+                              </div>
+                            </>
+                          )}
+                        </Dialog>
+                      </Modal>
+                    </ModalOverlay>
+                  </DialogTrigger>
+                </div>
+              </div>
+            );
+          })}
 
-            </div>
-          </div >
-        )
-        )}
-
-        <button type="button" onClick={addRow} aria-live="polite">
-          {QuestionOptions('buttons.addRow')}
-        </button>
+        <div className={styles.addChoiceContainer}>
+          <Button
+            onPress={addRow}
+            className={styles.addButton}
+          >
+            <PlusIcon />
+            <span>{QuestionOptions("buttons.addRow")}</span>
+          </Button>
+        </div>
       </div>
-      {/** Hidden live region for screen readers */}
-      <p aria-live="polite" className="hidden-accessibly">
+      <p
+        aria-live="polite"
+        className="hidden-accessibly"
+      >
         {announcement}
       </p>
-
     </>
   );
-}
+};
 
 export default QuestionOptionsComponent;

--- a/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
+++ b/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
@@ -139,6 +139,7 @@
 }
 
 .optionsCheckbox {
+  align-items: center;
   margin-bottom: 0;
 
   .checkBox {
@@ -182,7 +183,7 @@
 
   .default {
     grid-column: 2;
-    padding-top: 1.875rem;
+    padding-top: 1.75rem;
   }
 
   .actions {

--- a/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
+++ b/components/Form/QuestionOptionsComponent/optionsComponent.module.scss
@@ -1,97 +1,148 @@
-.optionsRow {
-  display: flex;
-  flex-direction: row;
-
-  .orderNumber {
-    max-width: 100px;
-  }
+/* Layout depends on available row width (main column + sidebar), not viewport. */
+.tableContainer {
+  container-type: inline-size;
+  container-name: question-options;
 }
 
-.deleteButton {
-  margin-bottom: 0rem;
+.instructions {
+  margin: 0 0 var(--space-4);
+  color: var(--gray-600);
+  font-size: var(--fs-base);
 }
 
-.formRow {
-  display: flex;
-  flex-direction: row;
-
-}
-
-.tableHeader {
-  font-weight: 700;
-  font-size: medium;
+.sectionError {
+  margin: calc(var(--space-2) * -1) 0 var(--space-4);
+  color: var(--brand-error);
+  font-size: var(--fs-small);
+  font-weight: 600;
 }
 
 .row {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-3);
   width: 100%;
-  gap: 10px;
-  border-bottom: 1px solid #eee;
-  padding-top: 0rem;
-  padding-bottom: 1rem;
-  margin-bottom: 1rem;
+  padding: var(--space-4);
+  margin-bottom: var(--space-3);
+  border: 1px solid var(--gray-100);
+  border-radius: 8px;
+  background: var(--gray-50);
+}
+
+.rowInvalid {
+  border-color: var(--brand-error);
 }
 
 .cell {
-  padding: 10px 0px;
-  flex: 1;
+  min-width: 0;
+  padding: 0;
 
   :global(.react-aria-TextField) {
-    margin-bottom: 0rem;
-    label{
+    margin-bottom: 0;
+    width: 100%;
+
+    label {
       font-weight: 400;
     }
-  }
 
-  label.react-aria-Checkbox{
-    white-space: nowrap;
-    font-weight: 400;
+    :global(.react-aria-Input) {
+      width: 100%;
+      max-width: 100%;
+    }
   }
-
 }
 
-.cellData {
-  border: 1px solid #ccc;
+.orderButtons {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.orderButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  min-width: 0;
+  margin: 0;
+  padding: 0 !important;
+  line-height: 1;
+
+  &[data-disabled] {
+    color: var(--gray-400);
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
 }
 
 .text {
-  min-width: 200px;
-}
-
-.orderNumber {
-  max-width: 30px;
-}
-
-.dmpIcon {
-  fill: black;
-}
-
-.dmpIcon:hover {
-  fill: red;
-}
-
-.remove {
-  display: flex;
-  align-items: center;
-  padding-top: 0.75rem;
+  min-width: 0;
 }
 
 .default {
-  margin-left: 20px;
-  label{
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  label {
     font-weight: 400;
   }
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+
+  .deleteButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 3rem;
+    height: 3rem;
+    padding: 0 !important;
+    margin: 0;
+    border: 0 !important;
+    border-radius: 4px;
+    background: transparent !important;
+    cursor: pointer;
+
+    &:hover,
+    &[data-hovered] {
+      background: transparent !important;
+
+      .trashcanIcon {
+        fill: var(--red-500);
+      }
+    }
+
+    &:focus-visible,
+    &[data-focus-visible] {
+      outline: 2px solid var(--blue-900);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.trashcanIcon {
+  fill: var(--blue-900);
+}
+
+.dialogActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
 }
 
 .optionsCheckbox {
   margin-bottom: 0;
 
-  label{
-    font-weight: 400;
-  }
   .checkBox {
-    margin-top: 10px;
+    margin-top: 0;
   }
 }
 
@@ -100,3 +151,42 @@
   font-weight: 400;
 }
 
+.addChoiceContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  margin-top: var(--space-4);
+  border: 1px dashed #d1d1d1;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.addButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+/* Keep each choice compact when the editor itself has enough room. */
+@container question-options (min-width: 40rem) {
+  .row {
+    grid-template-columns: minmax(12rem, 1fr) auto auto;
+    column-gap: var(--space-4);
+    align-items: start;
+  }
+
+  .text {
+    grid-column: 1;
+  }
+
+  .default {
+    grid-column: 2;
+    padding-top: 1.875rem;
+  }
+
+  .actions {
+    grid-column: 3;
+    padding-top: 1rem;
+  }
+}

--- a/components/QuestionAdd/__tests__/index.spec.tsx
+++ b/components/QuestionAdd/__tests__/index.spec.tsx
@@ -879,10 +879,8 @@ describe("QuestionAdd", () => {
         />);
     });
 
-    // Radio button info with order, text and checkbox should be in document
-    expect(screen.getByLabelText(/labels.order/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/labels.text/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/labels.default/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/labels.choiceNumber/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/buttons.setDefault/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'buttons.addRow' })).toBeInTheDocument();
   })
 
@@ -911,7 +909,7 @@ describe("QuestionAdd", () => {
     });
 
     await act(async () => {
-      fireEvent.change(screen.getByLabelText(/labels.text/), {
+      fireEvent.change(screen.getByLabelText(/labels.choiceNumber/), {
         target: { value: 'Yes' },
       });
     });
@@ -922,11 +920,11 @@ describe("QuestionAdd", () => {
     });
 
     // Wait for the new input to appear
-    const textInputs = await screen.findAllByLabelText(/labels.text/);
+    const textInputs = await screen.findAllByLabelText(/labels.choiceNumber/);
     fireEvent.change(textInputs[0], { target: { value: 'Option 1' } });
     fireEvent.change(textInputs[1], { target: { value: 'Option 2' } });
 
-    const defaultCheckboxes = screen.getAllByLabelText(/labels.default/);
+    const defaultCheckboxes = screen.getAllByLabelText(/buttons.setDefault/);
 
     // Simulate checking the first option as default
     fireEvent.click(defaultCheckboxes[0]);

--- a/components/QuestionAdd/index.tsx
+++ b/components/QuestionAdd/index.tsx
@@ -567,20 +567,18 @@ const QuestionAdd = ({
 
                 {/**Options question types*/}
                 {questionType && OPTIONS_QUESTION_TYPES.includes(questionType) && parsedQuestionJSON && (
-                  <>
+                  <div className={styles.optionsWrapper}>
                     <p className={styles.optionsDescription}>
                       {QuestionAdd('helpText.questionOptions', { questionName: questionName ?? '' })}
                     </p>
-                    <div className={styles.optionsWrapper}>
-                      <QuestionOptionsComponent
-                        rows={rows}
-                        setRows={updateRows}
-                        questionJSON={questionJSON}
-                        formSubmitted={formSubmitted}
-                        setFormSubmitted={setFormSubmitted}
-                      />
-                    </div>
-                  </>
+                    <QuestionOptionsComponent
+                      rows={rows}
+                      setRows={updateRows}
+                      questionJSON={questionJSON}
+                      formSubmitted={formSubmitted}
+                      setFormSubmitted={setFormSubmitted}
+                    />
+                  </div>
                 )}
 
                 {/**Date and Number range question types */}

--- a/components/QuestionAdd/questionAdd.module.scss
+++ b/components/QuestionAdd/questionAdd.module.scss
@@ -1,8 +1,9 @@
 @use '@/styles/responsive' as r;
 
 .optionsDescription {
-  font-size: var(--fs-sm);
-  font-weight:600;
+  margin: 0 0 var(--space-1);
+  font-size: var(--fs-base);
+  font-weight: 600;
 }
 
 .searchField {
@@ -36,9 +37,7 @@
 }
 
 .optionsWrapper {
-  border: 1px solid var(--border-color);
-  padding: var(--space-4);
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-6);
 }
 
 .questionFormField {

--- a/messages/en-US/templateBuilder.json
+++ b/messages/en-US/templateBuilder.json
@@ -425,7 +425,7 @@
     },
     "helpText": {
       "textField": "Changing the question type, for example from Text Field to Radio Buttons, may result in some data being lost.",
-      "questionOptions": "Please enter answer choices for the {questionType}",
+      "questionOptions": "Answer choices",
       "questionText": "Keep the question text concise and clear. Use the requirements or guidance to provide additional explanation.",
       "requirementText": "Use this for specific instructions on what researchers are required to include in their answer, such as what properties of their data they should be listing.",
       "guidanceText": "Let researchers know how to best provide answers to the requirements, such as policies to consider from your organization or what factors to consider.",
@@ -466,26 +466,39 @@
     }
   },
   "QuestionOptionsComponent": {
+    "headings": {
+      "removeChoice": "Remove choice {number}?"
+    },
     "labels": {
-      "order": "Order",
-      "text": "Text",
-      "default": "Default"
+      "choiceNumber": "Choice {number}",
+      "default": "Selected by default",
+      "reorder": "Reorder choice {number}"
     },
     "buttons": {
-      "addRow": "Add row",
-      "deleteRow": "Delete row {count}"
+      "addRow": "Add choice",
+      "deleteRow": "Remove choice {count}",
+      "cancel": "Cancel",
+      "confirmRemove": "Remove choice",
+      "setDefault": "Set choice {number} as default",
+      "clearDefault": "Clear choice {number} as default",
+      "moveUp": "Move choice {number} up",
+      "moveDown": "Move choice {number} down"
     },
     "messages": {
-      "successAddingRow": "Row {number} added",
-      "rowInfo": "Row {number}"
+      "rowInfo": "Choice {number}",
+      "choiceRequired": "Enter text for choice {number}.",
+      "choiceErrors": "Each answer choice must include text.",
+      "confirmRemove": "Are you sure you want to remove choice {number}?",
+      "instructions": "Add the choices plan writers can select. Each choice requires text. Use the arrows to change their display order."
     },
     "announcements": {
-      "rowDefault": "Row with ID {id} set as default.",
-      "rowRemoved": "Row with ID {id} removed.",
-      "rowAdded": "Row {nextNum} added."
+      "rowDefault": "Choice {number} set as default.",
+      "rowDefaultCleared": "Choice {number} is no longer set as default.",
+      "rowRemoved": "Choice {number} removed.",
+      "rowAdded": "Choice {nextNum} added.",
+      "rowMoved": "Choice moved from position {from} to {to}."
     },
     "placeholder": {
-      "orderNumber": "Enter order #",
       "text": "Enter text"
     }
   },
@@ -536,7 +549,7 @@
     },
     "helpText": {
       "textField": "Changing the question type, for example from Text Field to Radio Buttons, may result in some data being lost.",
-      "questionOptions": "Please enter answer choices for the {questionName}",
+      "questionOptions": "Answer choices",
       "questionText": "Keep the question text concise and clear. Use the requirements or guidance to provide additional explanation.",
       "requirementText": "Use this for specific instructions on what researchers are required to include in their answer, such as what properties of their data they should be listing.",
       "guidanceText": "Let researchers know how to best provide answers to the requirements, such as policies to consider from your organization or what factors to consider.",

--- a/messages/pt-BR/templateBuilder.json
+++ b/messages/pt-BR/templateBuilder.json
@@ -425,7 +425,7 @@
     },
     "helpText": {
       "textField": "Alterar o tipo de questão, por exemplo, de campo de texto para botões de rádio, pode resultar na perda de alguns dados.",
-      "questionOptions": "Por favor, insira as opções de resposta para o {questionType}",
+      "questionOptions": "Opções de resposta",
       "questionText": "Mantenha a pergunta concisa e clara. Use os requisitos ou orientações para fornecer explicações adicionais.",
       "requirementText": "Use isto para instruções específicas sobre o que os pesquisadores devem incluir em sua resposta, tais como as propriedades dos seus dados que deveriam listar.",
       "guidanceText": "Permita que os pesquisadores saibam como fornecer melhor respostas aos requisitos, tais como políticas para considerar de sua organização ou quais fatores considerar.",
@@ -466,26 +466,39 @@
     }
   },
   "QuestionOptionsComponent": {
+    "headings": {
+      "removeChoice": "Remover opção {number}?"
+    },
     "labels": {
-      "order": "Ordem",
-      "text": "Texto",
-      "default": "Padrão"
+      "choiceNumber": "Opção {number}",
+      "default": "Selecionada por padrão",
+      "reorder": "Reordenar opção {number}"
     },
     "buttons": {
-      "addRow": "Adicionar linha",
-      "deleteRow": "Excluir linha {count}"
+      "addRow": "Adicionar opção",
+      "deleteRow": "Remover opção {count}",
+      "cancel": "Cancelar",
+      "confirmRemove": "Remover opção",
+      "setDefault": "Definir opção {number} como padrão",
+      "clearDefault": "Desmarcar opção {number} como padrão",
+      "moveUp": "Mover opção {number} para cima",
+      "moveDown": "Mover opção {number} para baixo"
     },
     "messages": {
-      "successAddingRow": "Linha {number} adicionada",
-      "rowInfo": "Linha {number}"
+      "rowInfo": "Opção {number}",
+      "choiceRequired": "Insira o texto da opção {number}.",
+      "choiceErrors": "Cada opção de resposta deve incluir texto.",
+      "confirmRemove": "Tem certeza de que deseja remover a opção {number}?",
+      "instructions": "Adicione as opções que os redatores do plano podem selecionar. Cada opção requer texto. Use as setas para alterar a ordem de exibição."
     },
     "announcements": {
-      "rowDefault": "Linha com ID {id} definida como padrão.",
-      "rowRemoved": "Linha com ID {id} removida.",
-      "rowAdded": "Linha {nextNum} adicionada."
+      "rowDefault": "Opção {number} definida como padrão.",
+      "rowDefaultCleared": "A opção {number} não está mais definida como padrão.",
+      "rowRemoved": "Opção {number} removida.",
+      "rowAdded": "Opção {nextNum} adicionada.",
+      "rowMoved": "Opção movida da posição {from} para {to}."
     },
     "placeholder": {
-      "orderNumber": "Insira o pedido #",
       "text": "Digite o texto"
     }
   },
@@ -536,7 +549,7 @@
     },
     "helpText": {
       "textField": "Alterar o tipo de questão, por exemplo, de campo de texto para botões de rádio, pode resultar na perda de alguns dados.",
-      "questionOptions": "Por favor, insira as opções de resposta para o {questionName}",
+      "questionOptions": "Opções de resposta",
       "questionText": "Mantenha a pergunta concisa e clara. Use os requisitos ou orientações para fornecer explicações adicionais.",
       "requirementText": "Use isto para instruções específicas sobre o que os pesquisadores precisam incluir em sua resposta, tais como as propriedades dos seus dados que devem listar.",
       "guidanceText": "Permita que os pesquisadores saibam como fornecer melhor respostas aos requisitos, tais como políticas para considerar de sua organização ou quais fatores considerar.",


### PR DESCRIPTION
## Description

Fixes #61
https://github.com/CDLUC3/dmptool-doc/issues/61

Improves the template answer choice editor across desktop and mobile widths.

- Add up/down controls
- Uses responsive choice cards to keep fields and actions aligned
- Added removal confirmation and clearer validation feedback
- Preserves single defaults for radio buttons and single selects
- Supports multiple defaults for checkboxes and multi-selects

There are no dependencies related to this change.


<img width="797" height="947" alt="Image" src="https://github.com/user-attachments/assets/ee33516c-3b44-4a9f-a7fa-b43fd535c705" />

<img width="1912" height="948" alt="Image" src="https://github.com/user-attachments/assets/93661be7-010d-4264-b15d-79e6ebb24458" />



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added and updated unit tests for adding, removing, reordering, and validating choices

Ran all the automated test and manually tested in the browser 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective
- [x] I have completed automated accessibility testing for my changes
- [x] New and existing relevant unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A — no dependencies)

## Important Note:

The branch was created from the current development branch and does not revert existing development changes.