### PR TITLE
Bug/305/js hide add funding source for admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 - Updated `RepoSelectorForAnswer` to wait to query `Re3byUrIsDocument` until we have `preferredReposURIs` because preferred repos don't display even though they eventually do to trigger the display of the "preferred repositories" checkbox [#118]
 
 ## Fixed
+- Fixed the issue where "add Funder" button was displayed even when `readOnly` was set to true [#305]
 - Improved the project creation and project funding funder-search pages with clearer loading and fallback states, aligned lists and pagination controls, and improved accessibility [#71]
 - Fixed loading state not appearing immediately by removing the delayed fadeIn animation from the Loading component
 - Fixed section &  question reorder arrow buttons turning white on hover. Added a shared `order-button` style so arrows use link-blue colors and remain visible [#76]

--- a/app/[locale]/projects/[projectId]/fundings/__tests__/page.spec.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/__tests__/page.spec.tsx
@@ -294,9 +294,7 @@ describe('ProjectsProjectFunding', () => {
       });
     });
 
-    it('should not set isReadOnly when fundings array is empty even if project.readOnly is true', async () => {
-      // isReadOnly is only set in the effect when fundings.length > 0,
-      // so with no fundings the Add button should still appear (default isReadOnly = false)
+    it('should set isReadOnly to false when project.readOnly is false', async () => {
       render(
         <MockedProvider mocks={mocksReadOnlyNoFundings}>
           <ProjectsProjectFunding />
@@ -304,7 +302,7 @@ describe('ProjectsProjectFunding', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Add funding' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Add funding' })).not.toBeInTheDocument();
       });
     });
   });

--- a/app/[locale]/projects/[projectId]/fundings/page.tsx
+++ b/app/[locale]/projects/[projectId]/fundings/page.tsx
@@ -68,9 +68,9 @@ const ProjectsProjectFunding = () => {
   }
 
   useEffect(() => {
-    // Update project values from data results
-    if (projectData?.project?.fundings && projectData.project.fundings.length > 0) {
-      setIsReadOnly(projectData.project?.readOnly ?? false);
+    // Update is readOnly state whenever projectData changes
+    if (projectData?.project) {
+      setIsReadOnly(projectData.project?.readOnly || false);
     }
   }, [projectData])
 

--- a/app/[locale]/projects/[projectId]/page.tsx
+++ b/app/[locale]/projects/[projectId]/page.tsx
@@ -246,6 +246,7 @@ const ProjectOverviewPage: React.FC = () => {
               headingId="fundings-title"
               linkHref={routePath("projects.fundings.index", { projectId })}
               linkText={isReadOnly ? Global("buttons.view") : ProjectOverview("editFundingDetails")}
+              includeLink={!isReadOnly || project.fundings.length > 0}
               linkAriaLabel={isReadOnly ? ProjectOverview("viewFundingDetails") : ProjectOverview("editFundingDetails")}
             >
               {project.fundings.length > 0 ? (


### PR DESCRIPTION
## Description

- Fixed the issue where "add Funder" button was displayed even when `readOnly` was set to true
- Also, updated the `/projects/[projectId]` page to not show a link to an Admin with `readOnly` access if there are no funding sources, since the page would display anything but the title for that user.

Fixes # ([305](https://github.com/CDLUC3/dmptool-doc/issues/305))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have completed manual or automated accessibility testing for my changes
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Important Note:
Please make sure to do a careful merge of development branch into yours, to make sure you aren't reverting or effecting any previous commits to the development branch. 
